### PR TITLE
ctest speed-up

### DIFF
--- a/test/testinput/3dhyb.yml
+++ b/test/testinput/3dhyb.yml
@@ -56,8 +56,6 @@ cost_function:
         ocean_depth_min: 1000 # [m]
         rescale_bkgerr: 1.0
         efold_z: 2500.0       # [m]
-        variables:
-          variables: *soca_vars
         inputVariables:
           variables: *soca_vars
         outputVariables:
@@ -77,16 +75,12 @@ cost_function:
         cicen_max: 0.5
         hicen_min: 10.0
         hicen_max: 100.0
-        variables:
-          variables: *soca_vars
         inputVariables:
           variables: *soca_vars
         outputVariables:
           variables: *soca_vars
 
       - varchange: VertConvSOCA
-        variables:
-          variables: *soca_vars
         Lz_min: 2.0
         Lz_mld: 1
         Lz_mld_max: 500.0

--- a/test/testinput/3dhybfgat.yml
+++ b/test/testinput/3dhybfgat.yml
@@ -156,7 +156,7 @@ variational:
       version: IdTLM
       tstep: PT1H
       variables: *soca_vars
-    ninner: 5
+    ninner: 1
     gradient_norm_reduction: 1e-15
     test: 'on'
     prints:

--- a/test/testinput/3dhybfgat.yml
+++ b/test/testinput/3dhybfgat.yml
@@ -54,8 +54,6 @@ cost_function:
         ocean_depth_min: 1000 # [m]
         rescale_bkgerr: 1.0
         efold_z: 2500.0       # [m]
-        variables:
-          variables: *soca_vars
         inputVariables:
           variables: *soca_vars
         outputVariables:
@@ -75,16 +73,12 @@ cost_function:
         cicen_max: 0.5
         hicen_min: 10.0
         hicen_max: 100.0
-        variables:
-          variables: *soca_vars
         inputVariables:
           variables: *soca_vars
         outputVariables:
           variables: *soca_vars
 
       - varchange: VertConvSOCA
-        variables:
-          variables: *soca_vars
         Lz_min: 2.0
         Lz_mld: 1
         Lz_mld_max: 500.0

--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -63,8 +63,6 @@ cost_function:
         ocean_depth_min: 1000 # [m]
         rescale_bkgerr: 1.0
         efold_z: 2500.0       # [m]
-        variables:
-          variables: *soca_vars
         inputVariables:
           variables: *soca_vars
         outputVariables:
@@ -84,16 +82,12 @@ cost_function:
         cicen_max: 0.5
         hicen_min: 10.0
         hicen_max: 100.0
-        variables:
-          variables: *soca_vars
         inputVariables:
           variables: *soca_vars
         outputVariables:
           variables: *soca_vars
 
       - varchange: VertConvSOCA
-        variables:
-          variables: *soca_vars
         Lz_min: 2.0
         Lz_mld: 1
         Lz_mld_max: 500.0

--- a/test/testinput/3dvar_soca.yml
+++ b/test/testinput/3dvar_soca.yml
@@ -61,8 +61,6 @@ cost_function:
         ocean_depth_min: 1000 # [m]
         rescale_bkgerr: 1.0
         efold_z: 2500.0       # [m]
-        variables:
-          variables: *soca_vars
         inputVariables:
           variables: *soca_vars
         outputVariables:
@@ -86,16 +84,12 @@ cost_function:
         hicen_max: 100.0
         #fixed_std_sst: 0.005 # OK to create pretty increments
         #fixed_std_sss: 0.001 # but that option should not exist!
-        variables:
-          variables: *soca_vars
         inputVariables:
           variables: *soca_vars
         outputVariables:
           variables: *soca_vars
 
       - varchange: VertConvSOCA
-        variables:
-          variables: *soca_vars
         Lz_min: 10.0
         Lz_mld: 1
         Lz_mld_max: 500

