### PR TITLE
fix some uninitialized memory access found with valgrind

### DIFF
--- a/src/Fields/soca_fields_mod.F90
+++ b/src/Fields/soca_fields_mod.F90
@@ -116,6 +116,7 @@ contains
 
     ! Allocate and copy fields
     call soca_field_alloc(self, rhs_fld%geom)
+    call zeros(self)
     !call copy(self,rhs_fld)
 
     ! Associate geometry
@@ -208,6 +209,8 @@ contains
     self%ssh = 0.0_kind_real
     self%hocn = 0.0_kind_real
 
+    self%mld = 0.0_kind_real
+
     call self%ocnsfc%zeros()
     
   end subroutine zeros
@@ -227,6 +230,7 @@ contains
     self%ssh = 1.0_kind_real
     self%hocn = 1.0_kind_real
 
+    self%mld = 1.0_kind_real
   end subroutine ones
 
   ! ------------------------------------------------------------------------------

--- a/src/Geometry/soca_model_geom_type.F90
+++ b/src/Geometry/soca_model_geom_type.F90
@@ -114,6 +114,8 @@ contains
     other%ice_column = self%ice_column
     call geom_allocate(other)    
 
+    other%rossby_radius = self%rossby_radius
+    
   end subroutine geom_clone
 
   ! ------------------------------------------------------------------------------

--- a/src/Model/soca_mom6.F90
+++ b/src/Model/soca_mom6.F90
@@ -218,8 +218,8 @@ contains
     ! This include declares and sets the variable "version".
 #include "version_variable.h"
     character(len=40)  :: mod_name = "soca_mom6" ! This module's name.
-    integer :: ocean_nthreads != 1
-    integer :: ncores_per_node != 36
+    integer :: ocean_nthreads = 1
+    integer :: ncores_per_node = 1
     logical :: use_hyper_thread = .false.
     integer :: omp_get_num_threads,omp_get_thread_num,get_cpu_affinity,adder,base_cpu
     namelist /ocean_solo_nml/ date_init, calendar, months, days, hours, minutes, seconds,&

--- a/src/Utils/soca_bumpinterp2d_mod.F90
+++ b/src/Utils/soca_bumpinterp2d_mod.F90
@@ -18,7 +18,7 @@ module soca_bumpinterp2d_mod
      integer                           :: nobs          !< Number of values to interpolate
      real(kind=kind_real), allocatable :: lono(:)       !< Longitude of destination
      real(kind=kind_real), allocatable :: lato(:)       !< Latitude of destination 
-     logical                           :: initialized   !< Initialization switch
+     logical                           :: initialized = .false. !< Initialization switch
    contains
      procedure :: initialize => interp_init
      procedure :: info => interp_info
@@ -75,6 +75,7 @@ contains
     self%bump%nam%verbosity = 'none'
     self%bump%nam%write_obsop = .false.
     self%bump%nam%sam_write = .false.
+    self%bump%nam%strategy = 'specific_univariate'
 
     !Initialize geometry
     allocate(area(ns))


### PR DESCRIPTION
I found some instances of  usage of uninitialized values in soca. There was a small, but non-zero, chance that this could have been causing machine/compiler/random answer changes. More importantly though this is clearing up valgrind complaints so that future valgrind debugging will be easier.

other than errors in ioda (fixed with https://github.com/JCSDA/ioda/pull/215) and oops (https://github.com/JCSDA/oops/issues/238 , though I don't _think_ this one impacts answers in soca, errors seem localized to print statements for us), the only remaining valgrind complaints are within MOM6 advance... and I don't think any of us wants to fix MOM6 valgrind complaints.