### PR TITLE
Use the partial initialization feature of mom6

### DIFF
--- a/src/soca/Model/soca_model.interface.F90
+++ b/src/soca/Model/soca_model.interface.F90
@@ -71,6 +71,13 @@ subroutine c_soca_setup(c_conf, c_key_geom, c_key_model) bind (c,name='soca_setu
   ! Setup mom6 advance or identity model
   call f_conf%get_or_die("advance_mom6", model%advance_mom6)
 
+  ! Determine if this is a partial init of mom6
+  if ( f_conf%has("partial_init") ) then
+     call f_conf%get_or_die("partial_init", model%partial_init)
+  else
+     model%partial_init = .false. ! Full init as default
+  end if
+
   ! Setup defaults for clamping values in the model
   if ( f_conf%has("tocn_minmax") ) then
     call f_conf%get_or_die("tocn_minmax", tocn_minmax)

--- a/src/soca/Model/soca_model_mod.F90
+++ b/src/soca/Model/soca_model_mod.F90
@@ -36,6 +36,7 @@ type :: soca_model
    integer :: nx                !< Zonal grid dimension
    integer :: ny                !< Meridional grid dimension
    integer :: advance_mom6      !< call mom6 step if true
+   logical :: partial_init      !< Partial init of mom6 if true
    real(kind=kind_real) :: dt0  !< dimensional time (seconds)
    type(soca_mom6_config) :: mom6_config  !< MOM6 data structure
    real(kind_real), dimension(2) :: tocn_minmax, socn_minmax  !< min, max values
@@ -50,7 +51,7 @@ contains
 subroutine soca_setup(self)
   type(soca_model), intent(inout) :: self
 
-  call soca_mom6_init(self%mom6_config)
+  call soca_mom6_init(self%mom6_config, partial_init=self%partial_init)
 
 end subroutine soca_setup
 

--- a/test/testinput/checkpointmodel.yml
+++ b/test/testinput/checkpointmodel.yml
@@ -8,6 +8,7 @@ model:
   name: SOCA
   tstep: PT6H
   advance_mom6: 0
+  partial_update: 1
   variables: [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
   tocn_minmax: [-1.8, 32.0]
   socn_minmax: [0.1, 38.0]


### PR DESCRIPTION
Partial initialization was implemented in the mom6 initialization, but not used. This is required when using the "checkpoint" application and no forcing is present, which is he case when running the EMC coupled model.