### PR TITLE
Optional saving of local geometry

### DIFF
--- a/src/Geometry/soca_geom_mod.F90
+++ b/src/Geometry/soca_geom_mod.F90
@@ -287,7 +287,7 @@ contains
     class(soca_geom), intent(in) :: self
 
     character(len=256) :: geom_output_file = "geom_output.nc"
-    character(len=256) :: geom_output_pe,varname
+    character(len=256) :: geom_output_pe
     integer :: pe
     character(len=8) :: fmt = '(I5.5)'
     character(len=1024) :: strpe

--- a/src/Geometry/soca_geom_mod.F90
+++ b/src/Geometry/soca_geom_mod.F90
@@ -284,7 +284,7 @@ contains
   ! ------------------------------------------------------------------------------
   !> Write geometry info to file
   subroutine geom_infotofile(self)
-    class(soca_geom),  intent(in) :: self
+    class(soca_geom), intent(in) :: self
 
     character(len=256) :: geom_output_file = "geom_output.nc"
     character(len=256) :: geom_output_pe,varname

--- a/src/Geometry/soca_geom_mod.F90
+++ b/src/Geometry/soca_geom_mod.F90
@@ -315,14 +315,10 @@ contains
 
        call geom_get_domain_indices(self, "compute", is, ie, js, je)
        ns = (ie - is + 1) * (je - js + 1 )
-       varname='shoremask'
-       call write2pe(reshape(self%shoremask,(/ns/)),varname,geom_output_pe,.false.)
-       varname='mask'
-       call write2pe(reshape(self%mask2d,(/ns/)),varname,geom_output_pe,.true.)
-       varname='lon'
-       call write2pe(reshape(self%lon,(/ns/)),varname,geom_output_pe,.true.)
-       varname='lat'
-       call write2pe(reshape(self%lat,(/ns/)),varname,geom_output_pe,.true.)
+       call write2pe(reshape(self%shoremask,(/ns/)),'shoremask',geom_output_pe,.false.)
+       call write2pe(reshape(self%mask2d,(/ns/)),'mask',geom_output_pe,.true.)
+       call write2pe(reshape(self%lon,(/ns/)),'lon',geom_output_pe,.true.)
+       call write2pe(reshape(self%lat,(/ns/)),'lat',geom_output_pe,.true.)
     end if
 
   end subroutine geom_infotofile

--- a/src/Geometry/soca_geom_mod.F90
+++ b/src/Geometry/soca_geom_mod.F90
@@ -78,13 +78,9 @@ contains
     self%save_local_domain = .false.
     if (config_element_exists(c_conf,"save_local_domain")) then
        isave = config_get_int(c_conf,"read_from_file")
-       if (isave.eq.1 ) then
-          self%save_local_domain = .true.
-       else
-          self%save_local_domain = .false.
-       end if
+       if (isave.eq.1 ) self%save_local_domain = .true.
     endif
-    
+
     call geom_allocate(self)
 
   end subroutine geom_init
@@ -289,7 +285,7 @@ contains
   !> Write geometry info to file
   subroutine geom_infotofile(self)
     class(soca_geom),  intent(in) :: self
-    
+
     character(len=256) :: geom_output_file = "geom_output.nc"
     character(len=256) :: geom_output_pe,varname
     integer :: pe

--- a/src/Utils/soca_utils.F90
+++ b/src/Utils/soca_utils.F90
@@ -120,7 +120,7 @@ contains
     implicit none
 
     real(kind=kind_real), intent(in) :: vec(:)
-    character(len=256),   intent(in) :: varname
+    character(len=*),     intent(in) :: varname
     character(len=256),   intent(in) :: filename
     logical,              intent(in) :: append
 


### PR DESCRIPTION
closes #139 
The geometry constructor was saving the local domain for each pe, useful for debugging but cumbersome the rest of the time. It is now added as an option, the default does not save the local geometry. 