### PR TITLE
Apply landmask to fields for gpnorm() and random()

### DIFF
--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -266,7 +266,7 @@ subroutine random(self)
     ! NOTE: random seeds are not quite working the way expected,
     !  it is only set the first time normal_distribution() is called with a seed
   integer :: z
-  
+
   call check(self)
 
   ! set random values
@@ -820,13 +820,13 @@ subroutine gpnorm(fld, nf, pstat)
   call f_comm%allreduce(local_ocn_count, ocn_count, fckit_mpi_sum())
   mask = fld%geom%mask2d(isc:iec,jsc:jec) > 0.0
 
-  
+
   ! calculate global min, max, mean for each field
   ! NOTE: "cicen" category 1 (no ice) is not included in the stats
   do jj=1, fld%nf
     tmp=0.0
 
-    ! get local min/max/sum of each variable    
+    ! get local min/max/sum of each variable
     select case(fld%fldnames(jj))
     case("tocn")
       call fldinfo(fld%tocn(isc:iec,jsc:jec,:), mask, tmp)

--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -204,24 +204,6 @@ end subroutine zeros
 
 ! ------------------------------------------------------------------------------
 
-subroutine ones(self)
-  type(soca_field), intent(inout) :: self
-
-  call check(self)
-
-  self%socn = 1.0_kind_real
-  self%tocn = 1.0_kind_real
-  self%ssh = 1.0_kind_real
-  self%hocn = 1.0_kind_real
-  self%mld = 1.0_kind_real
-
-  call self%seaice%ones()
-  call self%ocnsfc%ones()
-
-end subroutine ones
-
-! ------------------------------------------------------------------------------
-
 subroutine dirac(self, f_conf)
   type(soca_field),          intent(inout) :: self
   type(fckit_configuration), intent(in)    :: f_conf   !< Configuration

--- a/src/soca/Fields/soca_fieldsutils_mod.F90
+++ b/src/soca/Fields/soca_fieldsutils_mod.F90
@@ -34,13 +34,14 @@ subroutine fldinfo3d(fld, mask, info)
   integer :: z
   real(kind=kind_real) :: tmp(3,size(fld, dim=3))
 
-!  print *, "DBG: ", size(fld,dim=3)
+  ! calculate the min/max/sum separately for each masked level
   do z = 1, size(tmp, dim=2)
      tmp(1,z) = minval(fld(:,:,z), mask=mask)
      tmp(2,z) = maxval(fld(:,:,z), mask=mask)
      tmp(3,z) = sum(   fld(:,:,z), mask=mask) / size(fld, dim=3)
   end do
 
+  ! then combine the min/max/sum over all levels
   info(1) = minval(tmp(1,:))
   info(2) = maxval(tmp(2,:))
   info(3) = sum(   tmp(3,:))
@@ -50,7 +51,7 @@ end subroutine fldinfo3d
 
 subroutine fldinfo2d(fld, mask, info)
   real(kind=kind_real),  intent(in) :: fld(:,:)
-  logical,               intent(in) :: mask(:,:)  
+  logical,               intent(in) :: mask(:,:)
   real(kind=kind_real), intent(out) :: info(3)
 
   info(1) = minval(fld, mask=mask)

--- a/src/soca/Fields/soca_fieldsutils_mod.F90
+++ b/src/soca/Fields/soca_fieldsutils_mod.F90
@@ -26,25 +26,36 @@ contains
 
 ! ------------------------------------------------------------------------------
 
-subroutine fldinfo3d(fld, info)
+subroutine fldinfo3d(fld, mask, info)
   real(kind=kind_real),  intent(in) :: fld(:,:,:)
+  logical,               intent(in) :: mask(:,:)
   real(kind=kind_real), intent(out) :: info(3)
 
-  info(1) = minval(fld)
-  info(2) = maxval(fld)
-  info(3) = sum(fld)/size(fld,3)
+  integer :: z
+  real(kind=kind_real) :: tmp(3,size(fld, dim=3))
 
