### PR TITLE
re-enable SIGFPE trapping for hofx

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -427,7 +427,6 @@ soca_add_test( NAME hofx3d
 
 soca_add_test( NAME hofx
                EXE  soca_hofx.x
-               NOTRAPFPE
                TEST_DEPENDS test_soca_gridgen )
 
 # TODO enshofx currently breaks compare.py


### PR DESCRIPTION
once corresponding branch in saber is merged (https://github.com/JCSDA/saber/pull/53) hofx test no longer throws FPE and so SIGFPE trapping can be re-enabled for that ctest.

closes #243 

Although trapping can be re-enabled in `hofx` , it still cannot in `3dvarfgat` and `enshofx` because of floating point errors now being thrown in the model in gcc/debug (which I of course have no hope of addressing)