### PR TITLE
Updates for eckit-1.1.0 and fckit-0.6.3

### DIFF
--- a/src/soca/Increment/Increment.cc
+++ b/src/soca/Increment/Increment.cc
@@ -9,23 +9,27 @@
 
 #include <algorithm>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "eckit/config/LocalConfiguration.h"
+#include "eckit/exception/Exceptions.h"
+
 #include "oops/base/Variables.h"
 #include "oops/generic/UnstructuredGrid.h"
 #include "oops/util/DateTime.h"
+#include "oops/util/Duration.h"
 #include "oops/util/Logger.h"
+
+#include "ufo/GeoVaLs.h"
+#include "ufo/Locations.h"
+
 #include "soca/ModelBiasIncrement.h"
 #include "soca/Covariance/ErrorCovariance.h"
 #include "soca/Fields/Fields.h"
 #include "soca/Geometry/Geometry.h"
 #include "soca/State/State.h"
 #include "soca/GetValuesTraj/GetValuesTraj.h"
-#include "oops/util/Duration.h"
-#include "ufo/GeoVaLs.h"
-#include "ufo/Locations.h"
 
 using oops::Log;
 

--- a/src/soca/Model/Model.cc
+++ b/src/soca/Model/Model.cc
@@ -5,17 +5,18 @@
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-#include <vector>
-
 #include "soca/Model/Model.h"
 
+#include <vector>
+
 #include "eckit/config/Configuration.h"
+#include "eckit/exception/Exceptions.h"
 
 #include "oops/util/DateTime.h"
 #include "oops/util/Logger.h"
 
 #include "soca/Fields/Fields.h"
-#include "ModelFortran.h"
+#include "soca/Model/ModelFortran.h"
 #include "soca/Geometry/Geometry.h"
 #include "soca/ModelBias.h"
 #include "soca/State/State.h"

--- a/src/soca/State/State.cc
+++ b/src/soca/State/State.cc
@@ -9,18 +9,13 @@
 
 #include <algorithm>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "eckit/config/LocalConfiguration.h"
+#include "eckit/exception/Exceptions.h"
 
 #include "oops/base/Variables.h"
-#include "soca/ModelBias.h"
-#include "soca/Fields/Fields.h"
-#include "soca/Geometry/Geometry.h"
-#include "soca/Increment/Increment.h"
-#include "soca/Model/Model.h"
-#include "soca/GetValuesTraj/GetValuesTraj.h"
 #include "oops/util/DateTime.h"
 #include "oops/util/Duration.h"
 #include "oops/util/Logger.h"
@@ -28,6 +23,12 @@
 #include "ufo/GeoVaLs.h"
 #include "ufo/Locations.h"
 
+#include "soca/ModelBias.h"
+#include "soca/Fields/Fields.h"
+#include "soca/Geometry/Geometry.h"
+#include "soca/Increment/Increment.h"
+#include "soca/Model/Model.h"
+#include "soca/GetValuesTraj/GetValuesTraj.h"
 
 using oops::Log;
 


### PR DESCRIPTION
 * Fix missing header files and header ordering
 * This fix supports the updates
    * fckit-0.5.3 -> fckit-0.6.3
    * eckit-0.23.0 -> eckit-1.1.0

This PR is related to the master tracking issue [jedi-stack#32](https://github.com/JCSDA/jedi-stack/issues/32).

To test, use the following soca-bundle settings (NOTE: the fckit branch has changed names as we now have merged upstream fckit):
```
ecbuild_bundle( PROJECT eckit GIT "https://github.com/ECMWF/eckit.git" TAG 1.1.0 )
ecbuild_bundle( PROJECT fckit GIT "https://github.com/JCSDA/fckit.git" BRANCH feature/fckit-0.6.3 UPDATE)
ecbuild_bundle( PROJECT oops GIT "https://github.com/JCSDA/oops.git" BRANCH feature/eckit-1.1.0 UPDATE )
ecbuild_bundle( PROJECT crtm GIT "https://github.com/JCSDA/crtm.git" BRANCH develop UPDATE )
ecbuild_bundle( PROJECT ioda GIT "https://github.com/JCSDA/ioda.git" BRANCH feature/eckit-1.1.0 UPDATE )
ecbuild_bundle( PROJECT ioda-converters GIT "https://github.com/JCSDA/ioda-converters.git" BRANCH develop UPDATE )
ecbuild_bundle( PROJECT gsw GIT "https://github.com/JCSDA/GSW-Fortran.git" BRANCH develop UPDATE )
ecbuild_bundle( PROJECT ufo GIT "https://github.com/JCSDA/ufo.git" BRANCH feature/eckit-1.1.0 UPDATE )
ecbuild_bundle( PROJECT fms GIT "https://github.com/JCSDA/FMS.git" BRANCH dev/master-ecbuild UPDATE )
ecbuild_bundle( PROJECT cvmix GIT "https://github.com/JCSDA/CVMix-src.git" BRANCH feature/ecbuild UPDATE )
ecbuild_bundle( PROJECT geokdtree GIT "https://github.com/JCSDA/geoKdTree.git" BRANCH feature/ecbuild UPDATE )
ecbuild_bundle( PROJECT mom6_da_hooks GIT "https://github.com/JCSDA/MOM6_DA_hooks.git" BRANCH feature/ecbuild UPDATE )
ecbuild_bundle( PROJECT mom6 GIT "https://github.com/JCSDA/MOM6.git" BRANCH dev/master-ecbuild UPDATE )
ecbuild_bundle( PROJECT soca GIT "https://github.com/JCSDA/soca.git" BRANCH feature/eckit-1.1.0 UPDATE)
```

I am still experience the same test failures:
```
	342 - test_soca_enspert (Failed)
	355 - test_soca_ensvariance (Failed)
	357 - test_soca_dirac_soca_cov (Failed)
	358 - test_soca_dirac_socahyb_cov (Failed)
	361 - test_soca_enshofx (Failed)
	362 - test_soca_3dvarsoca (Failed)
	363 - test_soca_3dvargodas (Failed)
	364 - test_soca_3dhyb (Failed)
	365 - test_soca_3dhybfgat (Failed)
	366 - test_soca_checkpointmodel (Failed)
	367 - test_soca_3dvarfgat (Failed)
```
@travissluka and I discussed these are all likely un-related to the eckit/fckit updates, and may be related to differences in other dependencies I have on my laptop.   Hopefully they will pass in a typical SOCA build/test environment.

Note that the OOPS repository in particular will not be backwards compatible with older fckit or eckit versions.  Since fckit is normally built in the bundle this is not an issue, but eckit must be updated independently if the JEDI repos are used outside of the jedi-stack controlled modules or container environments.  Containers will be updated soon, once all of the related eckit-1.1.0 PRs are merged into each JEDI repo.