### PR TITLE
added option to not call mom6 setup

### DIFF
--- a/src/soca/Model/Model.cc
+++ b/src/soca/Model/Model.cc
@@ -28,18 +28,25 @@ namespace soca {
   static oops::ModelMaker<Traits, Model> makermodel_("SOCA");
   // -----------------------------------------------------------------------------
   Model::Model(const Geometry & resol, const eckit::Configuration & model)
-    : keyConfig_(0), tstep_(0), geom_(resol), vars_(model)
+    : keyConfig_(0), tstep_(0), geom_(resol), vars_(model), setup_mom6_(true)
   {
     Log::trace() << "Model::Model" << std::endl;
     Log::trace() << "Model vars: " << vars_ << std::endl;
     tstep_ = util::Duration(model.getString("tstep"));
-    const eckit::Configuration * configc = &model;
-    soca_setup_f90(&configc, geom_.toFortran(), keyConfig_);
-    Log::trace() << "Model created" << std::endl;
+    setup_mom6_ = model.getBool("setup_mom6", true);
+    if (setup_mom6_)
+      {
+        const eckit::Configuration * configc = &model;
+        soca_setup_f90(&configc, geom_.toFortran(), keyConfig_);
+      }
+        Log::trace() << "Model created" << std::endl;
   }
   // -----------------------------------------------------------------------------
   Model::~Model() {
-    soca_delete_f90(keyConfig_);
+    if (setup_mom6_)
+      {
+        soca_delete_f90(keyConfig_);
+      }
     Log::trace() << "Model destructed" << std::endl;
   }
   // -----------------------------------------------------------------------------

--- a/src/soca/Model/Model.cc
+++ b/src/soca/Model/Model.cc
@@ -34,7 +34,7 @@ namespace soca {
     Log::trace() << "Model vars: " << vars_ << std::endl;
     tstep_ = util::Duration(model.getString("tstep"));
     setup_mom6_ = model.getBool("setup_mom6", true);
-        const eckit::Configuration * configc = &model;
+    const eckit::Configuration * configc = &model;
     if (setup_mom6_)
       {
         soca_setup_f90(&configc, geom_.toFortran(), keyConfig_);

--- a/src/soca/Model/Model.cc
+++ b/src/soca/Model/Model.cc
@@ -34,9 +34,9 @@ namespace soca {
     Log::trace() << "Model vars: " << vars_ << std::endl;
     tstep_ = util::Duration(model.getString("tstep"));
     setup_mom6_ = model.getBool("setup_mom6", true);
+        const eckit::Configuration * configc = &model;
     if (setup_mom6_)
       {
-        const eckit::Configuration * configc = &model;
         soca_setup_f90(&configc, geom_.toFortran(), keyConfig_);
       }
         Log::trace() << "Model created" << std::endl;

--- a/src/soca/Model/Model.h
+++ b/src/soca/Model/Model.h
@@ -66,6 +66,7 @@ namespace soca {
     void print(std::ostream &) const;
     int keyConfig_;
     util::Duration tstep_;
+    bool setup_mom6_;
     const Geometry geom_;
     const oops::Variables vars_;
   };

--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -18,7 +18,6 @@ resolution:
 
 model:
   name: SOCA
-  setup_mom6: false
   tstep: PT1H
   advance_mom6: 0
   setup_mom6: false

--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -16,10 +16,13 @@ resolution:
   num_ice_lev: 4
   num_sno_lev: 1
 
+setup_mom6: false
 model:
   name: SOCA
+  setup_mom6: false
   tstep: PT1H
   advance_mom6: 0
+  setup_mom6: false
   variables: &soca_vars [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
 
 # common obsfilters used by all obs

--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -16,7 +16,6 @@ resolution:
   num_ice_lev: 4
   num_sno_lev: 1
 
-setup_mom6: false
 model:
   name: SOCA
   setup_mom6: false


### PR DESCRIPTION
closes #163 
This feature adds the option to by-pass mom6 setup and reduce the associated memory overheads. This can be useful when running 3DVAR, for example, where the model is not used, but still constructed ([L68 of Variational.h](https://github.com/JCSDA/oops/blob/a9be4065788a8f016e0d23a0b851fd8948f9a2bf/src/oops/runs/Variational.h#L68)).