### PR TITLE
find_package(NetCDF)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,10 @@ set( SOCA_LINKER_LANGUAGE CXX )
 set( Boost_MINIMUM_VERSION "1.47" )
 include_directories( ${Boost_INCLUDE_DIR} )
 
+# NetCDF
+find_package( NetCDF REQUIRED COMPONENTS F90 )
+include_directories( ${NETCDF_INCLUDE_DIRS} )
+
 # eckit
 ecbuild_use_package( PROJECT eckit VERSION 1.1.0 REQUIRED )
 include_directories( ${ECKIT_INCLUDE_DIRS} )


### PR DESCRIPTION
Change-Id: Ie0a9fc4db0686a04d5045381ea66bad50767744a

## Description

SOCA was making use of the NetCDF Fortran library, but the package was not being explicitly being found.  It was probably relying on the dependencies to find it.  This PR makes it explicit.

It makes sure that the include path of NetCDF includes are before the system ones (in the case of using modules).  This was causing an issue on my OSX platforms.

Is a change of answers expected from this PR? -- No.


### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!) -- Sue me!


## Testing

How were these changes tested? -- ctest
What compilers / HPCs was it tested with? -- Intel & GNU / OSX and Discover
Are the changes covered by ctests? (If not, tests should be added first.) -- Not necessary



## Dependencies

None

Do PRs in upstream repositories need to be merged first?
None

