### PR TITLE
rename appropriate ObsOperators to "Identity" and "MarineVertInterp"

### DIFF
--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -122,7 +122,7 @@ cost_function:
         simulate:
           variables: [sea_surface_temperature]
       ObsOperator:
-        name: SeaSurfaceTemp
+        name: Identity
       Covariance:
         covariance: diagonal
       ObsFilters:
@@ -142,7 +142,7 @@ cost_function:
         simulate:
           variables: [sea_surface_salinity]
       ObsOperator:
-        name: SeaSurfaceSalinity      
+        name: Identity
       Covariance:
         covariance: diagonal
       ObsFilters:
@@ -201,7 +201,7 @@ cost_function:
         simulate:
           variables: [sea_water_salinity]
       ObsOperator:
-        name: InsituSalinity
+        name: MarineVertInterp
       Covariance:
         covariance: diagonal
       ObsFilters:

--- a/test/testinput/3dvar_soca.yml
+++ b/test/testinput/3dvar_soca.yml
@@ -133,7 +133,7 @@ cost_function:
         simulate:
           variables: [sea_surface_temperature]
       ObsOperator:
-        name: SeaSurfaceTemp
+        name: Identity
       Covariance:
         covariance: diagonal
       ObsFilters:
@@ -160,7 +160,7 @@ cost_function:
         simulate:
           variables: [sea_surface_salinity]
       ObsOperator:
-        name: SeaSurfaceSalinity      
+        name: Identity
       Covariance:
         covariance: diagonal
       ObsFilters:
@@ -219,7 +219,7 @@ cost_function:
         simulate:
           variables: [sea_water_salinity]
       ObsOperator:
-        name: InsituSalinity
+        name: MarineVertInterp
       Covariance:
         covariance: diagonal
       ObsFilters:

--- a/test/testinput/3dvarfgat.yml
+++ b/test/testinput/3dvarfgat.yml
@@ -124,7 +124,7 @@ cost_function:
         simulate:
           variables: [sea_surface_temperature]
       ObsOperator:
-        name: SeaSurfaceTemp
+        name: Identity
       Covariance:
         covariance: diagonal
       ObsFilters:
@@ -144,7 +144,7 @@ cost_function:
         simulate:
           variables: [sea_surface_salinity]
       ObsOperator:
-        name: SeaSurfaceSalinity      
+        name: Identity
       Covariance:
         covariance: diagonal
       ObsFilters:
@@ -203,7 +203,7 @@ cost_function:
         simulate:
           variables: [sea_water_salinity]
       ObsOperator:
-        name: InsituSalinity
+        name: MarineVertInterp
       Covariance:
         covariance: diagonal
       ObsFilters:

--- a/test/testinput/enshofx.yml
+++ b/test/testinput/enshofx.yml
@@ -52,7 +52,7 @@ Observations:
       simulate:
         variables: [sea_surface_temperature]
     ObsOperator:
-      name: SeaSurfaceTemp
+      name: Identity
     Covariance:
       covariance: diagonal
 
@@ -63,7 +63,7 @@ Observations:
       simulate:
         variables: [sea_surface_salinity]
     ObsOperator:
-      name: SeaSurfaceSalinity      
+      name: Identity
     Covariance:
       covariance: diagonal
 
@@ -96,7 +96,7 @@ Observations:
       simulate:
         variables: [sea_water_salinity]
     ObsOperator:
-      name: InsituSalinity
+      name: MarineVertInterp
     Covariance:
       covariance: diagonal
 

--- a/test/testinput/hofx.yml
+++ b/test/testinput/hofx.yml
@@ -45,7 +45,7 @@ Observations:
       simulate:
         variables: [sea_surface_temperature]
     ObsOperator:
-      name: SeaSurfaceTemp
+      name: Identity
     Covariance:
       covariance: diagonal
 
@@ -56,7 +56,7 @@ Observations:
       simulate:
         variables: [sea_surface_salinity]
     ObsOperator:
-      name: SeaSurfaceSalinity      
+      name: Identity
     Covariance:
       covariance: diagonal
 
@@ -89,7 +89,7 @@ Observations:
       simulate:
         variables: [sea_water_salinity]
     ObsOperator:
-      name: InsituSalinity
+      name: MarineVertInterp
     Covariance:
       covariance: diagonal
 

--- a/test/testinput/hofx3d.yml
+++ b/test/testinput/hofx3d.yml
@@ -38,7 +38,7 @@ Observations:
       simulate:
         variables: [sea_surface_temperature]
     ObsOperator:
-      name: SeaSurfaceTemp
+      name: Identity
     Covariance:
       covariance: diagonal
 
@@ -49,7 +49,7 @@ Observations:
       simulate:
         variables: [sea_surface_salinity]
     ObsOperator:
-      name: SeaSurfaceSalinity      
+      name: Identity
     Covariance:
       covariance: diagonal
 
@@ -82,7 +82,7 @@ Observations:
       simulate:
         variables: [sea_water_salinity]
     ObsOperator:
-      name: InsituSalinity
+      name: MarineVertInterp
     Covariance:
       covariance: diagonal
 


### PR DESCRIPTION
A pending PR in UFO (https://github.com/JCSDA/ufo/pull/652) removes the redundantly named ObsOperators
* `SeaSurfaceSalinity`
* `SeaSurfaceTemp`
* `InsituSalinity`

requiring us to now use the names for the generic identity operators
* `Identity`
* `MarineVertInterp`

testing requires UFO branch of the same name