### PR TITLE
FTP service is no longer available at PO.DAAC, the scripts using it fail to download the obs

### DIFF
--- a/scripts/obs/README.md
+++ b/scripts/obs/README.md
@@ -1,36 +1,34 @@
 # Download observations from public servers
-The scripts in the current directory (soca/scripts/obs) can be used to download observations from public servers.
+The scripts in the current directory (soca/scripts/obs) can be used to download oceanographic observations from public servers.
 
 ## Getting Started
-The scripts are written in bash. They could be executed to any machine with linux OS.
+The scripts are written in bash. They could be executed to any machine with *nix OS which supports Bash shell. 
 
 ### Prerequisites
-For the data hosted at the Physical Oceanography Distributed Active Archive Center (PO.DAAC), the access to the observations is two step process:
+For the data hosted at the Physical Oceanography Distributed Active Archive Center (PO.DAAC), the access to the observations is a two-step process:
 
-* The user has to register at https://urs.earthdata.nasa.gov. The same credentials are used for the PO.DAAC.
+* The user has to register at https://urs.earthdata.nasa.gov. The password used for accessing the data can be retrieved from "Drive API Credentials" (https://podaac-tools.jpl.nasa.gov/drive/login)
 
-* The credentials to be stored at the ~/.netrc of the local machine
+* The credentials to be stored at the ~/.netrc of the local machine as follows:
 
 ```
 touch ~/.netrc
 chmod 600 ~/.netrc
-echo 'machine podaac-tools.jpl.nasa.gov login USERNAME_from_PO.DAAC password PASSWORD_from_PO.DAAC' >> ~/.netrc
-
+echo 'machine podaac-tools.jpl.nasa.gov login USERNAME_from_Drive_API_Credentials password PASSWORD_from_Drive_API_Credentials' >> ~/.netrc
 ```
 
 ## How to use
-The user has to modify the following three variables at the get_obs.sh, according to their choices
-
-
-```
-date_start= 
-date_end=
-output_path=
+The users have to modify the following three variables at the get_obs.sh, according to their choices:
 
 ```
+date_start=YYYYMMDD
+date_end=YYYYMMDD
+output_path=/path/where/the/obs/will/be/saved/
+```
+
 ## Additional Information
 
-* When wget is called, the first call does not take into consideration the content of the ~/.netrc file, therefore it prompts a 401 error and it calls wget for a second time with the credentials from ~/.netrc and the observations are downloaded.
+* When wget is called, the first call does not take into consideration the content of the ~/.netrc file. Therefore it prompts a 401 error, and it calls wget for a second time with the credentials from ~/.netrc and the observations are downloaded.
 
-* If there are no data for specific date, a error message will appear. This message can mislead the user. 
+* If there are no data for a specific date, an error message will appear. This message can mislead the user, but the process does not fail. 
 

--- a/scripts/obs/README.md
+++ b/scripts/obs/README.md
@@ -1,0 +1,31 @@
+# Download observations from public servers
+The scripts in the current directory (soca/scripts/obs) can be used to download observations from public servers.
+
+## Getting Started
+The scripts are written in bash. They could be executed to any machine with linux OS.
+
+### Prerequisites
+For the data hosted at the Physical Oceanography Distributed Active Archive Center (PO.DAAC), the access to the observations is two step process:
+
+* The user has to register at https://urs.earthdata.nasa.gov. The same credentials are used for the PO.DAAC.
+
+* The credentials to be stored at the ~/.netrc of the local machine
+
+```
+touch ~/.netrc
+chmod 600 ~/.netrc
+echo 'machine podaac-tools.jpl.nasa.gov login USERNAME_from_PO.DAAC password PASSWORD_from_PO.DAAC' >> ~/.netrc
+
+```
+
+## How to use
+The user has to modify the following three variables at the get_obs.sh, according to their choices
+
+
+```
+date_start= 
+date_end=
+output_path=
+
+```
+

--- a/scripts/obs/README.md
+++ b/scripts/obs/README.md
@@ -28,4 +28,9 @@ date_end=
 output_path=
 
 ```
+## Additional Information
+
+* When wget is called, the first call does not take into consideration the content of the ~/.netrc file, therefore it prompts a 401 error and it calls wget for a second time with the credentials from ~/.netrc and the observations are downloaded.
+
+* If there are no data for specific date, a error message will appear. This message can mislead the user. 
 

--- a/scripts/obs/source.ghrsst_sst.sh
+++ b/scripts/obs/source.ghrsst_sst.sh
@@ -26,18 +26,18 @@ else
 fi
 
 sat=$1
-source_base="ftp://podaac-ftp.jpl.nasa.gov/allData/ghrsst/data/GDS2"
+source_base="https://podaac-tools.jpl.nasa.gov/drive/files/allData/ghrsst/data/GDS2"
 ignore="^$"
+file_sfx='*.nc'
+
 if [[ $sat == "amsr2" ]]; then
-    source="$source_base/$lvlU/AMSR2/REMSS/v8a/"
-    ignore="rt-"
+    source="$source_base/$lvlU/AMSR2/REMSS/v8a"
 elif [[ $sat == "gmi" ]]; then
-    source="$source_base/$lvlU/GMI/REMSS/v8.2a/"
+    source="$source_base/$lvlU/GMI/REMSS/v8.2a"
 elif [[ $sat == "goes16" ]]; then
