### PR TITLE
Resurrection of 3dvarfgat and hofx tests (although that later one is just a zombie)

### DIFF
--- a/src/Fields/soca_interpfields_mod.F90
+++ b/src/Fields/soca_interpfields_mod.F90
@@ -42,8 +42,6 @@ contains
     ! Indices for compute domain (no halo)
     call geom_get_domain_indices(fld%geom%ocean, "compute", isc, iec, jsc, jec)
 
-    !if (locs%nlocs==0) return
-
     ! Compute interpolation weights
     call horiz_interp%initialize(&
             &      fld%geom%ocean%lon(isc:iec,jsc:jec),&
@@ -106,7 +104,6 @@ contains
     type(soca_bumpinterp2d) :: horiz_interp    
     integer, save :: bumpid = 2000
 
-    if (locs%nlocs==0) return
     call check(fld)
 
     call initialize_interph(fld, locs, horiz_interp, bumpid)
@@ -131,7 +128,6 @@ contains
     real(kind=kind_real), allocatable :: gom_window(:,:)
     real(kind=kind_real), allocatable :: fld3d(:,:,:)        
 
-    !if (traj%noobs) return
     
     horiz_interp_p => traj%horiz_interp(1)
 
@@ -216,8 +212,6 @@ contains
     real(kind=kind_real), allocatable :: gom_window(:,:)
     real(kind=kind_real), allocatable :: fld3d(:,:,:)        
     integer :: iii(3), bumpid=1111
-    ! Exit if no obs
-    !if (locs%nlocs==0) return
 
     ! Sanity check
     call check(fld)    

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -343,8 +343,6 @@ ecbuild_add_test( TARGET test_soca_hofx
                       testinput/hofx.yml"
                       testoutput/hofx.test
                   DEPENDS soca_hofx.x)
-# the above test hangs, leave the following line until the test can be fixed
-set_tests_properties(test_soca_hofx PROPERTIES TIMEOUT 1)
 
 ecbuild_add_test( TARGET test_soca_3dvarsoca
                   MPI ${MPI_SOCA_TESTS}
@@ -385,9 +383,6 @@ ecbuild_add_test( TARGET test_soca_3dvarfgat
                       testinput/3dvarfgat.yml"
                       testoutput/3dvarfgat.test
                   DEPENDS soca_3dvar.x)
-
-# the above test hangs, leave the following line until the test can be fixed
-set_tests_properties(test_soca_3dvarfgat PROPERTIES TIMEOUT 6)
 
 ecbuild_add_test( TARGET test_soca_4dhybrid
                   MPI ${MPI_SOCA_TESTS}

--- a/test/testoutput/3dvarfgat.test
+++ b/test/testoutput/3dvarfgat.test
@@ -1,19 +1,23 @@
 Test     : CostJb   : Nonlinear Jb = 0
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 273.967, nobs = 46, Jo/n = 5.95581, err = 0.38937
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 1.58217, nobs = 16, Jo/n = 0.0988857, err = 1
+Test     : CostJo   : Nonlinear Jo(ADT) = 94.4856, nobs = 30, Jo/n = 3.14952, err = 0.1
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 29.655, nobs = 30, Jo/n = 0.988499, err = 0.915904
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 7.3741, nobs = 33, Jo/n = 0.223457, err = 0.61043
-Test     : CostFunction: Nonlinear J = 310.996
-Test     : RPCGMinimizer: reduction in residual norm = 0.013065
+Test     : CostFunction: Nonlinear J = 407.064
+Test     : RPCGMinimizer: reduction in residual norm = 0.0142133
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.034552   max=    1.000000   mean=    1.515067
+Test     :   cicen   min=   -0.035811   max=    1.000000   mean=    1.516179
 Test     :   hicen   min=    0.000000   max= 2667.837408   mean=  493.034857
-Test     :    socn   min=    0.000000   max=   39.037978   mean=  862.695614
-Test     :    tocn   min=   -1.883330   max=   31.008851   mean=  153.977965
-Test     :     ssh   min=   -2.103585   max=    0.912174   mean=   -0.296914
+Test     :    socn   min=    0.000000   max=   38.999706   mean=  862.953792
+Test     :    tocn   min=   -1.883330   max=   31.008851   mean=  153.710306
+Test     :     ssh   min=   -2.103405   max=    0.915520   mean=   -0.300249
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean= 3267.054300
-Test     : CostJb   : Nonlinear Jb = 649.967198
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 66.566628, nobs = 40, Jo/n = 1.664166, err = 0.391743
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 24.346018, nobs = 30, Jo/n = 0.811534, err = 0.915904
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 5.615017, nobs = 33, Jo/n = 0.170152, err = 0.610430
-Test     : CostFunction: Nonlinear J = 746.494862
+Test     : CostJb   : Nonlinear Jb = 1086.708885
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 66.822115, nobs = 40, Jo/n = 1.670553, err = 0.391743
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 1.417930, nobs = 16, Jo/n = 0.088621, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 90.014552, nobs = 30, Jo/n = 3.000485, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 24.363936, nobs = 30, Jo/n = 0.812131, err = 0.915904
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 5.620721, nobs = 33, Jo/n = 0.170325, err = 0.610430
+Test     : CostFunction: Nonlinear J = 1274.948139


### PR DESCRIPTION
All I did was to move the burden of handling the zero obs case downstream to bump interp. 
3dvarfgat passes, hofx doesn't hang but fails for issues pointed out by @danholdaway .  