--- a/test/testinput/3dvarfgat.yml
+++ b/test/testinput/3dvarfgat.yml
@@ -225,7 +225,7 @@ variational:
       version: IdTLM
       tstep: PT1H
       variables: *soca_vars
-    ninner: 5
+    ninner: 1
     gradient_norm_reduction: 1e-15
     test: 'on'
     prints:

--- a/test/testinput/3dvarfgat.yml
+++ b/test/testinput/3dvarfgat.yml
@@ -61,8 +61,6 @@ cost_function:
         ocean_depth_min: 1000 # [m]
         rescale_bkgerr: 1.0
         efold_z: 2500.0       # [m]
-        variables:
-          variables: *soca_vars
         inputVariables:
           variables: *soca_vars
         outputVariables:
@@ -86,16 +84,12 @@ cost_function:
         hicen_max: 100.0
         #fixed_std_sst: 0.005 # OK to create pretty increments
         #fixed_std_sss: 0.001 # but that option should not exist!
-        variables:
-          variables: *soca_vars
         inputVariables:
           variables: *soca_vars
         outputVariables:
           variables: *soca_vars
 
       - varchange: VertConvSOCA
-        variables:
-          variables: *soca_vars
         Lz_min: 10.0
         Lz_mld: 1
         Lz_mld_max: 500

--- a/test/testinput/balance.yml
+++ b/test/testinput/balance.yml
@@ -17,8 +17,6 @@ LinearVariableChangeTests:
 - varchange: BalanceSOCA
   toleranceInverse: 1e-12
   testinverse: 1
-  variables:
-    variables: *soca_vars
   dsdtmax: 1.0
   dsdzmin: 3.0e-3
   dtdzmin: 1.0e-3

--- a/test/testinput/bkgerrfilt.yml
+++ b/test/testinput/bkgerrfilt.yml
@@ -20,8 +20,6 @@ LinearVariableChangeTests:
   ocean_depth_min: 1000 # [m]
   rescale_bkgerr: 1.0
   efold_z: 1500.0       # [m]
-  variables:
-    variables: *soca_vars
   inputVariables:
     variables: *soca_vars
   outputVariables:

--- a/test/testinput/bkgerrgodas.yml
+++ b/test/testinput/bkgerrgodas.yml
@@ -30,8 +30,6 @@ LinearVariableChangeTests:
   cicen_max: 0.5
   hicen_min: 10.0
   hicen_max: 100.0
-  variables:
-    variables: *soca_vars
   inputVariables:
     variables: *soca_vars
   outputVariables:

--- a/test/testinput/bkgerrsoca.yml
+++ b/test/testinput/bkgerrsoca.yml
@@ -34,8 +34,6 @@ LinearVariableChangeTests:
   hicen_max: 100.0
   #fixed_std_sst: 0.005 # OK to create pretty increments
   #fixed_std_sss: 0.001 # but that option should not exist!
-  variables:
-    variables: *soca_vars
   inputVariables:
     variables: *soca_vars
   outputVariables:

--- a/test/testinput/dirac_soca_cov.yml
+++ b/test/testinput/dirac_soca_cov.yml
@@ -32,8 +32,6 @@ Covariance:
     ocean_depth_min: 100 # [m]
     rescale_bkgerr: 1.0
     efold_z: 2500.0       # [m]
-    variables:
-      variables: *soca_vars
     inputVariables:
       variables: *soca_vars
     outputVariables:

--- a/test/testinput/dirac_socahyb_cov.yml
+++ b/test/testinput/dirac_socahyb_cov.yml
@@ -42,8 +42,6 @@ Covariance:
      ocean_depth_min: 1000 # [m]
      rescale_bkgerr: 1.0
      efold_z: 2500.0       # [m]
-     variables:
-       variables: *soca_vars
      inputVariables:
        variables: *soca_vars
      outputVariables:
@@ -63,16 +61,12 @@ Covariance:
      cicen_max: 0.5
      hicen_min: 10.0
      hicen_max: 100.0
