### PR TITLE
Memory leak in getvalue

### DIFF
--- a/src/Utils/soca_bumpinterp2d_mod.F90
+++ b/src/Utils/soca_bumpinterp2d_mod.F90
@@ -106,6 +106,7 @@ contains
          &tmp_lonmod, tmp_latmod, area, vunit, tmp_maskmod(:,1),&
          &nobs=no, lonobs=obs_lon, latobs=obs_lat )
     call self%bump%run_drivers()
+    call self%bump%partial_dealloc
 
     self%initialized = .true.
     self%nobs = no


### PR DESCRIPTION
Add "partial dealloc" of bump object after the initialization. I remember a discussion with @danholdaway a while ago on the subject, but I forgot to actually implement the one liner fix ... So here it is. It allows the 1/4 deg mom6 dual space 3dvar to run on 100 cores, maybe less (on Theia, not sure of the memory).