### PR TITLE
Atmospheric Geometry (obs space only)

### DIFF
--- a/src/soca/Fortran.h
+++ b/src/soca/Fortran.h
@@ -55,16 +55,6 @@ namespace soca {
 
   extern "C" {
     // -----------------------------------------------------------------------------
-    //  Geometry
-    // -----------------------------------------------------------------------------
-    void soca_geo_setup_f90(F90geom &, const eckit::Configuration * const *);
-    void soca_geo_clone_f90(const F90geom &, F90geom &);
-    void soca_geo_info_f90(const F90geom &);
-    void soca_geo_gridgen_f90(const F90geom &,
-                              const eckit::Configuration * const *);
-    void soca_geo_delete_f90(F90geom &);
-
-    // -----------------------------------------------------------------------------
     //  Fields
     // -----------------------------------------------------------------------------
     void soca_field_create_f90(F90flds &, const F90geom &,

--- a/src/soca/Geometry/Geometry.cc
+++ b/src/soca/Geometry/Geometry.cc
@@ -32,13 +32,16 @@ namespace soca {
     if (init_atm_geom)
       {
         // Get Time Bounds
-        const util::DateTime bgn = util::DateTime(conf.getString("atm_geom.date_begin"));
-        const util::DateTime end = util::DateTime(conf.getString("atm_geom.date_end"));
+        const util::DateTime bgn =
+                    util::DateTime(conf.getString("atm_geom.date_begin"));
+        const util::DateTime end =
+                    util::DateTime(conf.getString("atm_geom.date_end"));
 
         // Create the Atmospheric Geometry in Observation Space
-        // Weird, but look at it as a time dependent unstructured grid for the atmosphere
+        // Weird, but look at it as a time dependent unstructured
+        // grid for the atmosphere
         const eckit::LocalConfiguration confatmgeom(conf, "atm_geom.ObsSpace");
-        ioda::ObsSpace atmobs( confatmgeom, comm, bgn, end);
+        ioda::ObsSpace atmobs(confatmgeom, comm, bgn, end);
 
         // Get grid size
         int nlocs = atmobs.nlocs();
@@ -49,8 +52,7 @@ namespace soca {
         atmobs.get_db("MetaData", "longitude", nlocs, lons.data());
         atmobs.get_db("MetaData", "latitude", nlocs, lats.data());
         soca_geo_setup_f90(keyGeom_, &configc, nlocs, &lats[0], &lons[0]);
-      } else
-      {
+      } else {
         int nlocs = 1;
         std::vector<double> lats(nlocs); lats[0] = 0.0;
         std::vector<double> lons(nlocs); lons[0] = 0.0;

--- a/src/soca/Geometry/GeometryFortran.h
+++ b/src/soca/Geometry/GeometryFortran.h
@@ -18,7 +18,11 @@ namespace eckit {
 namespace soca {
 
   extern "C" {
-    void soca_geo_setup_f90(F90geom &, const eckit::Configuration * const *);
+    void soca_geo_setup_f90(F90geom &,
+                            const eckit::Configuration * const *,
+                            const int  &,
+                            const double *,
+                            const double *);
     void soca_geo_clone_f90(const F90geom &, F90geom &);
     void soca_geo_info_f90(const F90geom &);
     void soca_geo_gridgen_f90(const F90geom &,

--- a/src/soca/Geometry/soca_geom.interface.F90
+++ b/src/soca/Geometry/soca_geom.interface.F90
@@ -8,6 +8,7 @@ module soca_geom_mod_c
 use iso_c_binding
 use fckit_configuration_module, only: fckit_configuration
 use soca_geom_mod, only: soca_geom
+use kinds
 
 implicit none
 
@@ -31,18 +32,26 @@ contains
 
 ! ------------------------------------------------------------------------------
 !> Setup geometry object
-subroutine c_soca_geo_setup(c_key_self, c_conf) bind(c,name='soca_geo_setup_f90')
-
+  subroutine c_soca_geo_setup(c_key_self, c_conf, nlocs, clats, clons) &
+       bind(c,name='soca_geo_setup_f90')
   integer(c_int), intent(inout) :: c_key_self
   type(c_ptr),       intent(in) :: c_conf
+  integer(c_int),    intent(in) :: nlocs
+  real(c_double),    intent(in) :: clats(nlocs)
+  real(c_double),    intent(in) :: clons(nlocs)
 
   type(soca_geom), pointer :: self
+  real(kind_real) :: atm_lats(nlocs)
+  real(kind_real) :: atm_lons(nlocs)
 
   call soca_geom_registry%init()
   call soca_geom_registry%add(c_key_self)
   call soca_geom_registry%get(c_key_self,self)
 
-  call self%init(fckit_configuration(c_conf))
+  atm_lats(:) = clats(:)
+  atm_lons(:) = clons(:)
+
+  call self%init(fckit_configuration(c_conf), nlocs, atm_lats, atm_lons)
 
 end subroutine c_soca_geo_setup
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ list( APPEND soca_test_input
   testinput/forecast_identity_cice.yml
   testinput/forecast_mom6.yml
   testinput/geometry.yml
+  testinput/geometryatm.yml
   testinput/gridgen.yml
   testinput/hofx.yml
   testinput/hofx3d.yml
@@ -93,6 +94,10 @@ list( APPEND soca_obs
   Data/Obs/sst.nc
 )
 
+list( APPEND ioda_obs
+  ${ioda_SOURCE_DIR}/test/testinput/atmosphere/smap_obs_2018041500_m.nc4
+)
+
 # Create Data directory for test input/output and symlink all files
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testinput)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testoutput)
@@ -135,6 +140,14 @@ foreach(FILENAME ${soca_obs})
      get_filename_component(filename ${FILENAME} NAME )
      execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
            ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}
+           ${CMAKE_CURRENT_BINARY_DIR}/Data/${filename} )
+endforeach(FILENAME)
+
+# Link to IODA obs
+foreach(FILENAME ${ioda_obs})
+     get_filename_component(filename ${FILENAME} NAME )
+     execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
+           ${FILENAME}
            ${CMAKE_CURRENT_BINARY_DIR}/Data/${filename} )
 endforeach(FILENAME)
 
@@ -308,6 +321,10 @@ soca_add_test( NAME enspert
 # Tests of class interfaces
 #-------------------------------------------------------------------------------
 soca_add_test( NAME geometry
+               SRC  TestGeometry.cc
+               TEST_DEPENDS test_soca_gridgen )
+
+soca_add_test( NAME geometryatm
                SRC  TestGeometry.cc
                TEST_DEPENDS test_soca_gridgen )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,10 +92,7 @@ list( APPEND soca_obs
   Data/Obs/prof.nc
   Data/Obs/sss.nc
   Data/Obs/sst.nc
-)
-
-list( APPEND ioda_obs
-  ${ioda_SOURCE_DIR}/test/testinput/atmosphere/smap_obs_2018041500_m.nc4
+  Data/Obs/smap_tb.nc
 )
 
 # Create Data directory for test input/output and symlink all files
@@ -140,14 +137,6 @@ foreach(FILENAME ${soca_obs})
      get_filename_component(filename ${FILENAME} NAME )
      execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
            ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}
-           ${CMAKE_CURRENT_BINARY_DIR}/Data/${filename} )
-endforeach(FILENAME)
-
-# Link to IODA obs
-foreach(FILENAME ${ioda_obs})
-     get_filename_component(filename ${FILENAME} NAME )
-     execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
-           ${FILENAME}
            ${CMAKE_CURRENT_BINARY_DIR}/Data/${filename} )
 endforeach(FILENAME)
 

--- a/test/Data/Obs/smap_tb.nc
+++ b/test/Data/Obs/smap_tb.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e95d16e193272374507f6ca6815a972dde1e5d7908877ca739b2ed0b102c196f
+size 10816

--- a/test/testinput/geometryatm.yml
+++ b/test/testinput/geometryatm.yml
@@ -9,5 +9,5 @@ Geometry:
     date_end: 2018-04-16T00:00:00Z
     ObsSpace:
       name: None
-      ObsDataIn:  {obsfile: ./Data/smap_obs_2018041500_m.nc4}
+      ObsDataIn:  {obsfile: ./Data/smap_tb.nc}
       simulate:   {variables: [ None ]}

--- a/test/testinput/geometryatm.yml
+++ b/test/testinput/geometryatm.yml
@@ -1,0 +1,13 @@
+Geometry:
+  num_ice_cat: 5
+  num_ice_lev: 4
+  num_sno_lev: 1
+  read_soca_grid: grid
+  atm_geom:
+    init: true
+    date_begin: 2018-04-14T00:00:00Z
+    date_end: 2018-04-16T00:00:00Z
+    ObsSpace:
+      name: None
+      ObsDataIn:  {obsfile: ./Data/smap_obs_2018041500_m.nc4}
+      simulate:   {variables: [ None ]}

--- a/test/testinput/gridgen.yml
+++ b/test/testinput/gridgen.yml
@@ -2,10 +2,17 @@ geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  atm_geom:
+    init: true
+    date_begin: 2018-04-14T00:00:00Z
+    date_end: 2018-04-16T00:00:00Z
+    ObsSpace:
+      name: None
+      ObsDataIn:  {obsfile: gmi_obs_test.nc4}
+      simulate:   {variables: [ sea_surface_temperature ]}
 
 gridgen:
   name: SOCA
   tstep: PT6H
   advance_mom6: 0
   variables: [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
-

--- a/test/testinput/gridgen.yml
+++ b/test/testinput/gridgen.yml
@@ -2,17 +2,10 @@ geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  atm_geom:
-    init: true
-    date_begin: 2018-04-14T00:00:00Z
-    date_end: 2018-04-16T00:00:00Z
-    ObsSpace:
-      name: None
-      ObsDataIn:  {obsfile: gmi_obs_test.nc4}
-      simulate:   {variables: [ sea_surface_temperature ]}
 
 gridgen:
   name: SOCA
   tstep: PT6H
   advance_mom6: 0
   variables: [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
+


### PR DESCRIPTION
## Description
On the road to "NSST"! (although we're starting with SSS).
This feature branch adds a simple optional atmospheric geometry to soca::Geometry, based on ioda observation files. 
It uses ioda::ObsSpace for the distribution, unlike what might have been stated earlier, there will be no attempt at trying to match atm grid points to the corresponding PE domains.

Is a change of answers expected from this PR? **NO**

### Issue(s) addressed
- fixes #246 

### Other unrelated work done
- Removed redundant geometry interface in Fortran.h
- Removed "shoreline" and its siblings from the geometry

## Testing
How were these changes tested? **ctest + tested on larger atm obs file with more pe's**
What compilers / HPCs was it tested with? **gcc only**
Are the changes covered by ctests? (If not, tests should be added first.) **YES geometryatm test**

## Dependencies
None