+!  print *, "DBG: ", size(fld,dim=3)
+  do z = 1, size(tmp, dim=2)
+     tmp(1,z) = minval(fld(:,:,z), mask=mask)
+     tmp(2,z) = maxval(fld(:,:,z), mask=mask)
+     tmp(3,z) = sum(   fld(:,:,z), mask=mask) / size(fld, dim=3)
+  end do
+
+  info(1) = minval(tmp(1,:))
+  info(2) = maxval(tmp(2,:))
+  info(3) = sum(   tmp(3,:))
 end subroutine fldinfo3d
 
 ! ------------------------------------------------------------------------------
 
-subroutine fldinfo2d(fld, info)
+subroutine fldinfo2d(fld, mask, info)
   real(kind=kind_real),  intent(in) :: fld(:,:)
+  logical,               intent(in) :: mask(:,:)  
   real(kind=kind_real), intent(out) :: info(3)
 
-  info(1) = minval(fld)
-  info(2) = maxval(fld)
-  info(3) = sum(fld)
+  info(1) = minval(fld, mask=mask)
+  info(2) = maxval(fld, mask=mask)
+  info(3) = sum(   fld, mask=mask)
 
 end subroutine fldinfo2d
 

--- a/src/soca/Fields/soca_ocnsfc_mod.F90
+++ b/src/soca/Fields/soca_ocnsfc_mod.F90
@@ -30,7 +30,6 @@ type :: soca_ocnsfc_type
    procedure :: create => soca_ocnsfc_create
    procedure :: delete => soca_ocnsfc_delete
    procedure :: zeros => soca_ocnsfc_zeros
-   procedure :: ones => soca_ocnsfc_ones
    procedure :: abs => soca_ocnsfc_abs
    procedure :: random => soca_ocnsfc_random
    procedure :: copy => soca_ocnsfc_copy
@@ -94,18 +93,6 @@ subroutine soca_ocnsfc_zeros(self)
   self%fric_vel    = 0.0_kind_real
 
 end subroutine soca_ocnsfc_zeros
-
-! ------------------------------------------------------------------------------
-subroutine soca_ocnsfc_ones(self)
-  class(soca_ocnsfc_type), intent(inout) :: self
-
-  self%sw_rad      = 1.0_kind_real
-  self%lw_rad      = 1.0_kind_real
-  self%latent_heat = 1.0_kind_real
-  self%sens_heat   = 1.0_kind_real
-  self%fric_vel    = 1.0_kind_real
-
-end subroutine soca_ocnsfc_ones
 
 ! ------------------------------------------------------------------------------
 subroutine soca_ocnsfc_abs(self)

--- a/src/soca/Fields/soca_ocnsfc_mod.F90
+++ b/src/soca/Fields/soca_ocnsfc_mod.F90
@@ -21,6 +21,8 @@ private
 public :: soca_ocnsfc_type
 
 type :: soca_ocnsfc_type
+   type(soca_geom),      pointer     :: geom
+
    real(kind=kind_real), allocatable :: sw_rad(:,:)
    real(kind=kind_real), allocatable :: lw_rad(:,:)
    real(kind=kind_real), allocatable :: latent_heat(:,:)
@@ -52,9 +54,12 @@ contains
 ! ------------------------------------------------------------------------------
 subroutine soca_ocnsfc_create(self, geom)
   class(soca_ocnsfc_type), intent(inout) :: self
-  type(soca_geom),            intent(in) :: geom
+  type(soca_geom), pointer,   intent(in) :: geom
 
   integer :: isd, ied, jsd, jed
+
+  ! Associate geometry
+  self%geom => geom
 
   ! Indices for data domain (with halo)
   isd = geom%isd ; ied = geom%ied
@@ -112,12 +117,19 @@ subroutine soca_ocnsfc_random(self)
 
   integer :: rseed = 1
 
