### PR TITLE
Added bounds for T&S in init integration

### DIFF
--- a/src/Model/soca_model_mod.F90
+++ b/src/Model/soca_model_mod.F90
@@ -82,6 +82,17 @@ subroutine soca_initialize_integration(self, flds)
   call mpp_update_domains(flds%tocn, flds%geom%ocean%G%Domain%mpp_domain)
   call mpp_update_domains(flds%socn, flds%geom%ocean%G%Domain%mpp_domain)
 
+  ! Impose bounds to T & S
+  ! TODO: Replace by a change of variable.
+  if ( self%tocn_minmax(1) /= real(-999., kind=8) ) &
+    where( flds%tocn < self%tocn_minmax(1) ) flds%tocn = self%tocn_minmax(1)
+  if ( self%tocn_minmax(2) /= real(-999., kind=8) ) &
+    where( flds%tocn > self%tocn_minmax(2) ) flds%tocn = self%tocn_minmax(2)
+  if ( self%socn_minmax(1) /= real(-999., kind=8) ) &
+    where( flds%socn < self%socn_minmax(1) ) flds%socn = self%socn_minmax(1)
+  if ( self%socn_minmax(2) /= real(-999., kind=8) ) &
+    where( flds%socn > self%socn_minmax(2) ) flds%socn = self%socn_minmax(2)
+  
   ! Update MOM's T and S to soca's
   self%mom6_config%MOM_CSp%T = real(flds%tocn, kind=8)
   self%mom6_config%MOM_CSp%S = real(flds%socn, kind=8)
@@ -159,7 +170,9 @@ subroutine soca_finalize_integration(self, flds)
   ! Update halo
   call mpp_update_domains(flds%tocn, flds%geom%ocean%G%Domain%mpp_domain)
   call mpp_update_domains(flds%socn, flds%geom%ocean%G%Domain%mpp_domain)
-
+ 
+  ! Impose bounds to T & S
+  ! TODO: Replace by a change of variable.
   if ( self%tocn_minmax(1) /= real(-999., kind=8) ) &
     where( flds%tocn < self%tocn_minmax(1) ) flds%tocn = self%tocn_minmax(1)
   if ( self%tocn_minmax(2) /= real(-999., kind=8) ) &


### PR DESCRIPTION
This is a follow up of @aerorahul 's "checkpointing" PR, which checked for out of bound values when writing a model restart. This PR does the same thing but at the level of the initialization of the model integration, and will, for example check for out of bound values at the start of each outer loop or after adding perturbations to the state.

closes #122  