### PR TITLE
release/stable-nightly update on bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,7 +127,9 @@ script:
 after_success:
   - |
     # If this is a cron run, update the release/stable branch of the bundle
-    # TODO: add check for "develop" and "cron"
-    docker exec jcsda_container bash -c \
-      'cd /jcsda/work && repo.src/${MAIN_REPO}/.travis/stable_mark.sh'
-    cd ${WORK_DIR} && ${WORK_DIR}/repo.src/${MAIN_REPO}/.travis/stable_commit.sh
+    # TODO: add check for "develop"
+    if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
+        docker exec jcsda_container bash -c \
+          'cd /jcsda/work && repo.src/${MAIN_REPO}/.travis/stable_mark.sh'
+        cd ${WORK_DIR} && ${WORK_DIR}/repo.src/${MAIN_REPO}/.travis/stable_commit.sh
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,3 +116,14 @@ script:
       'cd /jcsda/work/repo.src/${MAIN_REPO} \
        && lcov -c -d . -d ../../repo.build/${MAIN_REPO}/ -o coverage.info  --no-external -q \
        && bash <(curl -s https://codecov.io/bash)'
+
+
+
+#======================================================================
+#======================================================================
+after_success:
+  - |
+    # If this is a cron run, update the release/stable branch of the bundle
+    # TODO: add check for "develop" and "cron"
+    docker exec jcsda_container bash -c \
+      'cd /jcsda/work && repo.src/${MAIN_REPO}/.travis/mark_stable.sh'

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,6 @@ cache:
 before_install:
   - |
     # setup other configurables that the subsequent scripts use
