### PR TITLE
Halo update in geometry done at the wrong place

### DIFF
--- a/src/soca/Geometry/soca_geom_mod.F90
+++ b/src/soca/Geometry/soca_geom_mod.F90
@@ -97,6 +97,12 @@ subroutine geom_init(self, f_conf)
   if ( f_conf%has("read_soca_grid") ) &
       call geom_read(self)
 
+  ! Fill halo
+  call mpp_update_domains(self%lon, self%Domain%mpp_domain)
+  call mpp_update_domains(self%lat, self%Domain%mpp_domain)
+  call mpp_update_domains(self%mask2d, self%Domain%mpp_domain)
+  call mpp_update_domains(self%cell_area, self%Domain%mpp_domain)
+
   ! Set output option for local geometry
   if ( f_conf%has("save_local_domain") ) &
       call f_conf%get_or_die("save_local_domain", isave)
@@ -202,12 +208,6 @@ subroutine geom_allocate(self)
   ny = nxny(2)
   self%nx = nx
   self%ny = ny
-
-  ! Fill halo
-  call mpp_update_domains(self%lon, self%Domain%mpp_domain)
-  call mpp_update_domains(self%lat, self%Domain%mpp_domain)
-  call mpp_update_domains(self%mask2d, self%Domain%mpp_domain)
-  call mpp_update_domains(self%cell_area, self%Domain%mpp_domain)
 
 end subroutine geom_allocate
 


### PR DESCRIPTION
The halo update for geometry was done at the wrong place. 
Current develop does not make use of halo points, so this was never an issue, but it is still a bug and a problem in a separate branch that I work on.