-  ! Deallocate all ocean surface state
+  ! set random values
   call normal_distribution(self%sw_rad, 0.0_kind_real, 1.0_kind_real, rseed)
   call normal_distribution(self%lw_rad, 0.0_kind_real, 1.0_kind_real, rseed)
   call normal_distribution(self%latent_heat, 0.0_kind_real, 1.0_kind_real, rseed)
   call normal_distribution(self%sens_heat, 0.0_kind_real, 1.0_kind_real, rseed)
   call normal_distribution(self%fric_vel, 0.0_kind_real, 1.0_kind_real, rseed)
+
+  ! mask out land, set to zero
+  self%sw_rad = self%sw_rad * self%geom%mask2d
+  self%lw_rad = self%lw_rad * self%geom%mask2d
+  self%latent_heat = self%latent_heat * self%geom%mask2d
+  self%sens_heat = self%sens_heat * self%geom%mask2d
+  self%fric_vel = self%fric_vel * self%geom%mask2d
 
 end subroutine soca_ocnsfc_random
 
@@ -126,6 +138,10 @@ subroutine soca_ocnsfc_copy(self, rhs)
   class(soca_ocnsfc_type), intent(inout) :: self
   class(soca_ocnsfc_type),    intent(in) :: rhs
 
+  ! associate geometry
+  self%geom => rhs%geom
+
+  ! copy fields
   self%sw_rad      = rhs%sw_rad
   self%lw_rad      = rhs%lw_rad
   self%latent_heat = rhs%latent_heat

--- a/src/soca/Fields/soca_seaice_mod.F90
+++ b/src/soca/Fields/soca_seaice_mod.F90
@@ -36,7 +36,6 @@ type :: soca_seaice_type
    procedure :: create => soca_seaice_create
    procedure :: delete => soca_seaice_delete
    procedure :: zeros => soca_seaice_zeros
-   procedure :: ones => soca_seaice_ones
    procedure :: abs => soca_seaice_abs
    procedure :: random => soca_seaice_random
    procedure :: copy => soca_seaice_copy
@@ -103,16 +102,6 @@ subroutine soca_seaice_zeros(self)
   self%hsnon = 0.0_kind_real
 
 end subroutine soca_seaice_zeros
-
-! ------------------------------------------------------------------------------
-subroutine soca_seaice_ones(self)
-  class(soca_seaice_type), intent(inout) :: self
-
-  self%cicen = 1.0_kind_real
-  self%hicen = 1.0_kind_real
-  self%hsnon = 1.0_kind_real
-
-end subroutine soca_seaice_ones
 
 ! ------------------------------------------------------------------------------
 subroutine soca_seaice_abs(self)

--- a/src/soca/Fields/soca_seaice_mod.F90
+++ b/src/soca/Fields/soca_seaice_mod.F90
@@ -22,7 +22,7 @@ private
 public :: soca_seaice_type
 
 type :: soca_seaice_type
-   type(soca_geom), pointer          :: geom
+   type(soca_geom),      pointer     :: geom
 
    ! Sea-ice state  variables
    real(kind=kind_real), allocatable :: cicen(:,:,:) !< Ice Fraction

--- a/test/testref/3dhyb.test
+++ b/test/testref/3dhyb.test
@@ -4,18 +4,18 @@ Test     : CostFunction: Nonlinear J = 194.065
 Test     : RPCGMinimizer: reduction in residual norm = 0.403048
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.000000   max=    1.000000   mean=    0.255651
-Test     :   hicen   min=   -0.000625   max=    2.923064   mean=    0.160784
-Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.036687
-Test     :    socn   min=    0.000000   max=   40.441659   mean=   34.573562
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023962
+Test     :   hicen   min=   -0.000625   max=    2.923064   mean=    0.115985
+Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.573562
 Test     :    tocn   min=   -1.947135   max=   31.700465   mean=    6.010636
-Test     :     ssh   min=   -2.250718   max=    0.921788   mean=   -0.279087
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628598
-Test     :      sw   min= -225.097763   max=    0.000000   mean= -110.032311
+Test     :     ssh   min=   -2.250718   max=    0.921788   mean=   -0.292432
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
 Test     :      lw   min=    0.000000   max=   88.036087   mean=   48.153824
