### PR TITLE
Feature/godas bkgerr

### DIFF
--- a/src/Transforms/BkgErrGodas/soca_bkgerrgodas_mod.F90
+++ b/src/Transforms/BkgErrGodas/soca_bkgerrgodas_mod.F90
@@ -16,7 +16,8 @@ module soca_bkgerrgodas_mod
   use soca_utils
   use soca_omb_stats_mod
   use fckit_mpi_module
-  
+  use tools_const, only : pi
+
   implicit none
 
   !> Fortran derived type to hold configuration D
@@ -24,8 +25,9 @@ module soca_bkgerrgodas_mod
      type(soca_field),         pointer :: bkg
      type(soca_field)                  :: std_bkgerr
      type(soca_bkgerr_bounds_type)     :: bounds         ! Bounds for bkgerrgodas
-     real(kind=kind_real)              :: delta_z        ! For rescaling of the vertical gradient
-     real(kind=kind_real)              :: efold_sst        ! E-folding scale
+     real(kind=kind_real)              :: t_dz           ! For rescaling of the vertical gradient
+     real(kind=kind_real)              :: t_efold        ! E-folding scale for surf based T min
+     real(kind=kind_real)              :: ssh_phi_ex
      integer                           :: isc, iec, jsc, jec
   end type soca_bkgerrgodas_config
 
@@ -55,21 +57,25 @@ contains
     ! Allocate memory for bkgerrgodasor
     call create_copy(self%std_bkgerr, bkg)
 
-    ! Scaling for dT/dz
-    self%delta_z   = config_get_real(c_conf,"delta_z")
-
-    ! Vertical e-folding scale
-    self%efold_sst   = config_get_real(c_conf,"efold_sst")
-
     ! Get bounds from configuration
     call self%bounds%read(c_conf)
+
+    ! get parameters not already included in self%bounds
+    self%t_dz   = config_get_real(c_conf,"t_dz")
+    self%t_efold   = config_get_real(c_conf,"t_efold")
+    self%ssh_phi_ex = config_get_real(c_conf, "ssh_phi_ex")
 
     ! Associate background
     self%bkg => bkg
 
-    ! Std of bkg error for temperature based on dT/dz
-    ! TODO: No K^-1 applied, figure out what to do  
+    ! Set all fields to zero
+    call zeros(self%std_bkgerr)
+
+    ! Std of bkg error for T/S/SSH based on background.
+    ! S and SSH error are only for the unbalanced portion of S/SSH
     call soca_bkgerrgodas_tocn(self)
+    call soca_bkgerrgodas_socn(self)
+    call soca_bkgerrgodas_ssh(self)
 
     ! Apply config bounds to background error
     call self%bounds%apply(self%std_bkgerr)
@@ -107,29 +113,25 @@ contains
   end subroutine soca_bkgerrgodas_mult
 
   ! ------------------------------------------------------------------------------
-  !> Derive background error from vertial gradient of temperature 
+  !> Derive T background error from vertial gradient of temperature
   subroutine soca_bkgerrgodas_tocn(self)
     type(soca_bkgerrgodas_config),     intent(inout) :: self
-    
-    real(kind=kind_real), allocatable :: temp(:), sig1(:), sig2(:)
-    type(soca_domain_indices), target :: domain    
+
+    real(kind=kind_real), allocatable :: sig1(:), sig2(:)
+    type(soca_domain_indices), target :: domain
     integer :: is, ie, js, je, i, j, k
     integer :: ins, ns = 1, iter, niter = 1
     type(soca_omb_stats) :: sst
 
-    ! Set all fields to zero
-    call zeros(self%std_bkgerr)
-
     ! Get compute domain indices
     call geom_get_domain_indices(self%bkg%geom%ocean, "compute", &
          &domain%is, domain%ie, domain%js, domain%je)
-    
+
     ! Get local compute domain indices
     call geom_get_domain_indices(self%bkg%geom%ocean, "compute", &
          &domain%isl, domain%iel, domain%jsl, domain%jel, local=.true.)
 
     ! Allocate temporary arrays
