### PR TITLE
redo the way the weights are calculated

### DIFF
--- a/src/soca/Transforms/HorizFilt/HorizFilt.cc
+++ b/src/soca/Transforms/HorizFilt/HorizFilt.cc
@@ -33,14 +33,6 @@ namespace soca {
                              traj_.fields().toFortran(),
                              &confvars);
 
-    // Abort if filter type is not one of ["wavg","flow"]
-    std::vector<std::string> listfilt{"wavg", "flow"};
-    std::string filt_type = configc->getString("filter_type");
-    if (std::find(std::begin(listfilt), std::end(listfilt), filt_type) == std::end(listfilt))
-      {
-        ABORT("soca::HorizFilt wrong filter type");
-      }
-
     // Get number of iterations
     niter_ = configc->getInt("niter");
   }

--- a/test/testinput/dirac_horizfilt.yml
+++ b/test/testinput/dirac_horizfilt.yml
@@ -28,22 +28,15 @@ Covariance:
 
   - varchange: HorizFiltSOCA
     variables: [tocn, socn, ssh, cicen, hicen]
-    niter: 1
-    filter_type: wavg
+    niter: 2
+    scale_dist: 1000e3
+    scale_flow:  1.0
     inputVariables:
       variables: *soca_vars
     outputVariables:
       variables: *soca_vars
 
-  - varchange: HorizFiltSOCA
-    variables: [tocn, socn, ssh, cicen, hicen]
-    niter: 1
-    filter_type: flow
-    l_ssh: 0.5
-    inputVariables:
-      variables: *soca_vars
-    outputVariables:
-      variables: *soca_vars
+
 
 dirac:
   ixdir: [1, 17, 41, 31, 51, 63, 81, 14, 16, 43]

--- a/test/testinput/horizfilt.yml
+++ b/test/testinput/horizfilt.yml
@@ -17,7 +17,8 @@ LinearVariableChangeTests:
   toleranceInverse: 1e-12
   testinverse: 0
   niter: 3
-  filter_type: wavg
+  scale_flow: 0.5
+  scale_dist: 1e6
   variables: [cicen, hicen, socn, tocn, ssh, hocn]
   inputVariables:
     variables: *soca_vars


### PR DESCRIPTION
reworked the way the weights were being calculated. 

The yaml file now just has "scale_flow" and "scale_dist" for the distance based and ssh_difference based length scales, so that both methods can be done at the same time. 

Roughly performs as expected now, so long as `scale_dist / sqrt(niter)` is not _too_ much smaller than the size of grid box. (There's a reason a proper diffusion operator is implicit, not explicit)

I'll run at 1/4 deg on discover to test and generate pretty pictures