-     variables:
-       variables: *soca_vars
      inputVariables:
        variables: *soca_vars
      outputVariables:
        variables: *soca_vars
 
    - varchange: VertConvSOCA
-     variables:
-       variables: *soca_vars
      Lz_min: 2.0
      Lz_mld: 1
      Lz_mld_max: 500.0

--- a/test/testinput/genenspert.yml
+++ b/test/testinput/genenspert.yml
@@ -38,8 +38,6 @@ Covariance:
     ocean_depth_min: 1000 # [m]
     rescale_bkgerr: 1.0
     efold_z: 2500.0       # [m]
-    variables:
-      variables: *soca_vars
     inputVariables:
       variables: *soca_vars
     outputVariables:
@@ -59,8 +57,6 @@ Covariance:
     cicen_max: 0.5
     hicen_min: 10.0
     hicen_max: 100.0
-    variables:
-      variables: *soca_vars
     inputVariables:
       variables: *soca_vars
     outputVariables:

--- a/test/testinput/parameters_bump_loc.yml
+++ b/test/testinput/parameters_bump_loc.yml
@@ -25,10 +25,10 @@ bump:
   nrep: 2
   lsqrt: 1
   resol: 6
-  network: 1
-  mask: 1
+  network: 0
+  mask: 0
   mpicom: 2
   default_seed: 1
   forced_radii: 1
   rh: 2500000.0
-  rv: 5
+  rv: 500

--- a/test/testinput/static_SocaError_init.yml
+++ b/test/testinput/static_SocaError_init.yml
@@ -21,12 +21,12 @@ Covariance:
   method: cor
   strategy: specific_univariate
   new_nicas: 1
-  mask_check: 1
+  mask_check: 0
   ntry: 3
   nrep:  2
   lsqrt: 1
   resol: 6.0
-  network: 1
+  network: 0
   mpicom: 2
   forced_radii: 1
   date: *date

--- a/test/testinput/static_SocaError_init.yml
+++ b/test/testinput/static_SocaError_init.yml
@@ -21,12 +21,12 @@ Covariance:
   method: cor
   strategy: specific_univariate
   new_nicas: 1
-  mask_check: 0
+  mask_check: 1
   ntry: 3
   nrep:  2
   lsqrt: 1
   resol: 6.0
-  network: 0
+  network: 1
   mpicom: 2
   forced_radii: 1
   date: *date

--- a/test/testinput/vertconv.yml
+++ b/test/testinput/vertconv.yml
@@ -17,8 +17,6 @@ LinearVariableChangeTests:
 - varchange: VertConvSOCA
   toleranceInverse: 1e-12
   testinverse: 0
-  variables:
-    variables: *soca_vars
   Lz_min: 10.0
   Lz_mld: 1
   Lz_mld_max: 500.0

--- a/test/testoutput/3dhyb.test
+++ b/test/testoutput/3dhyb.test
@@ -1,21 +1,21 @@
 Test     : CostJb   : Nonlinear Jb = 0
 Test     : CostJo   : Nonlinear Jo(ADT) = 209.78, nobs = 100, Jo/n = 2.0978, err = 0.1
 Test     : CostFunction: Nonlinear J = 209.78
-Test     : RPCGMinimizer: reduction in residual norm = 0.534575
+Test     : RPCGMinimizer: reduction in residual norm = 0.544449
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.252557
-Test     :   hicen   min=   -0.000378   max=    2.947887   mean=    0.102704
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.252556
+Test     :   hicen   min=   -0.000389   max=    2.947887   mean=    0.102705
 Test     :   hsnon   min=    0.000000   max=    0.610656   mean=    0.024607