-Test     :      us   min=    0.004396   max=    0.019658   mean=    0.013258
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
 Test     : CostJb   : Nonlinear Jb = 4.610809
 Test     : CostJo   : Nonlinear Jo(ADT) = 126.332974, nobs = 100, Jo/n = 1.263330, err = 0.100000
 Test     : CostFunction: Nonlinear J = 130.943783

--- a/test/testref/3dhybfgat.test
+++ b/test/testref/3dhybfgat.test
@@ -4,12 +4,12 @@ Test     : CostFunction: Nonlinear J = 58.4626
 Test     : RPCGMinimizer: reduction in residual norm = 0.347462
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.000000   max=    1.000000   mean=    0.255640
-Test     :   hicen   min=   -0.000288   max=    2.923064   mean=    0.160784
-Test     :    socn   min=    0.000000   max=   40.441659   mean=   34.553291
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023949
+Test     :   hicen   min=   -0.000288   max=    2.923064   mean=    0.115985
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.553291
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.014003
-Test     :     ssh   min=   -1.923022   max=    0.916810   mean=   -0.270377
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628598
+Test     :     ssh   min=   -1.923022   max=    0.916810   mean=   -0.283721
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000

--- a/test/testref/3dvar_godas.test
+++ b/test/testref/3dvar_godas.test
@@ -10,18 +10,18 @@ Test     : CostFunction: Nonlinear J = 44044.3
 Test     : RPCGMinimizer: reduction in residual norm = 0.211447
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.000000   max=    1.000000   mean=    0.255639
-Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.160786
-Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.036687
-Test     :    socn   min=    0.000000   max=   40.441659   mean=   34.544422
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023948
+Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.115987
+Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544422
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018471
-Test     :     ssh   min=   -1.924813   max=    0.927295   mean=   -0.263425
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628598
-Test     :      sw   min= -225.092792   max=    0.000000   mean= -110.030405
+Test     :     ssh   min=   -1.924813   max=    0.927295   mean=   -0.276769
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :      sw   min= -225.092792   max=   -0.033703   mean= -110.030405
 Test     :     lhf   min=  -38.137270   max=  256.595432   mean=   64.433506
 Test     :     shf   min=  -58.949280   max=  201.374279   mean=    9.318215
-Test     :      lw   min=    0.000000   max=   88.036094   mean=   48.153835
-Test     :      us   min=    0.004396   max=    0.019669   mean=    0.013340
+Test     :      lw   min=   -0.000000   max=   88.036094   mean=   48.153835
+Test     :      us   min=    0.004396   max=    0.019669   mean=    0.009437
 Test     : CostJb   : Nonlinear Jb = 0.534338
 Test     : CostJo   : Nonlinear Jo(CoolSkin) = 34797.974890, nobs = 201, Jo/n = 173.124253, err = 0.364832
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 3864.098633, nobs = 154, Jo/n = 25.091550, err = 0.356997

--- a/test/testref/3dvar_soca.test
+++ b/test/testref/3dvar_soca.test
@@ -10,17 +10,17 @@ Test     : CostFunction: Nonlinear J = 26137.4
 Test     : RPCGMinimizer: reduction in residual norm = 0.196294
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.255657
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023535
 Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
-Test     :    socn   min=    0.000000   max=   40.441659   mean=   34.544410
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544410
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018880
-Test     :     ssh   min=   -1.924603   max=    0.927287   mean=   -0.263392
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628598
-Test     :      sw   min= -225.093922   max=   -0.000000   mean= -110.030550
+Test     :     ssh   min=   -1.924603   max=    0.927287   mean=   -0.276737
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :      sw   min= -225.093922   max=   -0.033703   mean= -110.030550
 Test     :     lhf   min=  -38.137476   max=  256.595387   mean=   64.433537
 Test     :     shf   min=  -58.949293   max=  201.374246   mean=    9.318213
 Test     :      lw   min=    0.000000   max=   88.036095   mean=   48.153834