-    allocate(temp(self%bkg%geom%ocean%nzo))
     allocate(sig1(self%bkg%geom%ocean%nzo), sig2(self%bkg%geom%ocean%nzo))
        
     ! Initialize sst background error to previously computed std of omb's
@@ -142,23 +144,21 @@ contains
        do j = domain%js, domain%je
           if (self%bkg%geom%ocean%mask2d(i,j).eq.1) then
 
-             ! Make sure Temp values in thin layers are realistic
-             temp(:) = self%bkg%tocn(i,j,:)
-             !call soca_clean_vertical(self%bkg%hocn(i,j,:), temp(:))
-
-             ! Step 1: sigb from dT/dz 
-             call soca_diff(sig1(:), temp(:), self%bkg%hocn(i,j,:))
-             sig1(:) = self%delta_z * abs(sig1) ! Rescale background error
+             ! Step 1: sigb from dT/dz
+             call soca_diff(sig1(:), self%bkg%tocn(i,j,:), self%bkg%hocn(i,j,:))
+             sig1(:) = self%t_dz * abs(sig1) ! Rescale background error
 
              ! Step 2: sigb based on efolding scale
-             sig2(:) = sst%bgerr_model(i,j)*&
-                  &exp(-self%bkg%layer_depth(i,j,:)/self%efold_sst)
+             sig2(:) = self%bounds%t_min + (sst%bgerr_model(i,j)-self%bounds%t_min)*&
+                  &exp((self%bkg%layer_depth(i,j,1)-self%bkg%layer_depth(i,j,:))&
+                    &/self%t_efold)
 
              ! Step 3: sigb = max(sig1, sig2)
              do k = 1, self%bkg%geom%ocean%nzo
-                self%std_bkgerr%tocn(i,j,k) = max(sig1(k), sig2(k))
+                self%std_bkgerr%tocn(i,j,k) = min( max(sig1(k), sig2(k)), &
+                  & self%bounds%t_max)
              end do
-             
+
              ! Step 4: Vertical smoothing
              do iter = 1, niter
                 do k = 2, self%bkg%geom%ocean%nzo-1
@@ -176,12 +176,79 @@ contains
 
     ! Release memory
     call sst%exit()
-    deallocate(temp, sig1, sig2)
+    deallocate(sig1, sig2)
 
   end subroutine soca_bkgerrgodas_tocn
 
   ! ------------------------------------------------------------------------------