-Test     :    socn   min=    0.000000   max=   38.999706   mean=   34.516625
-Test     :    tocn   min=   -1.883330   max=   31.008839   mean=    6.151577
-Test     :     ssh   min=   -2.191975   max=    0.935498   mean=   -0.306260
+Test     :    socn   min=    0.000000   max=   38.999706   mean=   34.520423
+Test     :    tocn   min=   -1.883330   max=   31.008840   mean=    6.151645
+Test     :     ssh   min=   -2.189378   max=    0.934031   mean=   -0.306380
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  130.682172
 Test     :      sw   min= -226.053650   max=    0.000000   mean= -110.176189
 Test     :     lhf   min=  -85.418602   max=  317.347870   mean=   64.442333
 Test     :     shf   min= -121.299400   max=  242.676361   mean=    8.957396
 Test     :      lw   min=   -0.000000   max=   89.266090   mean=   47.830237
 Test     :      us   min=    0.004396   max=    0.021537   mean=    0.011925
-Test     : CostJb   : Nonlinear Jb = 2.012989
-Test     : CostJo   : Nonlinear Jo(ADT) = 146.701823, nobs = 100, Jo/n = 1.467018, err = 0.100000
-Test     : CostFunction: Nonlinear J = 148.714812
+Test     : CostJb   : Nonlinear Jb = 3.431670
+Test     : CostJo   : Nonlinear Jo(ADT) = 149.317746, nobs = 100, Jo/n = 1.493177, err = 0.100000
+Test     : CostFunction: Nonlinear J = 152.749417

--- a/test/testoutput/3dhybfgat.test
+++ b/test/testoutput/3dhybfgat.test
@@ -1,20 +1,20 @@
 Test     : CostJb   : Nonlinear Jb = 0
 Test     : CostJo   : Nonlinear Jo(ADT) = 94.7803, nobs = 31, Jo/n = 3.05743, err = 0.1
 Test     : CostFunction: Nonlinear J = 94.7803
-Test     : RPCGMinimizer: reduction in residual norm = 0.00323678
+Test     : RPCGMinimizer: reduction in residual norm = 0.395671
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.252551
-Test     :   hicen   min=   -0.000213   max=    2.947887   mean=    0.102703
-Test     :    socn   min=    0.000000   max=   38.999706   mean=   34.512169
-Test     :    tocn   min=   -1.883330   max=   31.008675   mean=    6.151027
-Test     :     ssh   min=   -2.102592   max=    0.910734   mean=   -0.306080
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.252549
+Test     :   hicen   min=   -0.000309   max=    2.947887   mean=    0.102703
+Test     :    socn   min=    0.000000   max=   38.999706   mean=   34.513923
+Test     :    tocn   min=   -1.883330   max=   31.008824   mean=    6.152467
+Test     :     ssh   min=   -2.103104   max=    0.924840   mean=   -0.303358
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  130.682172
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     : CostJb   : Nonlinear Jb = 1.194176
-Test     : CostJo   : Nonlinear Jo(ADT) = 85.736254, nobs = 31, Jo/n = 2.765686, err = 0.100000
-Test     : CostFunction: Nonlinear J = 86.930429
+Test     : CostJb   : Nonlinear Jb = 1.431249
+Test     : CostJo   : Nonlinear Jo(ADT) = 89.928126, nobs = 31, Jo/n = 2.900907, err = 0.100000
+Test     : CostFunction: Nonlinear J = 91.359376

--- a/test/testoutput/3dvarfgat.test
+++ b/test/testoutput/3dvarfgat.test
@@ -7,26 +7,26 @@ Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 29.9701, nobs = 30, Jo/n
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 7.38039, nobs = 33, Jo/n = 0.223648, err = 0.61043
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 47.095, nobs = 20, Jo/n = 2.35475, err = 0.1
 Test     : CostFunction: Nonlinear J = 3790.87
-Test     : RPCGMinimizer: reduction in residual norm = 0.103367
+Test     : RPCGMinimizer: reduction in residual norm = 0.705812
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.253287
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.252881
 Test     :   hicen   min=    0.000000   max=    2.947887   mean=    0.108958
