### PR TITLE
update increment.yaml to work with ioda PR

### DIFF
--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -88,7 +88,6 @@ subroutine create_constructor(self, geom, vars)
 
   ! Allocate
   call soca_field_alloc(self, geom)
-  !call zeros(self)
 
   ! Associate geometry
   self%geom => geom
@@ -112,8 +111,6 @@ subroutine create_copy(self, rhs_fld)
 
   ! Allocate and copy fields
   call soca_field_alloc(self, rhs_fld%geom)
-  call zeros(self)
-  !call copy(self,rhs_fld)
 
   ! Associate geometry
   self%geom => rhs_fld%geom
@@ -156,6 +153,7 @@ subroutine soca_field_alloc(self, geom)
   ! Allocate surface fields for cool skin
   call self%ocnsfc%create(geom)
 
+  call zeros(self)
 end subroutine soca_field_alloc
 
 ! ------------------------------------------------------------------------------

--- a/test/testinput/increment.yml
+++ b/test/testinput/increment.yml
@@ -19,13 +19,14 @@ InterpTest:
       simulate:
         variables: []
       Generate:
-        nobs: 10
-        lat1: -20
-        lat2: 20
-        lon1: -150
-        lon2: -140
+        Random:
+          nobs: 1000
+          lat1: -75
+          lat2: 90
+          lon1: 0
+          lon2: 360
+          random_seed: 1
         obs_errors: []
-        random_seed: 1
   GeoVaLs:
     variables:
     - sea_water_potential_temperature


### PR DESCRIPTION
## Description

- Changes the `increment.yaml` file to work with the pending IODA PR.
- switch back to using random locations over the globe
- zeros out the fields at allocation time (seems needed for above point to work)

I know we changed the lat/lon box previously to not be global because of some bug where 
increments over land break (because who cares about land with soca?). But by zeroing out the 
fields at allocation time, combined with some other bugfixes done previously, this seems to make the increment test happy even if an obsloc is over land. It might also help with some other SIGFPE issues I was seeing... I'll close those later after more testing

### Issue(s) addressed

- fixes #253
- fixes #202


## Testing

The increment ctest passes with gcc7 / intel17 / intel19 on desktop. Valgrind seems to have no complaints either.

## Dependencies
- test with ioda branch of matching name
- waiting on JCSDA/ioda/pull/363 before merging