-Test     :      us   min=    0.004396   max=    0.019669   mean=    0.013335
+Test     :      us   min=    0.004396   max=    0.019669   mean=    0.009432
 Test     : CostJb   : Nonlinear Jb = 2.409733
 Test     : CostJo   : Nonlinear Jo(CoolSkin) = 19968.841370, nobs = 168, Jo/n = 118.862151, err = 0.359475
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 655.986417, nobs = 113, Jo/n = 5.805190, err = 0.349115

--- a/test/testref/3dvarfgat.test
+++ b/test/testref/3dvarfgat.test
@@ -10,12 +10,12 @@ Test     : CostFunction: Nonlinear J = 5995.64
 Test     : RPCGMinimizer: reduction in residual norm = 0.485988
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.258562
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.027021
 Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
-Test     :    socn   min=    0.000000   max=   40.441659   mean=   34.546552
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.546552
 Test     :    tocn   min=   -3.687986   max=   31.700465   mean=    6.005667
-Test     :     ssh   min=   -1.923509   max=    0.927278   mean=   -0.264073
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628598
+Test     :     ssh   min=   -1.923509   max=    0.927278   mean=   -0.277417
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000

--- a/test/testref/checkpointmodel.test
+++ b/test/testref/checkpointmodel.test
@@ -1,12 +1,12 @@
 Test     : input background: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.000000   max=    1.000000   mean=    0.255630
-Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.160786
-Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.036687
-Test     :    socn   min=    0.000000   max=   40.441659   mean=   34.544390
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023937
+Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.115987
+Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
-Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.263446
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628598
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000
@@ -14,13 +14,13 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.255630
-Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.160786
-Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.036687
-Test     :    socn   min=    0.000000   max=   40.441659   mean=   34.544422
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023948
+Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.115987
+Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544422
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018471
-Test     :     ssh   min=   -1.924813   max=    0.927295   mean=   -0.263425
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628598
+Test     :     ssh   min=   -1.924813   max=    0.927295   mean=   -0.276769
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000
@@ -28,13 +28,13 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : output background: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.255630
-Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.160786
-Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.036687
-Test     :    socn   min=    0.100000   max=   38.000000   mean=   34.593180
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023948
+Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.115987
+Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
+Test     :    socn   min=   10.721046   max=   38.000000   mean=   34.539802
 Test     :    tocn   min=   -1.800000   max=   31.700465   mean=    6.018610
-Test     :     ssh   min=   -1.924813   max=    0.927295   mean=   -0.263425
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628598
+Test     :     ssh   min=   -1.924813   max=    0.927295   mean=   -0.276769
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000

--- a/test/testref/dirac_horizfilt.test
+++ b/test/testref/dirac_horizfilt.test
@@ -1,6 +1,6 @@
 Test     : Increment: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    0.070621   mean=    0.000103
+Test     :   cicen   min=    0.000000   max=    0.070621   mean=    0.000124
 Test     :   hicen   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :    socn   min=    0.000000   max=    0.061217   mean=    0.000024
 Test     :    tocn   min=    0.000000   max=    0.065040   mean=    0.000024

--- a/test/testref/dirac_soca_cov.test
+++ b/test/testref/dirac_soca_cov.test
@@ -1,6 +1,6 @@
 Test     : Increment: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.050591   max=    0.000000   mean=   -0.000453
+Test     :   cicen   min=   -0.050591   max=    0.000000   mean=   -0.000543
 Test     :   hicen   min=    0.000000   max=  100.000000   mean=    0.142306
 Test     :    socn   min=   -0.049696   max=    0.271495   mean=    0.000351
 Test     :    tocn   min=    0.000000   max=    5.506776   mean=    0.023556

--- a/test/testref/dirac_socahyb_cov.test
+++ b/test/testref/dirac_socahyb_cov.test
@@ -1,6 +1,6 @@
 Test     : Increment: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.025295   max=    0.000002   mean=   -0.000201
+Test     :   cicen   min=   -0.025295   max=    0.000002   mean=   -0.000241
 Test     :   hicen   min=   -0.000121   max=   50.000000   mean=    0.071153
 Test     :    socn   min=   -0.082948   max=    0.049096   mean=    0.000116
 Test     :    tocn   min=   -0.006633   max=    2.809385   mean=    0.010579
