### PR TITLE
Feature/forcing

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,6 +61,8 @@ list( APPEND soca_model_param
 )
 
 list( APPEND soca_model_restarts
+  Data/90x43x25/INPUT/forcing_daily.nc
+  Data/90x43x25/INPUT/forcing_monthly.nc
   Data/90x43x25/INPUT/hycom1_25.nc
   Data/90x43x25/INPUT/ice_model.res.nc
   Data/90x43x25/INPUT/layer_coord25.nc

--- a/test/Data/90x43x25/INPUT/forcing_daily.nc
+++ b/test/Data/90x43x25/INPUT/forcing_daily.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b30f79c976fd8e29fb14b4be7a2a1a1c180f13027a0214b59ebf9db62f686253
+size 469258

--- a/test/Data/90x43x25/INPUT/forcing_monthly.nc
+++ b/test/Data/90x43x25/INPUT/forcing_monthly.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:525df58a4739368eb37d39a8b32bab9b396a4d7d937681e1f616ab574b7b57fd
+size 94765

--- a/test/Data/90x43x25/MOM_input
+++ b/test/Data/90x43x25/MOM_input
@@ -525,16 +525,64 @@ MAXTRUNC = 1000                 !   [truncations save_interval-1] default = 0
 ! === module ocean_model_init ===
 
 ! === module MOM_surface_forcing ===
-BUOY_CONFIG = "zero"            !
+BUOY_CONFIG = "file"            !
                                 ! The character string that indicates how buoyancy forcing
                                 ! is specified. Valid options include (file), (zero),
                                 ! (linear), (USER), (BFB) and (NONE).
-WIND_CONFIG = "zero"            !
+ARCHAIC_OMIP_FORCING_FILE = False !   [Boolean] default = True
+                                ! If true, use the forcing variable decomposition from
+                                ! the old German OMIP prescription that predated CORE. If
+                                ! false, use the variable groupings available from MOM
+                                ! output diagnostics of forcing variables.
+LONGWAVE_FILE = "forcing_daily.nc" !
+                                ! The file with the longwave heat flux, in the variable
+                                ! given by LONGWAVE_FORCING_VAR.
+SHORTWAVE_FILE = "forcing_daily.nc" !
+                                ! The file with the shortwave heat flux, in the variable
+                                ! given by SHORTWAVE_FORCING_VAR.
+EVAPORATION_FILE = "forcing_daily.nc" !
+                                ! The file with the evaporative moisture flux, in the
+                                ! variable given by EVAP_FORCING_VAR.
+LATENTHEAT_FILE = "forcing_daily.nc" !
+                                ! The file with the latent heat flux, in the variable
+                                ! given by LATENT_FORCING_VAR.
+SENSIBLEHEAT_FILE = "forcing_daily.nc" !
+                                ! The file with the sensible heat flux, in the variable
+                                ! given by SENSIBLE_FORCING_VAR.
+RAIN_FILE = "forcing_monthly.nc" !
+                                ! The file with the liquid precipitation flux, in the
+                                ! variable given by RAIN_FORCING_VAR.
+SNOW_FILE = "forcing_monthly.nc" !
+                                ! The file with the frozen precipitation flux, in the
+                                ! variable given by SNOW_FORCING_VAR.
+RUNOFF_FILE = "forcing_monthly.nc" !
+                                ! The file with the fresh and frozen runoff/calving
+                                ! fluxes, in variables given by LIQ_RUNOFF_FORCING_VAR
+                                ! and FROZ_RUNOFF_FORCING_VAR.
+SSTRESTORE_FILE = "forcing_daily.nc" !
+                                ! The file with the SST toward which to restore in the
+                                ! variable given by SST_RESTORE_VAR.
+SALINITYRESTORE_FILE = "forcing_daily.nc" !
+                                ! The file with the surface salinity toward which to
+                                ! restore in the variable given by SSS_RESTORE_VAR.
+WIND_CONFIG = "file"            !
                                 ! The character string that indicates how wind forcing
                                 ! is specified. Valid options include (file), (2gyre),
                                 ! (1gyre), (gyres), (zero), and (USER).
-
-
+WIND_FILE = "forcing_daily.nc" !
+                                ! The file in which the wind stresses are found in
+                                ! variables STRESS_X and STRESS_Y.
+WINDSTRESS_X_VAR = "taux"       ! default = "STRESS_X"
+                                ! The name of the x-wind stress variable in WIND_FILE.
+WINDSTRESS_Y_VAR = "tauy"       ! default = "STRESS_Y"
+                                ! The name of the y-wind stress variable in WIND_FILE.
+WINDSTRESS_STAGGER = "C"        ! default = "A"
+                                ! A character indicating how the wind stress components
+                                ! are staggered in WIND_FILE.  This may be A or C for now.
+FLUXCONST = 0.5                 !   [m day-1]
+                                ! The constant that relates the restoring surface fluxes
+                                ! to the relative surface anomalies (akin to a piston
+                                ! velocity).  Note the non-MKS units.
 ! === module MOM_restart ===
 
 ! === module MOM_file_parser ===

--- a/test/testinput/model_test.yml
+++ b/test/testinput/model_test.yml
@@ -12,7 +12,7 @@ ModelBias:
 
 ModelTest:
   fclength: PT6H
-  finalnorm: 47432.49628809125715634
+  finalnorm: 47432.48579950715065934
   tolerance: 1e-12
 
 Model:

--- a/test/testoutput/3dvarfgat.test
+++ b/test/testoutput/3dvarfgat.test
@@ -1,32 +1,32 @@
 Test     : CostJb   : Nonlinear Jb = 0
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 292.028, nobs = 48, Jo/n = 6.08392, err = 0.387632
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 273.967, nobs = 46, Jo/n = 5.95581, err = 0.38937
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 1.58217, nobs = 16, Jo/n = 0.0988857, err = 1
-Test     : CostJo   : Nonlinear Jo(ADT) = 94.4856, nobs = 30, Jo/n = 3.14952, err = 0.1
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 29.655, nobs = 30, Jo/n = 0.988499, err = 0.915904
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 7.3741, nobs = 33, Jo/n = 0.223457, err = 0.61043
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 293.793, nobs = 48, Jo/n = 6.12068, err = 0.387632
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 275.523, nobs = 46, Jo/n = 5.98963, err = 0.38937
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 1.57977, nobs = 16, Jo/n = 0.0987355, err = 1
+Test     : CostJo   : Nonlinear Jo(ADT) = 94.5156, nobs = 30, Jo/n = 3.15052, err = 0.1
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 29.9701, nobs = 30, Jo/n = 0.999004, err = 0.915904
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 7.38039, nobs = 33, Jo/n = 0.223648, err = 0.61043
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 47.095, nobs = 20, Jo/n = 2.35475, err = 0.1
-Test     : CostFunction: Nonlinear J = 746.187
-Test     : RPCGMinimizer: reduction in residual norm = 0.0794154
+Test     : CostFunction: Nonlinear J = 749.856
+Test     : RPCGMinimizer: reduction in residual norm = 0.0797219
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.055079   max=    1.029333   mean=    0.254074
+Test     :   cicen   min=   -0.055057   max=    1.029330   mean=    0.254066
 Test     :   hicen   min=    0.000000   max= 2667.837408   mean=   98.606971
-Test     :    socn   min=    0.000000   max=   38.999706   mean=   34.515087
-Test     :    tocn   min=   -2.822662   max=   31.008851   mean=    6.145753
-Test     :     ssh   min=   -2.104479   max=    0.914524   mean=   -0.299265
+Test     :    socn   min=    0.000000   max=   38.999706   mean=   34.515076
+Test     :    tocn   min=   -2.824007   max=   31.008851   mean=    6.145967
+Test     :     ssh   min=   -2.104480   max=    0.914522   mean=   -0.299253
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  130.682172
-Test     :      sw   min=  -57.127134   max=  -57.070394   mean=  -86.521931
-Test     :     lhf   min=  102.903667   max=  103.088292   mean=  156.072842
-Test     :     shf   min=    7.699462   max=    7.700493   mean=   11.667580
-Test     :      lw   min=  599.911860   max=  600.096168   mean=  909.162084
-Test     :      us   min=    0.079892   max=    0.080099   mean=    0.121222
-Test     : CostJb   : Nonlinear Jb = 1150.784037
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 68.594717, nobs = 48, Jo/n = 1.429057, err = 0.387632
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 55.790337, nobs = 40, Jo/n = 1.394758, err = 0.391743
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 1.472224, nobs = 16, Jo/n = 0.092014, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 91.329580, nobs = 30, Jo/n = 3.044319, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 26.231020, nobs = 30, Jo/n = 0.874367, err = 0.915904
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 5.805313, nobs = 33, Jo/n = 0.175919, err = 0.610430
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 7.218644, nobs = 20, Jo/n = 0.360932, err = 0.100000
-Test     : CostFunction: Nonlinear J = 1407.225872
+Test     :      sw   min=  -57.127378   max=  -57.069791   mean=  -86.521927
+Test     :     lhf   min=  102.901702   max=  103.089084   mean=  156.072828
+Test     :     shf   min=    7.699451   max=    7.700498   mean=   11.667580
+Test     :      lw   min=  599.911069   max=  600.098129   mean=  909.162097
+Test     :      us   min=    0.079890   max=    0.080100   mean=    0.121222
+Test     : CostJb   : Nonlinear Jb = 1146.259666
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 69.042842, nobs = 48, Jo/n = 1.438393, err = 0.387632
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 55.758133, nobs = 40, Jo/n = 1.393953, err = 0.391743
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 1.474191, nobs = 16, Jo/n = 0.092137, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 91.105425, nobs = 30, Jo/n = 3.036848, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 26.613050, nobs = 30, Jo/n = 0.887102, err = 0.915904
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 5.820122, nobs = 33, Jo/n = 0.176367, err = 0.610430
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 7.227125, nobs = 20, Jo/n = 0.361356, err = 0.100000
+Test     : CostFunction: Nonlinear J = 1403.300553

--- a/test/testoutput/enshofx.test
+++ b/test/testoutput/enshofx.test
@@ -4,8 +4,8 @@ Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.252545
 Test     :   hicen   min=    0.000000   max= 2667.837408   mean=   98.606971
 Test     :    socn   min=    0.000000   max=   39.224980   mean=   34.515960
 Test     :    tocn   min=   -2.095108   max=   31.317652   mean=    6.153311
-Test     :     ssh   min=   -2.230970   max=    0.901205   mean=   -0.297196
-Test     :    hocn   min=    0.000957   max= 1345.978568   mean=  130.682164
+Test     :     ssh   min=   -2.230916   max=    0.901090   mean=   -0.297197
+Test     :    hocn   min=    0.000957   max= 1345.978171   mean=  130.682164
 Test     :      sw   min=  -57.100000   max=  -57.100000   mean=  -86.521926
 Test     :     lhf   min=  103.000000   max=  103.000000   mean=  156.072827
 Test     :     shf   min=    7.700000   max=    7.700000   mean=   11.667580
@@ -15,9 +15,9 @@ Test     : Final state for member 0:
 Test     :   Valid time: 2018-04-15T08:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.252545
 Test     :   hicen   min=    0.000000   max= 2667.837408   mean=   98.606971
-Test     :    socn   min=    0.000000   max=   39.154098   mean=   34.505411
-Test     :    tocn   min=   -1.924560   max=   31.290826   mean=    6.147091
-Test     :     ssh   min=   -2.246393   max=    0.900526   mean=   -0.297308
+Test     :    socn   min=    0.000000   max=   39.154097   mean=   34.504876
+Test     :    tocn   min=   -1.921331   max=   31.306478   mean=    6.146490
+Test     :     ssh   min=   -2.246268   max=    0.900079   mean=   -0.297315
 Test     :    hocn   min=    0.001000   max= 1349.850000   mean=  130.682156
 Test     :      sw   min=  -57.100000   max=  -57.100000   mean=  -86.521926
 Test     :     lhf   min=  103.000000   max=  103.000000   mean=  156.072827
@@ -25,21 +25,21 @@ Test     :     shf   min=    7.700000   max=    7.700000   mean=   11.667580
 Test     :      lw   min=  600.000000   max=  600.000000   mean=  909.162099
 Test     :      us   min=    0.080000   max=    0.080000   mean=    0.121222
 Test     : H(x) for member 0:
-Test     : CoolSkin nobs= 17 Min=11.204242, Max=29.841848, RMS=23.718238
-Test     : SeaSurfaceTemp nobs= 17 Min=11.218102, Max=29.855749, RMS=23.731775
-Test     : SeaSurfaceSalinity nobs= 14 Min=32.715026, Max=36.201326, RMS=34.905260
-Test     : ADT nobs= 11 Min=-0.959786, Max=0.952985, RMS=0.710538
-Test     : InsituTemperature nobs= 10 Min=8.296843, Max=26.638721, RMS=19.168577
-Test     : InsituSalinity nobs= 10 Min=34.628616, Max=35.172057, RMS=34.960205
+Test     : CoolSkin nobs= 17 Min=11.204242, Max=29.841848, RMS=23.717015
+Test     : SeaSurfaceTemp nobs= 17 Min=11.218102, Max=29.855749, RMS=23.730552
+Test     : SeaSurfaceSalinity nobs= 14 Min=32.715026, Max=36.201326, RMS=34.895130
+Test     : ADT nobs= 11 Min=-0.959936, Max=0.952946, RMS=0.710411
+Test     : InsituTemperature nobs= 10 Min=8.296848, Max=26.718814, RMS=19.179927
+Test     : InsituSalinity nobs= 10 Min=34.628616, Max=35.189696, RMS=34.962019
 Test     : SeaIceFraction nobs= 8 Min=0.000000, Max=0.996173, RMS=0.680767
 Test     : End H(x) for member 0
 Test     : Initial state for member 1:
 Test     :   Valid time: 2018-04-15T06:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.252545
 Test     :   hicen   min=    0.000000   max= 2667.837408   mean=   98.606971
-Test     :    socn   min=    0.000000   max=   39.447967   mean=   34.538897
-Test     :    tocn   min=   -1.924808   max=   31.075817   mean=    6.149524
-Test     :     ssh   min=   -2.270988   max=    0.899654   mean=   -0.297305
+Test     :    socn   min=    0.000000   max=   39.447965   mean=   34.538204
+Test     :    tocn   min=   -1.925049   max=   31.093117   mean=    6.148585
+Test     :     ssh   min=   -2.270860   max=    0.899206   mean=   -0.297312
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  130.682157
 Test     :      sw   min=  -57.100000   max=  -57.100000   mean=  -86.521926
 Test     :     lhf   min=  103.000000   max=  103.000000   mean=  156.072827
@@ -50,22 +50,22 @@ Test     : Final state for member 1:
 Test     :   Valid time: 2018-04-15T08:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.252545
 Test     :   hicen   min=    0.000000   max= 2667.837408   mean=   98.606971
-Test     :    socn   min=    0.000000   max=   39.287154   mean=   34.529314
-Test     :    tocn   min=   -1.918361   max=   31.064515   mean=    6.146754
-Test     :     ssh   min=   -2.317152   max=    0.909417   mean=   -0.297537
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  130.682133
+Test     :    socn   min=    0.000000   max=   39.287124   mean=   34.528586
+Test     :    tocn   min=   -1.919026   max=   31.098817   mean=    6.145463
+Test     :     ssh   min=   -2.317706   max=    0.908869   mean=   -0.297573
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  130.682128
 Test     :      sw   min=  -57.100000   max=  -57.100000   mean=  -86.521926
 Test     :     lhf   min=  103.000000   max=  103.000000   mean=  156.072827
 Test     :     shf   min=    7.700000   max=    7.700000   mean=   11.667580
 Test     :      lw   min=  600.000000   max=  600.000000   mean=  909.162099
 Test     :      us   min=    0.080000   max=    0.080000   mean=    0.121222
 Test     : H(x) for member 1:
-Test     : CoolSkin nobs= 17 Min=11.061360, Max=29.841979, RMS=23.620745
-Test     : SeaSurfaceTemp nobs= 17 Min=11.075220, Max=29.855880, RMS=23.634269
-Test     : SeaSurfaceSalinity nobs= 14 Min=33.079983, Max=35.767173, RMS=34.574174
-Test     : ADT nobs= 11 Min=-0.908611, Max=0.947450, RMS=0.687130
-Test     : InsituTemperature nobs= 10 Min=8.190523, Max=26.556854, RMS=19.172156
-Test     : InsituSalinity nobs= 10 Min=34.600028, Max=35.162330, RMS=34.956339
+Test     : CoolSkin nobs= 17 Min=11.061857, Max=29.848316, RMS=23.601408
+Test     : SeaSurfaceTemp nobs= 17 Min=11.075718, Max=29.862217, RMS=23.614929
+Test     : SeaSurfaceSalinity nobs= 14 Min=33.076702, Max=35.776559, RMS=34.581195
+Test     : ADT nobs= 11 Min=-0.909733, Max=0.947071, RMS=0.686862
+Test     : InsituTemperature nobs= 10 Min=8.190531, Max=26.607718, RMS=19.179244
+Test     : InsituSalinity nobs= 10 Min=34.600028, Max=35.167139, RMS=34.956812
 Test     : SeaIceFraction nobs= 8 Min=0.000000, Max=0.996173, RMS=0.680767
 Test     : End H(x) for member 1
 Test     : Initial state for member 2:
@@ -74,8 +74,8 @@ Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.252545
 Test     :   hicen   min=    0.000000   max= 2667.837408   mean=   98.606971
 Test     :    socn   min=    0.000000   max=   39.183521   mean=   34.500522
 Test     :    tocn   min=   -2.105869   max=   30.958657   mean=    6.152913
-Test     :     ssh   min=   -2.278406   max=    0.907008   mean=   -0.297366
-Test     :    hocn   min=    0.000957   max= 1346.023177   mean=  130.682160
+Test     :     ssh   min=   -2.278462   max=    0.906368   mean=   -0.297383
+Test     :    hocn   min=    0.000957   max= 1346.023928   mean=  130.682158
 Test     :      sw   min=  -57.100000   max=  -57.100000   mean=  -86.521926
 Test     :     lhf   min=  103.000000   max=  103.000000   mean=  156.072827
 Test     :     shf   min=    7.700000   max=    7.700000   mean=   11.667580
@@ -85,21 +85,21 @@ Test     : Final state for member 2:
 Test     :   Valid time: 2018-04-15T08:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.252545
 Test     :   hicen   min=    0.000000   max= 2667.837408   mean=   98.606971
-Test     :    socn   min=    0.000000   max=   39.061311   mean=   34.493249
-Test     :    tocn   min=   -1.897548   max=   30.950055   mean=    6.138766
-Test     :     ssh   min=   -2.247427   max=    0.908315   mean=   -0.297746
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  130.682134
+Test     :    socn   min=    0.000000   max=   39.061374   mean=   34.492615
+Test     :    tocn   min=   -1.897550   max=   30.967496   mean=    6.137755
+Test     :     ssh   min=   -2.249361   max=    0.908145   mean=   -0.297852
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  130.682120
 Test     :      sw   min=  -57.100000   max=  -57.100000   mean=  -86.521926
 Test     :     lhf   min=  103.000000   max=  103.000000   mean=  156.072827
 Test     :     shf   min=    7.700000   max=    7.700000   mean=   11.667580
 Test     :      lw   min=  600.000000   max=  600.000000   mean=  909.162099
 Test     :      us   min=    0.080000   max=    0.080000   mean=    0.121222
 Test     : H(x) for member 2:
-Test     : CoolSkin nobs= 17 Min=11.087655, Max=29.842165, RMS=23.707222
-Test     : SeaSurfaceTemp nobs= 17 Min=11.101515, Max=29.856066, RMS=23.720752
-Test     : SeaSurfaceSalinity nobs= 14 Min=33.720039, Max=35.853467, RMS=34.851818
-Test     : ADT nobs= 11 Min=-0.927621, Max=0.943660, RMS=0.691436
-Test     : InsituTemperature nobs= 10 Min=8.221117, Max=26.514957, RMS=19.154379
-Test     : InsituSalinity nobs= 10 Min=34.624799, Max=35.155080, RMS=34.958198
+Test     : CoolSkin nobs= 17 Min=11.087655, Max=29.842165, RMS=23.706426
+Test     : SeaSurfaceTemp nobs= 17 Min=11.101515, Max=29.856066, RMS=23.719956
+Test     : SeaSurfaceSalinity nobs= 14 Min=33.724706, Max=35.853467, RMS=34.850689
+Test     : ADT nobs= 11 Min=-0.930040, Max=0.942359, RMS=0.691435
+Test     : InsituTemperature nobs= 10 Min=8.221119, Max=26.515396, RMS=19.154556
+Test     : InsituSalinity nobs= 10 Min=34.624799, Max=35.155037, RMS=34.958197
 Test     : SeaIceFraction nobs= 8 Min=0.000000, Max=0.996173, RMS=0.680767
 Test     : End H(x) for member 2

--- a/test/testoutput/forecast_mom6.test
+++ b/test/testoutput/forecast_mom6.test
@@ -15,10 +15,10 @@ Test     : Final state:
 Test     :   Valid time: 2018-04-15T06:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.252545
 Test     :   hicen   min=    0.000000   max= 2667.837408   mean=   98.606971
-Test     :    socn   min=    0.000000   max=   39.037325   mean=   34.508551
-Test     :    tocn   min=   -1.883213   max=   30.980013   mean=    6.154571
-Test     :     ssh   min=   -2.114536   max=    0.906006   mean=   -0.297224
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  130.682164
+Test     :    socn   min=    0.000000   max=   39.037826   mean=   34.508529
+Test     :    tocn   min=   -1.885402   max=   31.031805   mean=    6.153534
+Test     :     ssh   min=   -2.116457   max=    0.905869   mean=   -0.297333
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  130.682150
 Test     :      sw   min=  -57.100000   max=  -57.100000   mean=  -86.521926
 Test     :     lhf   min=  103.000000   max=  103.000000   mean=  156.072827
 Test     :     shf   min=    7.700000   max=    7.700000   mean=   11.667580

--- a/test/testoutput/genenspert.test
+++ b/test/testoutput/genenspert.test
@@ -17,8 +17,8 @@ Test     :   cicen   min=   -0.344406   max=    1.232382   mean=    0.256513
 Test     :   hicen   min=  -41.294283   max= 2654.924156   mean=   98.597182
 Test     :    socn   min=    0.000000   max=   39.224980   mean=   34.515960
 Test     :    tocn   min=   -2.095108   max=   31.317652   mean=    6.153311
-Test     :     ssh   min=   -2.230970   max=    0.901205   mean=   -0.297196
-Test     :    hocn   min=    0.000957   max= 1345.978568   mean=  130.682164
+Test     :     ssh   min=   -2.230916   max=    0.901090   mean=   -0.297197
+Test     :    hocn   min=    0.000957   max= 1345.978171   mean=  130.682164
 Test     :      sw   min=  -57.100000   max=  -57.100000   mean=  -86.521926
 Test     :     lhf   min=  103.000000   max=  103.000000   mean=  156.072827
 Test     :     shf   min=    7.700000   max=    7.700000   mean=   11.667580
@@ -28,9 +28,9 @@ Test     : Member 1 final state:
 Test     :   Valid time: 2018-04-15T06:00:00Z
 Test     :   cicen   min=   -0.369093   max=    1.306602   mean=    0.250380
 Test     :   hicen   min=  -30.749962   max= 2663.679194   mean=   98.279735
-Test     :    socn   min=    0.000000   max=   39.447967   mean=   34.538897
-Test     :    tocn   min=   -1.924808   max=   31.075817   mean=    6.149524
-Test     :     ssh   min=   -2.270988   max=    0.899654   mean=   -0.297305
+Test     :    socn   min=    0.000000   max=   39.447965   mean=   34.538204
+Test     :    tocn   min=   -1.925049   max=   31.093117   mean=    6.148585
+Test     :     ssh   min=   -2.270860   max=    0.899206   mean=   -0.297312
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  130.682157
 Test     :      sw   min=  -57.100000   max=  -57.100000   mean=  -86.521926
 Test     :     lhf   min=  103.000000   max=  103.000000   mean=  156.072827
@@ -43,8 +43,8 @@ Test     :   cicen   min=   -0.319454   max=    1.171552   mean=    0.251921
 Test     :   hicen   min=  -38.446472   max= 2683.748465   mean=   98.858788
 Test     :    socn   min=    0.000000   max=   39.183521   mean=   34.500522
 Test     :    tocn   min=   -2.105869   max=   30.958657   mean=    6.152913
-Test     :     ssh   min=   -2.278406   max=    0.907008   mean=   -0.297366
-Test     :    hocn   min=    0.000957   max= 1346.023177   mean=  130.682160
+Test     :     ssh   min=   -2.278462   max=    0.906368   mean=   -0.297383
+Test     :    hocn   min=    0.000957   max= 1346.023928   mean=  130.682158
 Test     :      sw   min=  -57.100000   max=  -57.100000   mean=  -86.521926
 Test     :     lhf   min=  103.000000   max=  103.000000   mean=  156.072827
 Test     :     shf   min=    7.700000   max=    7.700000   mean=   11.667580
@@ -54,10 +54,10 @@ Test     : Member 3 final state:
 Test     :   Valid time: 2018-04-15T06:00:00Z
 Test     :   cicen   min=   -0.367003   max=    1.187798   mean=    0.254667
 Test     :   hicen   min=  -40.334560   max= 2668.801488   mean=   98.770684
-Test     :    socn   min=    0.000000   max=   39.059749   mean=   34.521184
-Test     :    tocn   min=   -1.897734   max=   31.071877   mean=    6.134516
-Test     :     ssh   min=   -2.247361   max=    0.912679   mean=   -0.297392
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  130.682152
+Test     :    socn   min=    0.000000   max=   39.059716   mean=   34.520517
+Test     :    tocn   min=   -1.897734   max=   31.088828   mean=    6.133484
+Test     :     ssh   min=   -2.247909   max=    0.912134   mean=   -0.297429
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  130.682147
 Test     :      sw   min=  -57.100000   max=  -57.100000   mean=  -86.521926
 Test     :     lhf   min=  103.000000   max=  103.000000   mean=  156.072827
 Test     :     shf   min=    7.700000   max=    7.700000   mean=   11.667580
@@ -69,8 +69,8 @@ Test     :   cicen   min=   -0.345213   max=    1.124785   mean=    0.253645
 Test     :   hicen   min=  -28.044784   max= 2660.394840   mean=   98.880312
 Test     :    socn   min=    0.000000   max=   39.823491   mean=   34.527774
 Test     :    tocn   min=   -2.091573   max=   30.975591   mean=    6.161964
-Test     :     ssh   min=   -2.168405   max=    0.909743   mean=   -0.297451
-Test     :    hocn   min=    0.000961   max= 1346.050538   mean=  130.682150
+Test     :     ssh   min=   -2.169596   max=    0.909360   mean=   -0.297520
+Test     :    hocn   min=    0.000961   max= 1346.052088   mean=  130.682140
 Test     :      sw   min=  -57.100000   max=  -57.100000   mean=  -86.521926
 Test     :     lhf   min=  103.000000   max=  103.000000   mean=  156.072827
 Test     :     shf   min=    7.700000   max=    7.700000   mean=   11.667580

--- a/test/testoutput/hofx.test
+++ b/test/testoutput/hofx.test
@@ -15,21 +15,21 @@ Test     : Final state:
 Test     :   Valid time: 2018-04-15T03:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.252545
 Test     :   hicen   min=    0.000000   max= 2667.837408   mean=   98.606971
-Test     :    socn   min=    0.000000   max=   39.037648   mean=   34.508870
-Test     :    tocn   min=   -1.883288   max=   30.999315   mean=    6.154315
-Test     :     ssh   min=   -2.115299   max=    0.904582   mean=   -0.297181
-Test     :    hocn   min=    0.000957   max= 1345.949348   mean=  130.682168
+Test     :    socn   min=    0.000000   max=   39.037770   mean=   34.508909
+Test     :    tocn   min=   -1.885421   max=   31.016797   mean=    6.153956
+Test     :     ssh   min=   -2.115360   max=    0.903955   mean=   -0.297198
+Test     :    hocn   min=    0.000957   max= 1345.950587   mean=  130.682166
 Test     :      sw   min=  -57.100000   max=  -57.100000   mean=  -86.521926
 Test     :     lhf   min=  103.000000   max=  103.000000   mean=  156.072827
 Test     :     shf   min=    7.700000   max=    7.700000   mean=   11.667580
 Test     :      lw   min=  600.000000   max=  600.000000   mean=  909.162099
 Test     :      us   min=    0.080000   max=    0.080000   mean=    0.121222
 Test     : H(x): 
-Test     : CoolSkin nobs= 21 Min=3.672935, Max=29.608128, RMS=25.912199
-Test     : SeaSurfaceTemp nobs= 21 Min=3.686794, Max=29.622029, RMS=25.925487
-Test     : SeaSurfaceSalinity nobs= 9 Min=33.176612, Max=35.830379, RMS=34.486325
-Test     : ADT nobs= 14 Min=-0.752536, Max=1.561914, RMS=1.019816
-Test     : InsituTemperature nobs= 10 Min=7.750185, Max=30.304328, RMS=23.490562
-Test     : InsituSalinity nobs= 10 Min=33.968657, Max=35.712908, RMS=35.031266
+Test     : CoolSkin nobs= 21 Min=3.672935, Max=29.621231, RMS=25.921059
+Test     : SeaSurfaceTemp nobs= 21 Min=3.686794, Max=29.635132, RMS=25.934347
+Test     : SeaSurfaceSalinity nobs= 9 Min=33.176554, Max=35.830379, RMS=34.486207
+Test     : ADT nobs= 14 Min=-0.752580, Max=1.562011, RMS=1.019883
+Test     : InsituTemperature nobs= 10 Min=7.750182, Max=30.329756, RMS=23.493833
+Test     : InsituSalinity nobs= 10 Min=33.964664, Max=35.712910, RMS=35.030880
 Test     : SeaIceFraction nobs= 14 Min=0.000000, Max=0.999966, RMS=0.658284
 Test     : End H(x)


### PR DESCRIPTION
surface forcing was added for the 4 degree configuration (all fluxes were previously set to zero).
A single monthly field for April is provided for precip & runoff, daily fields for the dates around the 4/15 test date (4/14 12Z to 4/16 12Z) are used for the rest of the fluxes.

Tests answers were updated for the tests using model advance. 

closes #109 