### PR TITLE
use mpi is being called in fortran, so CMakeLists.txt should enforce …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,11 @@ include_directories( ${FMS_INCLUDE_DIRS} )
 ecbuild_use_package( PROJECT mom6 REQUIRED )
 include_directories( ${MOM6_INCLUDE_DIRS} )
 
+# MPI
+ecbuild_find_mpi( COMPONENTS CXX Fortran REQUIRED )
+ecbuild_include_mpi()
+link_libraries(${MPI_CXX_LIBRARIES} ${MPI_Fortran_LIBRARIES})
+
 ################################################################################
 # Definitions
 ################################################################################


### PR DESCRIPTION
…it is required