@@ -8,9 +8,9 @@ Test     :     ssh   min=   -0.013960   max=    0.021443   mean=    0.000200
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : Increment: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.055709
-Test     :   hicen   min=   -0.000000   max=    1.000000   mean=    0.066851
-Test     :    socn   min=   -0.000000   max=    1.000000   mean=    0.066845
-Test     :    tocn   min=   -0.000000   max=    1.000000   mean=    0.066845
-Test     :     ssh   min=   -0.000000   max=    1.000000   mean=    0.066851
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.066851
+Test     :   hicen   min=    0.000000   max=    1.000000   mean=    0.066851
+Test     :    socn   min=    0.000000   max=    1.000000   mean=    0.066845
+Test     :    tocn   min=    0.000000   max=    1.000000   mean=    0.066845
+Test     :     ssh   min=    0.000000   max=    1.000000   mean=    0.066851
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000

--- a/test/testref/enspert.test
+++ b/test/testref/enspert.test
@@ -1,11 +1,11 @@
 Test     : Initial state: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.255630
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023503
 Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
-Test     :    socn   min=    0.000000   max=   40.441659   mean=   34.544390
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
-Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.263446
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628598
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000
@@ -13,66 +13,66 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : Member 0 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.255465
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023305
 Test     :   hicen   min=   -1.651350   max=    3.018419   mean=    0.103447
-Test     :    socn   min=    0.000000   max=   40.441655   mean=   34.558219
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.558219
 Test     :    tocn   min=   -1.888671   max=   31.711318   mean=    6.006912
-Test     :     ssh   min=   -1.872869   max=    0.923615   mean=   -0.263522
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628589
-Test     :      sw   min= -225.097763   max=   -0.000000   mean= -110.032311
+Test     :     ssh   min=   -1.872869   max=    0.923615   mean=   -0.276867
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628055
+Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
-Test     :      lw   min=    0.000000   max=   88.036087   mean=   48.153824
-Test     :      us   min=    0.004396   max=    0.019658   mean=    0.013258
+Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
 Test     : Member 1 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.255386
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023210
 Test     :   hicen   min=   -1.425462   max=    2.448354   mean=    0.069675
-Test     :    socn   min=    0.000000   max=   40.441655   mean=   34.523387
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.523387
 Test     :    tocn   min=   -1.888352   max=   31.711287   mean=    6.015936
-Test     :     ssh   min=   -1.857352   max=    0.924522   mean=   -0.263585
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628600
-Test     :      sw   min= -225.097763   max=   -0.000000   mean= -110.032311
+Test     :     ssh   min=   -1.857352   max=    0.924522   mean=   -0.276930
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628066
+Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
-Test     :      lw   min=    0.000000   max=   88.036087   mean=   48.153824
-Test     :      us   min=    0.004396   max=    0.019658   mean=    0.013258
+Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
 Test     : Member 2 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.255684
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023567
 Test     :   hicen   min=   -1.552657   max=    2.481507   mean=    0.090478
-Test     :    socn   min=    0.000000   max=   40.533992   mean=   34.532446
+Test     :    socn   min=   10.720592   max=   40.533992   mean=   34.532446
 Test     :    tocn   min=   -1.898194   max=   31.711393   mean=    6.007395
-Test     :     ssh   min=   -1.947674   max=    0.917680   mean=   -0.263371
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628645
-Test     :      sw   min= -225.097763   max=   -0.000000   mean= -110.032311
+Test     :     ssh   min=   -1.947674   max=    0.917680   mean=   -0.276716
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628111
+Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
-Test     :      lw   min=    0.000000   max=   88.036087   mean=   48.153824
-Test     :      us   min=    0.004396   max=    0.019658   mean=    0.013258
+Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
 Test     : Member 3 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.255419
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023249
 Test     :   hicen   min=   -1.515012   max=    2.532327   mean=    0.104401
-Test     :    socn   min=    0.000000   max=   40.441655   mean=   34.572525
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.572525
 Test     :    tocn   min=   -1.941466   max=   31.711251   mean=    6.015971
