### PR TITLE
fix MPI_Finalize() being called in soca

### DIFF
--- a/src/Model/soca_mom6.F90
+++ b/src/Model/soca_mom6.F90
@@ -310,7 +310,10 @@ contains
     type(soca_mom6_config), intent(inout) :: mom6_config
 
     ! Finalize fms
-    call io_infra_end ; call MOM_infra_end
+    call io_infra_end
+
+    !! as a temporary workaround to MPI_Finalize() issues, MOM_infra_end is NOT called
+    ! call MOM_infra_end
 
     ! Finalize mom6
     call MOM_end(mom6_config%MOM_CSp)


### PR DESCRIPTION
closes #93
this is a temporary fix, to make `test_soca_model` and `test_soca_linearmodel` work again, and should be examined more closely in the future to be done cleaner.