-  
+  !> Derive unbalanced SSH background error, based on latitude
+  subroutine soca_bkgerrgodas_ssh(self)
+    type(soca_bkgerrgodas_config),     intent(inout) :: self
+    type(soca_domain_indices), target :: domain
+    integer :: i, j, k
+
+    ! Get compute domain indices
+    call geom_get_domain_indices(self%bkg%geom%ocean, "compute", &
+         &domain%is, domain%ie, domain%js, domain%je)
+
+    ! Loop over compute domain
+    do i = domain%is, domain%ie
+       do j = domain%js, domain%je
+            if (self%bkg%geom%ocean%mask2d(i,j) .ne. 1) cycle
+
+            if ( abs(self%bkg%geom%ocean%lat(i,j)) >= self%ssh_phi_ex) then
+              ! if in extratropics, set to max value
+              self%std_bkgerr%ssh(i,j) = self%bounds%ssh_max
+            else
+              ! otherwise, taper to min value (0.0) toward equator
+              self%std_bkgerr%ssh(i,j) = self%bounds%ssh_min + 0.5 * &
+                (self%bounds%ssh_max - self%bounds%ssh_min) * &
+                (1 - cos(pi * self%bkg%geom%ocean%lat(i,j) / self%ssh_phi_ex))
+            end if
+       end do
+    end do
+  end subroutine soca_bkgerrgodas_ssh
+
+
+  ! ------------------------------------------------------------------------------
+  !> Derive unbalanced S background error, based on MLD
+  subroutine soca_bkgerrgodas_socn(self)
+    type(soca_bkgerrgodas_config),     intent(inout) :: self
+    !
+    real(kind=kind_real), allocatable :: dsdz(:), dtdz(:)
+    type(soca_domain_indices), target :: domain
+    integer :: is, ie, js, je, i, j, k
+    real(kind=kind_real) :: r
+
+
+    ! Get compute domain indices
+    call geom_get_domain_indices(self%bkg%geom%ocean, "compute", &
+         &domain%is, domain%ie, domain%js, domain%je)
+    !
+    ! Get local compute domain indices
+    call geom_get_domain_indices(self%bkg%geom%ocean, "compute", &
+         &domain%isl, domain%iel, domain%jsl, domain%jel, local=.true.)
+
+    ! TODO read in a precomputed surface S background error
+
+    ! Loop over compute domain
+    do i = domain%is, domain%ie
+      do j = domain%js, domain%je
+        if (self%bkg%geom%ocean%mask2d(i,j) /= 1)  cycle
+
+        do k = 1, self%bkg%geom%ocean%nzo
+          if ( self%bkg%layer_depth(i,j,k) <= self%bkg%mld(i,j)) then
+            ! if in the mixed layer, set to the maximum value
+            self%std_bkgerr%socn(i,j,k) = self%bounds%s_max
+          else
+            ! otherwise, taper to the minium value below MLD
+            r = 0.1 + 0.45 * (1-tanh( 2 * log( &
+              & self%bkg%layer_depth(i,j,k) / self%bkg%mld(i,j) )))
+            self%std_bkgerr%socn(i,j,k) = max(self%bounds%s_min, r*self%bounds%s_max)
+          end if
+        end do
+      end do
+    end do
+  end subroutine soca_bkgerrgodas_socn
+
 end module soca_bkgerrgodas_mod
-
-

--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -114,7 +114,9 @@ cost_function:
       - varchange: VertConvSOCA
         variables:
           variables: *soca_vars
-        Lz: 10.0
+        Lz_min: 2.0
+        Lz_mld: 1
+        Lz_mld_max: 500.0
         scale_layer_thick: 1.5
         inputVariables:
           variables: *soca_vars

--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -20,19 +20,13 @@ model:
   name: SOCA
   tstep: PT1H
   advance_mom6: 0
-  variables: [cicen, hicen, socn, tocn, ssh, hocn]  
+  variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn]
 cost_function:
   cost_type: 3D-Var
   window_begin: '2018-04-14T00:00:00Z'
   window_length: P2D
-  variables:
-  - cicen
-  - hicen
-  - socn
-  - tocn
-  - ssh
-  - hocn
-  varchange: Identity  
+  variables: *soca_vars
+  varchange: Identity
   Jb:
     Background:
       state:
@@ -89,115 +83,53 @@ cost_function:
         ocean_depth_min: 1000 # [m]
         rescale_bkgerr: 1.0
         efold_z: 2500.0       # [m]
-        variables:                                
-          variables:
-          - cicen
-          - hicen
-          - socn
-          - tocn
-          - ssh
-          - hocn
+        variables:
+          variables: *soca_vars
         inputVariables:
-          variables:
-          - cicen
-          - hicen
-          - socn
-          - tocn
-          - ssh
-          - hocn
+          variables: *soca_vars
         outputVariables:
-          variables:
-          - cicen
-          - hicen
-          - socn
-          - tocn
-          - ssh
-          - hocn        
+          variables: *soca_vars
+
       - varchange: BkgErrGODAS