-Test     :     ssh   min=   -1.909793   max=    0.917274   mean=   -0.262981
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628683
-Test     :      sw   min= -225.097763   max=   -0.000000   mean= -110.032311
+Test     :     ssh   min=   -1.909793   max=    0.917274   mean=   -0.276326
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628149
+Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
-Test     :      lw   min=    0.000000   max=   88.036087   mean=   48.153824
-Test     :      us   min=    0.004396   max=    0.019658   mean=    0.013258
+Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
 Test     : Member 4 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.255526
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023378
 Test     :   hicen   min=   -1.774887   max=    2.724659   mean=    0.088841
-Test     :    socn   min=    0.000000   max=   40.441655   mean=   34.551107
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.551107
 Test     :    tocn   min=   -1.885716   max=   31.711256   mean=    6.013778
-Test     :     ssh   min=   -1.966797   max=    0.915250   mean=   -0.262675
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628661
-Test     :      sw   min= -225.097763   max=   -0.000000   mean= -110.032311
+Test     :     ssh   min=   -1.966797   max=    0.915250   mean=   -0.276019
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628127
+Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
-Test     :      lw   min=    0.000000   max=   88.036087   mean=   48.153824
-Test     :      us   min=    0.004396   max=    0.019658   mean=    0.013258
+Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356

--- a/test/testref/ensvariance.test
+++ b/test/testref/ensvariance.test
@@ -1,6 +1,6 @@
 Test     : Variance: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    0.001533   mean=    0.000010
+Test     :   cicen   min=    0.000000   max=    0.001533   mean=    0.000012
 Test     :   hicen   min=    0.000000   max=    0.000002   mean=    0.000000
 Test     :    socn   min=    0.000000   max=    2.175341   mean=    0.056263
 Test     :    tocn   min=    0.000000   max=    3.997766   mean=    0.027547

--- a/test/testref/forecast_identity.test
+++ b/test/testref/forecast_identity.test
@@ -1,26 +1,26 @@
 Test     : Initial state: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.255630
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023503
 Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
-Test     :    socn   min=    0.000000   max=   40.441659   mean=   34.544390
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
-Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.263446
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628598
-Test     :      sw   min= -225.097763   max=   -0.000000   mean= -110.032311
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
-Test     :      lw   min=    0.000000   max=   88.036087   mean=   48.153824
-Test     :      us   min=    0.004396   max=    0.019658   mean=    0.013258
+Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
 Test     : Final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.255630
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023503
 Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
-Test     :    socn   min=    0.000000   max=   40.441659   mean=   34.544390
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
-Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.263446
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628598
-Test     :      sw   min= -225.097763   max=   -0.000000   mean= -110.032311
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
-Test     :      lw   min=    0.000000   max=   88.036087   mean=   48.153824
-Test     :      us   min=    0.004396   max=    0.019658   mean=    0.013258
+Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356

--- a/test/testref/forecast_identity_cice.test
+++ b/test/testref/forecast_identity_cice.test
@@ -1,28 +1,28 @@
 Test     : Initial state: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.000000   max=    1.000000   mean=    0.255630
-Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.160786
-Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.036687
-Test     :    socn   min=    0.000000   max=   40.441659   mean=   34.544390
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023937
+Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.115987
+Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
-Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.263446
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628598
-Test     :      sw   min= -225.097763   max=   -0.000000   mean= -110.032311
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
-Test     :      lw   min=    0.000000   max=   88.036087   mean=   48.153824
-Test     :      us   min=    0.004396   max=    0.019658   mean=    0.013258
+Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
 Test     : Final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=   -0.000000   max=    1.000000   mean=    0.255630
-Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.160786
-Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.036687
-Test     :    socn   min=    0.000000   max=   40.441659   mean=   34.544390
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023937
+Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.115987
+Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
-Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.263446
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628598
-Test     :      sw   min= -225.097763   max=   -0.000000   mean= -110.032311
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
-Test     :      lw   min=    0.000000   max=   88.036087   mean=   48.153824
-Test     :      us   min=    0.004396   max=    0.019658   mean=    0.013258
+Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356