-    echo "GH_TOKEN: $GH_TOKEN"
     export MAIN_BUILD_TYPE=Debug
     export LIB_BUILD_TYPE=RelWIthDebInfo
     export BRANCH=$( [[ "$TRAVIS_PULL_REQUEST" == "false" ]] && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,8 +127,7 @@ script:
 after_success:
   - |
     # If this is a cron run, update the release/stable branch of the bundle
-    # TODO: add check for "develop"
-    if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
+    if [[ "$TRAVIS_EVENT_TYPE" == "cron" && "$TRAVIS_BRANCH" == "develop" ]]; then
         docker exec jcsda_container bash -c \
           'cd /jcsda/work && repo.src/${MAIN_REPO}/.travis/stable_mark.sh'
         cd ${WORK_DIR} && ${WORK_DIR}/repo.src/${MAIN_REPO}/.travis/stable_commit.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ env:
     - MATCH_REPOS="saber oops ioda ioda-converters ufo soca soca-config"
     - LFS_REPOS=""
 
+    # secure token used to push changes to GitHub (user: travissluka)
+    - secure: phYDV8BnMVQMhKbuyfpA0cUvelL3Jn9GrMunbAQAa4Hw6OInALu0BSoPAm5xd+lPAsVkhy3BwHlRvjqGYmhDr3NFuxUbZ/l1CcSOJZmV5Rp+5CY5nk0scQ9asuRSzt6jHBIaj9ncOyTWc7B3H6Vp88z6dBDgzeXWMaLy5A7u3fkTVI3dYAmvPAEd9wRp4nI6ij2lnTELIziTYZ07nrdIzYfAc6sqvPXhLkZfxYMkfDAbHHWZt+kGoJGPFfsjX1K7cgj32Ro+lm3Vl0u732QRCw3nUefhZrz3PkkGeX1U+GjQsz8liEgBqKng4ZxocepPsv5gwZj/frMCCtcXj59Pia5pmHy6vzdq4XCp/WpYwbbMEF9y9qVL35s9On9JnU20DEOV4r5c9rmJd8gbpsfK1reT8KOD5zJe9YBHRRXajweq23TFJPRyHVHlnSF8OtybOVG6OMLba9vvPTveQuaDIyc3kur5QtbM0HVv3uplef14m1frQYqji9I99h/pI5WcueRpcxARwagL1tnl3cfK4LyI3QWXidetDduE3MJQNfsKADlKKBVw9W2JyzNFCNj0J7x8r5SwObRX7Kj9YZfIPJGVt5rDc0OZm9wCt/BEZclTLyf4qbFibX/0glPiFoqhuYP/ZXAbQdYWI+si68gxcql33+PMkmbuhehA8qNZicE=
+
 branches:
   only:
     - develop
@@ -57,6 +60,7 @@ cache:
 before_install:
   - |
     # setup other configurables that the subsequent scripts use
+    echo "GH_TOKEN: $GH_TOKEN"
     export MAIN_BUILD_TYPE=Debug
     export LIB_BUILD_TYPE=RelWIthDebInfo
     export BRANCH=$( [[ "$TRAVIS_PULL_REQUEST" == "false" ]] && \
@@ -126,4 +130,5 @@ after_success:
     # If this is a cron run, update the release/stable branch of the bundle
     # TODO: add check for "develop" and "cron"
     docker exec jcsda_container bash -c \
-      'cd /jcsda/work && repo.src/${MAIN_REPO}/.travis/mark_stable.sh'
+      'cd /jcsda/work && repo.src/${MAIN_REPO}/.travis/stable_mark.sh'
+    cd ${WORK_DIR} && ${WORK_DIR}/repo.src/${MAIN_REPO}/.travis/stable_commit.sh

--- a/.travis/get_repo_hash.cmake
+++ b/.travis/get_repo_hash.cmake
@@ -1,0 +1,8 @@
+# This is a simple cmake script that will use ecbuild to search for a given repository, and
+# print out the git hash of that repo if found. This is useful for finding the git version
+# of a repo that has been preinstalled in a container
+
+cmake_minimum_required( VERSION 3.3.2 FATAL_ERROR )
+include( ecbuild_system )
+ecbuild_use_package( PROJECT ${REPO_NAME} REQUIRED)
+message(STATUS "git_hash " ${${REPO_NAME}_GIT_SHA1} )

--- a/.travis/mark_stable.sh
+++ b/.travis/mark_stable.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#================================================================================
+# (C) Copyright 2019 UCAR
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# After automated tests pass, this script is used to create an updated
+# "stable branch" tag of the CMakeLists.txt file in the bundle.
+#================================================================================
+set -e
+
+RELEASE_BRANCH=${RELEASE_BRANCH:-release/stable-nightly}
+
+cwd=$(pwd)
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# figure out what git hash is associated with each repo in the bundle.
+# Note that there are several places where this repo could exist.
+bundle_dir=$cwd/bundle
+bundle_repos=$(grep "ecbuild_bundle(" $bundle_dir/CMakeLists.txt | awk '{print $3}')
+cp $bundle_dir/CMakeLists.txt $bundle_dir/CMakeLists.new
+for r in $bundle_repos; do
+
+    echo ""
+    echo "Finding hash tag for $r..."
+    verfile_cache=$REPO_CACHE/$r/build.version
+    verfile_src=$cwd/repo.bundle/$r/build.version
+    hash="none"
+
+    # check if repo exists in the build cache
+    echo -n "searching build cache... "
+    if [[ -e $verfile_cache ]]; then
+        hash=$(grep git_hash $verfile_cache || echo "_ none")
+        hash=$(echo "$hash" | awk '{print $2}')
+    fi
+    [[ "$hash" == "none" ]] && echo "NOT found" || echo "FOUND"
+
+    # check the repo source ( for uncached repos, i.e. the main test repo)
+    if [[ "$hash" == "none" ]]; then
+        echo -n "searching uncached src.. "
+        [[ -e $verfile_src ]] \
+            && hash=$(grep git_hash $verfile_src || echo "_ none") \
+            && hash=$(echo "$hash" | awk '{print $2}')
+        [[ "$hash" == "none" ]] && echo "NOT found" || echo "FOUND"
+    fi
+
+    # use ecbuild to find the repo (i.e. check if in the container)
+    if [[ "$hash" == "none" ]]; then
+        echo -n "searching cmake paths... "
+        rm -rf $cwd/repo_hash
+        mkdir -p $cwd/repo_hash/build
+        cp $SCRIPT_DIR/get_repo_hash.cmake  $cwd/repo_hash/CMakeLists.txt
+        cd $cwd/repo_hash/build
+        hash=$(ecbuild -DREPO_NAME=${r^^} ../  | grep "git_hash" || echo "none")
+        [[ "$hash" != "none" ]] && hash=$(echo "$hash" | awk '{print $3}')
+        [[ "$hash" == "none" ]] && echo "NOT found" || echo "FOUND"
+    fi
+
+    # otherwise, we couldn't find the repo, either the repo in the bundle wasn't used for
+    # the ctests, or something bad happened. Oh well.
+
+    # if a git hash was found, update the bundle with a tagged version
+    echo "git_hash: $hash"
+    if [[ $hash != "none" ]]; then
+        hash=${hash:0:7}
+        echo "changing $r to $hash"
+        sed -i "s/\(.* PROJECT $r .*\) \(BRANCH\|TAG\) .*/\1 TAG $hash \)/" $bundle_dir/CMakeLists.new
+    fi
+done
+
+
+# The following git sorcery ensures that the commit which will be pushed onto the release branch
+# is the tagged version of what is in develop, and keeps develop and the current release branch
+# as its parents (i.e. it looks like a merge, but it is not a real merge)
+
+# get the git commit hash for the relevant involved branches
+cd $bundle_dir
+ref_develop=$(git rev-parse HEAD)
+git checkout $RELEASE_BRANCH
+ref_stable=$(git rev-parse HEAD)
+ref_common=$(git merge-base $ref_develop $ref_stable)
+
+# do we need to update the ancestors after merging changes?
+# (needs to be done when develop has been updated since the last release tag)
+amend=""
+if [[ "$ref_common" != "$ref_develop" ]]; then
+    git merge -s ours develop -m "temporary branch"
+    amend="--amend"
+fi
+
+# check in the changes
+msg="nightly stable branch $(date +%Y-%m-%d)"
+mv CMakeLists.new CMakeLists.txt
+git add .
+git commit -m "$msg" $amend
+
+# push the changes
+git push

--- a/.travis/stable_commit.sh
+++ b/.travis/stable_commit.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#================================================================================
+# (C) Copyright 2019 UCAR
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# The following git sorcery ensures that the commit which will be pushed onto
+# the release branch is the tagged version of what is in develop, and keeps
+# develop and the current release branch as its parents (i.e. it looks like a
+# merge, but it is not a real merge)
+#================================================================================
+
+set -e
+
+RELEASE_BRANCH=${RELEASE_BRANCH:-release/stable-nightly}
+
+cwd=$(pwd)
+
+
+git clone ${BUNDLE_URL} bundle.stable
+cd bundle.stable
+
+# get the git commit hash for the relevant involved branches 
+ref_develop=$(git rev-parse HEAD)
+git checkout $RELEASE_BRANCH
+ref_stable=$(git rev-parse HEAD)
+ref_common=$(git merge-base $ref_develop $ref_stable)
+
+# do we need to update the ancestors after merging changes?
+# (needs to be done when develop has been updated since the last release tag)
+amend=""
+if [[ "$ref_common" != "$ref_develop" ]]; then
+    git merge -s ours develop -m "temporary branch"
+    amend="--amend"
+fi
+
+# check in the changes
+msg="nightly stable branch $(date +%Y-%m-%d)"
+cat ../bundle/CMakeLists.new > CMakeLists.txt
+git add .
+git status
+git diff
+git commit -m "$msg" $amend

--- a/.travis/stable_mark.sh
+++ b/.travis/stable_mark.sh
@@ -5,7 +5,9 @@
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 #
 # After automated tests pass, this script is used to create an updated
-# "stable branch" tag of the CMakeLists.txt file in the bundle.
+# "stable branch" version of CMakeLists.txt file in the bundle.
+# This must be done inside the container. Afterward the stable_commit.sh script
+# is run outside the container
 #================================================================================
 set -e
 
@@ -18,29 +20,29 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # Note that there are several places where this repo could exist.
 bundle_dir=$cwd/bundle
 bundle_repos=$(grep "ecbuild_bundle(" $bundle_dir/CMakeLists.txt | awk '{print $3}')
-cp $bundle_dir/CMakeLists.txt $bundle_dir/CMakeLists.new
 for r in $bundle_repos; do
 
     echo ""
     echo "Finding hash tag for $r..."
-    verfile_cache=$REPO_CACHE/$r/build.version
-    verfile_src=$cwd/repo.bundle/$r/build.version
     hash="none"
 
     # check if repo exists in the build cache
-    echo -n "searching build cache... "
-    if [[ -e $verfile_cache ]]; then
-        hash=$(grep git_hash $verfile_cache || echo "_ none")
-        hash=$(echo "$hash" | awk '{print $2}')
+    if [[ "$hash" == "none" ]]; then
+        echo -n "searching build cache... "
+        verfile_cache=$REPO_CACHE/$r/build.version
+        [[ -e $verfile_cache ]] \
+            && hash=$(grep git_hash $verfile_cache || echo "_ none") \
+            && hash=$(echo "$hash" | awk '{print $2}')
+        [[ "$hash" == "none" ]] && echo "NOT found" || echo "FOUND"
     fi
-    [[ "$hash" == "none" ]] && echo "NOT found" || echo "FOUND"
 
     # check the repo source ( for uncached repos, i.e. the main test repo)
     if [[ "$hash" == "none" ]]; then
         echo -n "searching uncached src.. "
-        [[ -e $verfile_src ]] \
-            && hash=$(grep git_hash $verfile_src || echo "_ none") \
-            && hash=$(echo "$hash" | awk '{print $2}')
+        src_dir=$cwd/repo.src/$r
+        [[ -d $src_dir ]] \
+            && cd $src_dir \
+            && hash=$(git rev-parse HEAD || echo "none")
         [[ "$hash" == "none" ]] && echo "NOT found" || echo "FOUND"
     fi
 
@@ -51,7 +53,7 @@ for r in $bundle_repos; do
         mkdir -p $cwd/repo_hash/build
         cp $SCRIPT_DIR/get_repo_hash.cmake  $cwd/repo_hash/CMakeLists.txt
         cd $cwd/repo_hash/build
-        hash=$(ecbuild -DREPO_NAME=${r^^} ../  | grep "git_hash" || echo "none")
+        hash=$(ecbuild -DREPO_NAME=${r^^} ../ 2> /dev/null | grep "git_hash" || echo "none")
         [[ "$hash" != "none" ]] && hash=$(echo "$hash" | awk '{print $3}')
         [[ "$hash" == "none" ]] && echo "NOT found" || echo "FOUND"
     fi
@@ -64,35 +66,6 @@ for r in $bundle_repos; do
     if [[ $hash != "none" ]]; then
         hash=${hash:0:7}
         echo "changing $r to $hash"
-        sed -i "s/\(.* PROJECT $r .*\) \(BRANCH\|TAG\) .*/\1 TAG $hash \)/" $bundle_dir/CMakeLists.new
+        sed -i "s/\(.* PROJECT $r .*\) \(BRANCH\|TAG\) .*/\1 TAG $hash \)/" $bundle_dir/CMakeLists.txt
     fi
 done
-
-
-# The following git sorcery ensures that the commit which will be pushed onto the release branch
-# is the tagged version of what is in develop, and keeps develop and the current release branch
-# as its parents (i.e. it looks like a merge, but it is not a real merge)
-
-# get the git commit hash for the relevant involved branches
-cd $bundle_dir
-ref_develop=$(git rev-parse HEAD)
-git checkout $RELEASE_BRANCH
-ref_stable=$(git rev-parse HEAD)
-ref_common=$(git merge-base $ref_develop $ref_stable)
-
-# do we need to update the ancestors after merging changes?
-# (needs to be done when develop has been updated since the last release tag)
-amend=""
-if [[ "$ref_common" != "$ref_develop" ]]; then
-    git merge -s ours develop -m "temporary branch"
-    amend="--amend"
-fi
-
-# check in the changes
-msg="nightly stable branch $(date +%Y-%m-%d)"
-mv CMakeLists.new CMakeLists.txt
-git add .
-git commit -m "$msg" $amend
-
-# push the changes
-git push


### PR DESCRIPTION
Previously we had been using my desktop to run the tests nightly and then update the `release/stable-nightly-soca` branch of each upstream repo.

Now, TravisCI handles this for us with the daily `develop` cron job. Instead of updating branches in the upstream repos, the `soca-bundle CMakeLists.txt` from the latest `develop` is modified to replace branch names with git hashes (similar to what we did for the v0.1 release tag).

This has been running in the background for the past several days to confirm it is working. See: 
https://github.com/JCSDA/soca-bundle/commits/release/stable-nightly

Since there is now a separate commit in the `soca-bundle:release/stable-nightly` branch for each day when any of the repos changes, going forward this will allow us to rewind to any set of repos that were working in the past.

There should be sufficient documentation in the scripts to figure out what is going on