-        t_min: 0.0
-        t_max: 2.5
-        s_min: 0.0 
-        s_max: 0.2
-        ssh_min: 0.0 # std ssh=0 => ssh balance applied as  
-        ssh_max: 0.0 #              strong constraint
+        t_min: 0.1
+        t_max: 2.0
+        t_dz:  20.0
+        t_efold: 500.0
+        s_min: 0.0
+        s_max: 0.25
+        ssh_min: 0.0   # value at EQ
+        ssh_max: 0.1   # value in Extratropics
+        ssh_phi_ex: 20 # lat of transition from extratropics
         cicen_min: 0.1
         cicen_max: 0.5
         hicen_min: 10.0
         hicen_max: 100.0
-        delta_z: 100.0
-        efold_sst: 5.0
-        variables:                                
-          variables:
-          - cicen
-          - hicen
-          - socn
-          - tocn
-          - ssh
-          - hocn
+        variables:
+          variables: *soca_vars
         inputVariables:
-          variables:
-          - cicen
-          - hicen
-          - socn
-          - tocn
-          - ssh
-          - hocn
+          variables: *soca_vars
         outputVariables:
-          variables:
-          - cicen
-          - hicen
-          - socn
-          - tocn
-          - ssh
-          - hocn
+          variables: *soca_vars
+
       - varchange: VertConvSOCA
-        variables:                                
-          variables:
-          - cicen
-          - hicen
-          - socn
-          - tocn
-          - ssh
-          - hocn
+        variables:
+          variables: *soca_vars
         Lz: 10.0
         scale_layer_thick: 1.5
         inputVariables:
-          variables:
-          - cicen
-          - hicen
-          - socn
-          - tocn
-          - ssh
-          - hocn
+          variables: *soca_vars
         outputVariables:
-          variables:
-          - cicen
-          - hicen
-          - socn
-          - tocn
-          - ssh
-          - hocn
+          variables: *soca_vars
+
       - varchange: BalanceSOCA
         dsdtmax: 0.1
         dsdzmin: 3.0e-6
         dtdzmin: 1.0e-6
         nlayers: 10        
         inputVariables:
-          variables:
-          - cicen
-          - hicen
-          - socn
-          - tocn
-          - ssh
-          - hocn
+          variables: *soca_vars
         outputVariables:
-          variables:
-          - cicen
-          - hicen
-          - socn
-          - tocn
-          - ssh
-          - hocn
+          variables: *soca_vars
   Jo:
     ObsTypes:
     - ObsType: ADT
@@ -281,7 +213,7 @@ variational:
       version: IdTLM
       tstep: PT1H
       advance_mom6: 0
-      variables: [cicen, hicen, socn, tocn, ssh, hocn]
+      variables: *soca_vars
     ninner: 10
     gradient_norm_reduction: 1e-15
     test: 'on'

--- a/test/testinput/3dvar_soca.yml
+++ b/test/testinput/3dvar_soca.yml
@@ -164,7 +164,9 @@ cost_function:
           - tocn
           - ssh
           - hocn
-        Lz: 10.0
+        Lz_min: 10.0
+        Lz_mld: 1
+        Lz_mld_max: 500
         scale_layer_thick: 1.5
         inputVariables:
           variables:

--- a/test/testinput/3dvarfgat_mom6.yml
+++ b/test/testinput/3dvarfgat_mom6.yml
@@ -164,7 +164,9 @@ cost_function:
           - tocn
           - ssh
           - hocn
-        Lz: 10.0
+        Lz_min: 10.0
+        Lz_mld: 0
+        Lz_mld_max: 500.0
         scale_layer_thick: 1.5
         inputVariables:
           variables:

--- a/test/testinput/4dhyb.yml
+++ b/test/testinput/4dhyb.yml
@@ -153,7 +153,8 @@ cost_function:
           - tocn
           - ssh
           - hocn
-        Lz: 10.0
+        Lz_min: 10.0
+        Lz_mld: 0
         scale_layer_thick: 1.5
         inputVariables:
           variables:

--- a/test/testinput/bkgerrgodas.yml
+++ b/test/testinput/bkgerrgodas.yml
@@ -9,46 +9,27 @@ State:
   basename: ./INPUT/
   ocn_filename: MOM.res.nc
   ice_filename: ice_model.res.nc