-Test     :    socn   min=    0.000000   max=   38.999706   mean=   34.516986
-Test     :    tocn   min=   -3.252924   max=   31.281110   mean=    6.182853
-Test     :     ssh   min=   -2.104129   max=    0.917031   mean=   -0.298136
+Test     :    socn   min=    0.000000   max=   39.030702   mean=   34.508845
+Test     :    tocn   min=   -2.175325   max=   31.008856   mean=    6.169264
+Test     :     ssh   min=   -2.103569   max=    0.912630   mean=   -0.296483
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  130.682172
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     : CostJb   : Nonlinear Jb = 3666.695647
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 1688.748139, nobs = 48, Jo/n = 35.182253, err = 0.387632
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 364.966758, nobs = 40, Jo/n = 9.124169, err = 0.391743
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 1.461812, nobs = 16, Jo/n = 0.091363, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 90.619582, nobs = 30, Jo/n = 3.020653, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 26.153884, nobs = 30, Jo/n = 0.871796, err = 0.915904
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 5.736058, nobs = 33, Jo/n = 0.173820, err = 0.610430
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 33.124716, nobs = 20, Jo/n = 1.656236, err = 0.100000
-Test     : CostFunction: Nonlinear J = 5877.506596
+Test     : CostJb   : Nonlinear Jb = 2844.205371
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 2687.682331, nobs = 48, Jo/n = 55.993382, err = 0.387632
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 169.826256, nobs = 40, Jo/n = 4.245656, err = 0.391743
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 1.566437, nobs = 16, Jo/n = 0.097902, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 93.522595, nobs = 30, Jo/n = 3.117420, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 29.723890, nobs = 30, Jo/n = 0.990796, err = 0.915904
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 7.086164, nobs = 33, Jo/n = 0.214732, err = 0.610430
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 38.811136, nobs = 20, Jo/n = 1.940557, err = 0.100000
+Test     : CostFunction: Nonlinear J = 5872.424178

--- a/test/testoutput/dirac_socahyb_cov.test
+++ b/test/testoutput/dirac_socahyb_cov.test
@@ -1,16 +1,16 @@
 Test     : Increment: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=   -0.039291   max=    0.005000   mean=   -0.000244
-Test     :   hicen   min=   -0.000069   max=   50.000000   mean=    0.142790
-Test     :    socn   min=   -0.070098   max=    0.151473   mean=    0.000504
-Test     :    tocn   min=   -0.004605   max=    4.327118   mean=    0.011613
-Test     :     ssh   min=   -0.009516   max=    0.050772   mean=    0.000291
+Test     :   hicen   min=   -0.000074   max=   50.000000   mean=    0.142790
+Test     :    socn   min=   -0.098835   max=    0.176265   mean=    0.000442
+Test     :    tocn   min=   -0.005738   max=    4.381662   mean=    0.011682
+Test     :     ssh   min=   -0.010054   max=    0.051230   mean=    0.000292
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : Increment: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.054673
-Test     :   hicen   min=   -0.000000   max=    1.000000   mean=    0.065608
-Test     :    socn   min=   -0.000000   max=    1.000000   mean=    0.006404
-Test     :    tocn   min=   -0.000000   max=    1.000000   mean=    0.006404
-Test     :     ssh   min=   -0.000000   max=    1.000000   mean=    0.065608
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.072204
+Test     :   hicen   min=   -0.000000   max=    1.000000   mean=    0.086645
+Test     :    socn   min=   -0.000000   max=    1.000000   mean=    0.086638
+Test     :    tocn   min=   -0.000000   max=    1.000000   mean=    0.086638
+Test     :     ssh   min=   -0.000000   max=    1.000000   mean=    0.086645
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000


### PR DESCRIPTION
closes #158 
@travissluka @aerorahul : We could speed up "3dvarfgat" and "3dhybfgat" by simplifying the B matrix and removing some of the obs. I think this is all tested elsewhere, let me know what you think.
The initialization of bump localization is 2-3 sec instead of ~70 sec (on my laptop/2 cores).