-    source="$source_base/$lvlU/GOES16/OSPO/v2.5/"
+    source="$source_base/$lvlU/GOES16/OSPO/v2.5"
 elif [[ $sat == "windsat" ]]; then
-    source="$source_base/$lvlU/WindSat/REMSS/v7.0.1a/"
-    ignore="rt-"
+    source="$source_base/$lvlU/WindSat/REMSS/v7.0.1a"
 else
     echo $usage
     exit 1
@@ -49,23 +49,11 @@ pwd=$(pwd)
 
 source_dir=$source/$yr/$dy/
 echo $source_dir
-files=$(curl -lf $source_dir || echo "" )
-for f in $files; do
-    # ignore the .md5 files
-    fe=${f##*.}
-    [[ $fe == "md5" ]] && continue
 
-    # some other files need to be ignored, depending on the source
-    [[ $f =~ $ignore ]] && continue
-    
-    d=$out_dir/$date
-    
-    # skip if file already exists
-    [[ -e $d/$f ]] && continue
+d=$out_dir/$date
+mkdir -p $d
+cd $d
 
-    mkdir -p $d
-    cd $d
-    wget $source_dir/$f
-    cd $pwd
-done
+wget -r -nc -np -nH -nd -A $file_sfx  $source_dir
 
+cd $pwd

--- a/scripts/obs/source.jpl_smap.sh
+++ b/scripts/obs/source.jpl_smap.sh
@@ -21,12 +21,17 @@ yr=${date:0:4}
 dy=$(date -d "$date" "+%j")
 
 
+source_base="https://podaac-tools.jpl.nasa.gov/drive/files/allData/smap/L2"
+
 if [[ $type == "jpl" ]]; then
-    source="ftp://podaac-ftp.jpl.nasa.gov/allData/smap/L2/JPL/V4.2"
+    source=$source_base"/JPL/V4.2"
+    file_sfx='*.h5'
 elif [[ $type == "rss_40km" ]]; then
-    source="ftp://podaac-ftp.jpl.nasa.gov/allData/smap/L2/RSS/V3/SCI/40KM"
+    source=$source_base"/RSS/V3/SCI/40KM"
+    file_sfx='*.nc'
 elif [[ $type == "rss_70km" ]]; then
-    source="ftp://podaac-ftp.jpl.nasa.gov/allData/smap/L2/RSS/V3/SCI/70KM"
+    source=$source_base"/RSS/V3/SCI/70KM"
+    file_sfx='*.nc'
 else
     echo $usage
     exit 1
@@ -36,16 +41,11 @@ out_dir="$output_path/sss.smap.$type"
 pwd=$(pwd)
 source_dir=$source/${yr}/${dy}/
 
+d=$out_dir/$date
+mkdir -p $d
+cd $d
 
-files=$(curl $source_dir -l)
-for f in $files; do
-    # ignore the .md5 files
-    fe=${f##*.}
-    [[  $fe == "md5" ]] && continue
-    
-    d=$out_dir/$date
-    mkdir -p $d
-    cd $d
-    wget $source_dir/$f
-    cd $pwd
-done
+wget -r -nc -np -nH -nd -A $file_sfx  $source_dir
+
+cd $pwd
+

--- a/scripts/obs/source.nesdis_sst_viirs.sh
+++ b/scripts/obs/source.nesdis_sst_viirs.sh
@@ -15,7 +15,7 @@ dy=$(date -d "$date" "+%j")
 
 lvl=$1
 if [[ $lvl == "l2p" ]]; then
-    source="ftp://podaac-ftp.jpl.nasa.gov/allData/ghrsst/data/GDS2/L2P/VIIRS_NPP/OSPO/v2.41"
+    source="https://podaac-tools.jpl.nasa.gov/drive/files/allData/ghrsst/data/GDS2/L2P/VIIRS_NPP/OSPO/v2.41"
 elif [[ $lvl == "l3u" ]]; then    
     source="ftp://ftp.star.nesdis.noaa.gov/pub/socd2/coastwatch/sst/ran/viirs/npp/l3u"
 else
@@ -23,20 +23,17 @@ else
     exit 1
 fi
 
+file_sfx='*.nc'
+
 out_dir="$3/sst.viirs_${lvl}.nesdis"
 
 source_dir=$source/${yr}/${dy}/
 pwd=$(pwd)
+d=$out_dir/$date
+mkdir -p $d
+cd $d
 
-files=$(curl $source_dir -l)
-for f in $files; do
-    # ignore the .md5 files
-    fe=${f##*.}
-    [[ ! $fe == "nc" ]] && continue
-    
-    d=$out_dir/$date
-    mkdir -p $d
-    cd $d
-    wget $source_dir/$f
-    cd $pwd
-done
+wget -r -nc -np -nH -nd -A $file_sfx  $source_dir
+
+cd $pwd
+


### PR DESCRIPTION
Since the 3rd June 2019, FTP service is no longer available at PO.DAAC

All the scripts that used it (source.ghrsst_sst.sh, source.jpl_smap.sh, source.nesdis_sst_viirs.sh) have been updated to use the PO.DAAC Drive instead.

The PO.DAAC is password-protected, the user has to register at the PO.DAAC Drive server and create at the working machine ~/.netrc file as following:

```
touch ~/.netrc
chmod 600 ~/.netrc
echo 'machine podaac-tools.jpl.nasa.gov login USERNAME_from_PO.DAAC password PASSWORD_from_PO.DAAC' >> ~/.netrc
```

To download data, use the get_obs.sh as usual.