-  variables: [cicen, hicen, socn, tocn, ssh, hocn]
+  variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn]
 LinearVariableChangeTests:
 - varchange: BkgErrGODAS
   toleranceInverse: 1e-12
   testinverse: 1
   t_min: 0.0
-  t_max: 2.5
-  s_min: 0.0 
-  s_max: 0.2
-  ssh_min: 0.0 # std ssh=0 => ssh balance applied as  
-  ssh_max: 0.0 #              strong constraint
+  t_max: 2.0
+  t_dz:  20.0
+  t_efold: 500.0
+  s_min: 0.0
+  s_max: 0.25
+  ssh_min: 0.0 
+  ssh_max: 0.1
+  ssh_phi_ex: 20
   cicen_min: 0.1
   cicen_max: 0.5
   hicen_min: 10.0
   hicen_max: 100.0
-  delta_z: 100.0
-  efold_sst: 5.0
-  variables:  
-    variables:
-    - cicen
-    - hicen
-    - socn
-    - tocn
-    - ssh
-    - hocn
+  variables:
+    variables: *soca_vars
   inputVariables:
-    variables:
-    - cicen
-    - hicen
-    - socn
-    - tocn
-    - ssh
-    - hocn
+    variables: *soca_vars
   outputVariables:
-    variables:
-    - cicen
-    - hicen
-    - socn
-    - tocn
-    - ssh
-    - hocn
-
-
+    variables: *soca_vars

--- a/test/testinput/genenspert.yml
+++ b/test/testinput/genenspert.yml
@@ -60,17 +60,18 @@ Covariance:
  - varchange: BkgErrGODAS
    t_min: 0.0
    t_max: 2.5
-   s_min: 0.0 
-   s_max: 0.2
+   t_dz: 20
+   t_efold: 500.0
+   s_min: 0.0
+   s_max: 0.25
    ssh_min: 0.0
-   ssh_max: 0.0
+   ssh_max: 0.1
+   ssh_phi_ex: 20
    cicen_min: 0.1
    cicen_max: 0.5
    hicen_min: 10.0
    hicen_max: 100.0
-   delta_z: 100.0
-   efold_sst: 5.0
-   variables:  
+   variables:
      variables:
      - cicen
      - hicen
@@ -124,7 +125,9 @@ Covariance:
      - tocn
      - ssh
      - hocn
-   Lz: 10.0
+   Lz_min: 10.0
+   Lz_mld: 1
+   Lz_mld_max: 500.0
    scale_layer_thick: 1.5
    inputVariables:
      variables:

--- a/test/testinput/vertconv.yml
+++ b/test/testinput/vertconv.yml
@@ -26,9 +26,11 @@ LinearVariableChangeTests:
     - socn
     - tocn
     - ssh
-    - hocn  
-  Lz: 10.0
-  scale_layer_thick: 3 
+    - hocn
+  Lz_min: 10.0
+  Lz_mld: 1
+  Lz_mld_max: 500.0
+  scale_layer_thick: 1.5
   inputVariables:
     variables:
     - cicen


### PR DESCRIPTION
Changes to godas-style background error / vertical correlations, to facilitate assimilation of surface observations

closes #58 
closes #39 

* unbalanced SSH bkg error implemented (no real impact, other than prettier analysis increment plots!)
* unbalanced S bkg error in mixed layer. Works okay for now, but when it's science time it will need to be cleaned up a bit (e.g. make MLD field look less ugly, use horizontally varying surface values from omb stats, ...)
* vertical correlation lengths can use the MLD in the surface layer length scales. Values equal MLD at surface, linearly interpolates to model level thicknesses at base of ML

need suggestions on what to rename the background error class, it's not really "godas" anymore.

drop the hz  correlation lengths down to 500km, and use the following hgodas obs if you want to see some pretty increments.
https://drive.google.com/open?id=16fGd2wmDhZK1yMNQE2b7mW-iELDA0pHv