### PR TITLE
don't recreate bump geom on every getvalue call

### DIFF
--- a/src/soca/Utils/soca_bumpinterp2d_mod.F90
+++ b/src/soca/Utils/soca_bumpinterp2d_mod.F90
@@ -79,7 +79,7 @@ subroutine interp_init(self, mod_lon, mod_lat, mod_mask, obs_lon, obs_lat, bumpi
     bump%nam%obsop_interp = 'bilin'     ! Interpolation type (bilinear)
     bump%nam%default_seed = .true.
     bump%nam%new_obsop = .true.
-    bump%nam%verbosity = 'main'
+    bump%nam%verbosity = 'none'
     bump%nam%write_obsop = .false.
     bump%nam%sam_write = .false.
     bump%nam%strategy = 'specific_univariate'

--- a/src/soca/Utils/soca_bumpinterp2d_mod.F90
+++ b/src/soca/Utils/soca_bumpinterp2d_mod.F90
@@ -9,17 +9,15 @@ use fckit_mpi_module, only: fckit_mpi_comm
 use fckit_log_module, only : fckit_log
 use kinds, only: kind_real
 use type_bump, only: bump_type
+use type_obsop, only: obsop_type
 
 implicit none
 
 private
-public :: soca_bumpinterp2d, &
-          interp_init, interp_exit, &
-          interp_apply, interpad_apply, &
-          interp_info
+public :: soca_bumpinterp2d
 
 type :: soca_bumpinterp2d
-   type(bump_type)                   :: bump          !< bump interp object
+   type(obsop_type)                  :: obsop         !< bump interp object
    integer                           :: nobs          !< Number of values to interpolate
    real(kind=kind_real), allocatable :: lono(:)       !< Longitude of destination
    real(kind=kind_real), allocatable :: lato(:)       !< Latitude of destination
@@ -31,6 +29,13 @@ type :: soca_bumpinterp2d
    procedure :: applyad => interpad_apply
    procedure :: finalize => interp_exit
 end type soca_bumpinterp2d
+
+! The bump grid here is stored separately from the interpolation weights
+! (obsop inside soca_bumpinterp2d) because the unstructured grid only needs
+! to be setup once
+! TODO: these shouldn't be globals, put them somewhere correct
+type(bump_type) :: bump
+logical         :: bump_initialized = .false.
 
 contains
 
@@ -56,65 +61,72 @@ subroutine interp_init(self, mod_lon, mod_lat, mod_mask, obs_lon, obs_lat, bumpi
 
   if (self%initialized) call interp_exit(self)
 
-  ! Each bump%nam%prefix must be distinct, set bump id
-  write(cbumpcount,"(I0.5)") bumpid
-  bump_nam_prefix = 'soca_bump_interp_'//cbumpcount
+  ! Initialize the bump grid for the obs interpolation
+  ! This only needs to be done once
+  if(.not. bump_initialized) then
+    ! Each bump%nam%prefix must be distinct, set bump id
+    write(cbumpcount,"(I0.5)") bumpid
+    bump_nam_prefix = 'soca_bump_interp_'//cbumpcount
 
-  !Get the obs and state dimension
-  ni = size(mod_lon, 1)
-  nj = size(mod_lon, 2)
-  ns = ni * nj
+    !Get the obs and state dimension
+    ni = size(mod_lon, 1)
+    nj = size(mod_lon, 2)
+    ns = ni * nj
+
+    ! Initialize bump parameters
+    call bump%nam%init()
+    bump%nam%prefix = bump_nam_prefix   ! Prefix for files output
+    bump%nam%obsop_interp = 'bilin'     ! Interpolation type (bilinear)
+    bump%nam%default_seed = .true.
+    bump%nam%new_obsop = .true.
+    bump%nam%verbosity = 'main'
+    bump%nam%write_obsop = .false.
+    bump%nam%sam_write = .false.
+    bump%nam%strategy = 'specific_univariate'
+
+    !Initialize geometry
+    allocate(area(ns))
+    allocate(vunit(ns,1))
+    area = 1.0           ! Dummy area
+    vunit = 1.0          ! Dummy vertical unit
+
+    !Allocate temporary arrays
+    allocate(tmp_lonmod(ns), tmp_latmod(ns), tmp_maskmod(ni, nj))
+    tmp_lonmod(:) = reshape(mod_lon, (/ns/))
+    tmp_latmod(:) = reshape(mod_lat, (/ns/))
+
+    ! TODO: Fix interp with mask
+  !!$   tmp_maskmod = .false.
+  !!$    where(mod_mask==1.0)
+  !!$       tmp_maskmod = .true.
+  !!$    end where
+    tmp_maskmod = reshape(tmp_maskmod, (/ns, 1/))
+    tmp_maskmod = .true.
+
+    ! Rotate longitudes
+    where (tmp_lonmod < -180.0_kind_real)
+       tmp_lonmod = tmp_lonmod + 360.0_kind_real
+    end where
+
+    !Initialize the bump geometry
+    call bump%setup_online( ns, 1, 1, 1,&
+         &tmp_lonmod, tmp_latmod, area, vunit, tmp_maskmod(:,1))
+
+    !Release memory
+    deallocate(area)
+    deallocate(vunit)
+    deallocate(tmp_lonmod, tmp_latmod, tmp_maskmod)
+
+    bump_initialized = .true.
+  end if
+
+  ! initialize the interpolation weights
   no = size(obs_lon, 1)
-
-  ! Initialize bump parameters
-  call self%bump%nam%init()
-  self%bump%nam%prefix = bump_nam_prefix   ! Prefix for files output
-  self%bump%nam%obsop_interp = 'bilin'     ! Interpolation type (bilinear)
-  self%bump%nam%default_seed = .true.
-  self%bump%nam%new_obsop = .true.
-  self%bump%nam%verbosity = 'none'
-  self%bump%nam%write_obsop = .false.
-  self%bump%nam%sam_write = .false.
-  self%bump%nam%strategy = 'specific_univariate'
-
-  !Initialize geometry
-  allocate(area(ns))
-  allocate(vunit(ns,1))
-  area = 1.0           ! Dummy area
-  vunit = 1.0          ! Dummy vertical unit
-
-  !Allocate temporary arrays
-  allocate(tmp_lonmod(ns), tmp_latmod(ns), tmp_maskmod(ni, nj))
-  tmp_lonmod(:) = reshape(mod_lon, (/ns/))
-  tmp_latmod(:) = reshape(mod_lat, (/ns/))
-
-  ! TODO: Fix interp with mask
-!!$   tmp_maskmod = .false.
-!!$    where(mod_mask==1.0)
-!!$       tmp_maskmod = .true.
-!!$    end where
-  tmp_maskmod = reshape(tmp_maskmod, (/ns, 1/))
-  tmp_maskmod = .true.
-
-  ! Rotate longitudes
-  where (tmp_lonmod < -180.0_kind_real)
-     tmp_lonmod = tmp_lonmod + 360.0_kind_real
-  end where
-
-  !Calculate interpolation weight using BUMP
-  call self%bump%setup_online( ns, 1, 1, 1,&
-       &tmp_lonmod, tmp_latmod, area, vunit, tmp_maskmod(:,1),&
-       &nobs=no, lonobs=obs_lon, latobs=obs_lat )
-  call self%bump%run_drivers()
-  call self%bump%partial_dealloc
+  call self%obsop%from(no, obs_lon, obs_lat)
+  call self%obsop%run_obsop(bump%mpl,bump%rng,bump%nam,bump%geom)
 
   self%initialized = .true.
   self%nobs = no
-
-  !Release memory
-  deallocate(area)
-  deallocate(vunit)
-  deallocate(tmp_lonmod, tmp_latmod, tmp_maskmod)
 
 end subroutine interp_init
 
@@ -139,8 +151,7 @@ subroutine interp_apply(self, fld, obs)
   !tmp_fld = fld
   !tmp_fld = reshape(tmp_fld,(/ns, 1/))
   tmp_obs(:,1) = obs
-  !call self%bump%apply_obsop(tmp_fld,tmp_obs)
-  call self%bump%apply_obsop(fld,tmp_obs)
+  call self%obsop%apply(bump%mpl,bump%geom,fld,tmp_obs)
   obs = tmp_obs(:,1)
 
   deallocate(tmp_obs)
@@ -156,15 +167,7 @@ subroutine interpad_apply(self, fld, obs)
   real(kind=kind_real),     intent(inout) :: fld(:,:)
   real(kind=kind_real),        intent(in) :: obs(:)
 
-  ! Locals
-  real(kind=kind_real), allocatable :: tmp_obs(:)
-  integer :: nobs
-
-  nobs = size(obs, 1)
-  allocate(tmp_obs(nobs))
-  tmp_obs = obs
-  call self%bump%apply_obsop_ad(tmp_obs, fld)
-  deallocate(tmp_obs)
+  call self%obsop%apply_ad(bump%mpl,bump%geom,obs,fld)
 
 end subroutine interpad_apply
 
@@ -189,7 +192,6 @@ subroutine interp_exit(self)
   self%nobs = 0
   if (allocated(self%lono)) deallocate(self%lono)
   if (allocated(self%lato)) deallocate(self%lato)
-  call self%bump%dealloc()
   self%initialized = .false.
 
 end subroutine interp_exit


### PR DESCRIPTION
This is a bit of a quick hack to get the getValues() times more reasonable.

On Discover, getValues() was taking **460s** with the 1/4 deg grid and about 300k observations from SST/ADT/insituT/S. The geometry in bump was being reinitialized every time getValues() was called (for a total of 12 times), and this is currently very slow un-parallelized code in bump. Now, the bump geometry is only initialized once, and a separate `type_obsop` class is carried around instead for the interpolation. The same configuration now only takes **50s** for getValues().

No answers should change 

Again, this is a bit of a quick hack.(there is a global variable in the fortran code, gasp!) We can get back to this and do it in a cleaner way once some of the interpolation is cleaned up in oops (e.g https://github.com/JCSDA/oops/pull/357)