--- a/test/testref/forecast_mom6.test
+++ b/test/testref/forecast_mom6.test
@@ -1,11 +1,11 @@
 Test     : Initial state: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.255630
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023503
 Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
-Test     :    socn   min=    0.000000   max=   40.441659   mean=   34.544390
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
-Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.263446
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628598
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000
@@ -13,14 +13,14 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : Final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.255630
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023503
 Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
-Test     :    socn   min=    0.000000   max=   40.441636   mean=   34.545194
+Test     :    socn   min=   10.718537   max=   40.441636   mean=   34.545194
 Test     :    tocn   min=   -1.888294   max=   31.764659   mean=    6.018086
-Test     :     ssh   min=   -1.905847   max=    0.908715   mean=   -0.263197
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628583
-Test     :      sw   min= -225.097763   max=   -0.000000   mean= -110.032311
+Test     :     ssh   min=   -1.905847   max=    0.908715   mean=   -0.276542
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628049
+Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
-Test     :      lw   min=    0.000000   max=   88.036087   mean=   48.153824
-Test     :      us   min=    0.004396   max=    0.019658   mean=    0.013258
+Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356

--- a/test/testref/hofx.test
+++ b/test/testref/hofx.test
@@ -1,11 +1,11 @@
 Test     : Initial state: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.255630
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023503
 Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
-Test     :    socn   min=    0.000000   max=   40.441659   mean=   34.544390
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
-Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.263446
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628598
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000
@@ -13,17 +13,17 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : Final state: 
 Test     :   Valid time: 2018-04-15T03:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.255630
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023503
 Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
-Test     :    socn   min=    0.000000   max=   40.441647   mean=   34.544468
+Test     :    socn   min=   10.719748   max=   40.441647   mean=   34.544468
 Test     :    tocn   min=   -1.888350   max=   31.732789   mean=    6.017616
-Test     :     ssh   min=   -1.908126   max=    0.908462   mean=   -0.263238
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628622
-Test     :      sw   min= -225.097763   max=   -0.000000   mean= -110.032311
+Test     :     ssh   min=   -1.908126   max=    0.908462   mean=   -0.276583
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628088
+Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
-Test     :      lw   min=    0.000000   max=   88.036087   mean=   48.153824
-Test     :      us   min=    0.004396   max=    0.019658   mean=    0.013258
+Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
 Test     : H(x): 
 Test     : CoolSkin nobs= 21 Min=0.782627, Max=24.863122, RMS=21.430268
 Test     : SeaSurfaceTemp nobs= 21 Min=4.207161, Max=29.766979, RMS=26.048145

--- a/test/testref/hofx3d.test
+++ b/test/testref/hofx3d.test
@@ -1,16 +1,16 @@
 Test     : Initial state: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.255630
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023503
 Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
-Test     :    socn   min=    0.000000   max=   40.441659   mean=   34.544390
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
-Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.263446
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628598
-Test     :      sw   min= -225.097763   max=   -0.000000   mean= -110.032311
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
-Test     :      lw   min=    0.000000   max=   88.036087   mean=   48.153824
-Test     :      us   min=    0.004396   max=    0.019658   mean=    0.013258
+Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
 Test     : H(x): CoolSkin nobs= 201 Min=-4.180048, Max=25.207414, RMS=19.187170
 Test     : SeaSurfaceTemp nobs= 201 Min=-0.743529, Max=30.655820, RMS=23.171631
 Test     : SeaSurfaceSalinity nobs= 100 Min=14.686840, Max=37.067415, RMS=33.593276


### PR DESCRIPTION
* applies the land mask for `Increment::random()`, land locations are set to zero for the random increment. This is needed so that the `GeometryIterator` test will pass if the soca iterator skips over land points. This currently does not change the answers of any of our tests
* instead of doing the same thing for `ones()`, I just removed that method because it was not being used and is not required by the oops interface. (Free bonus code coverage points!!)
* the same masking is applied to `gpnorm()`, min/max/mean values now exclude land points (e.g. look at the minimum salinity, which is no longer 0.0). Test reference answers are updated because of this.

closes #114 
closes #231 