### PR TITLE
bugfix for intel

### DIFF
--- a/src/Transforms/BkgErrGodas/soca_bkgerrgodas_mod.F90
+++ b/src/Transforms/BkgErrGodas/soca_bkgerrgodas_mod.F90
@@ -118,7 +118,7 @@ contains
     type(soca_bkgerrgodas_config),     intent(inout) :: self
 
     real(kind=kind_real), allocatable :: sig1(:), sig2(:)
-    type(soca_domain_indices), target :: domain
+    type(soca_domain_indices), pointer :: domain
     integer :: is, ie, js, je, i, j, k
     integer :: ins, ns = 1, iter, niter = 1
     type(soca_omb_stats) :: sst


### PR DESCRIPTION
Intel compiler demands to be a pointer instead of a target.

Change-Id: I6570360d757b2ae03c69f74af761bd5c21873e69