### PR TITLE
Use of CRTM UFO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ env:
     - BUNDLE_URL="https://github.com/JCSDA/soca-bundle.git"
     - MAIN_REPO=soca
     - LIB_REPOS="fms cvmix geokdtree mom6_da_hooks gsw mom6
-                 fckit saber oops ioda ufo ioda-converters soca-config"
+                 fckit saber oops ioda ufo ioda-converters soca-config crtm"
     - BUILD_OPT_OOPS="-DENABLE_OOPS_TOYMODELS=OFF"
     - BUILD_OPT_SOCA="-DSOCA_TESTS_FORC_DEFAULT_TOL=ON"
-    - MATCH_REPOS="saber oops ioda ioda-converters ufo soca soca-config"
+    - MATCH_REPOS="saber oops ioda ioda-converters ufo soca soca-config crtm"
     - LFS_REPOS=""
 
     # secure token used to push changes to GitHub (user: travissluka)

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     - BUILD_OPT=""
     - BUILD_OPT_CRTM="-DBUILD_CRTM=ON"
     - BUILD_OPT_OOPS="-DENABLE_OOPS_TOYMODELS=OFF"
-    - BUILD_OPT_SOCA="-DSOCA_TESTS_FORC_DEFAULT_TOL=ON"
+    - BUILD_OPT_SOCA="-DSOCA_TESTS_FORC_DEFAULT_TOL=ON -DCRTM_FIX_DIR=../../repo.src/crtm/fix"
     - MATCH_REPOS="saber oops ioda ioda-converters ufo soca soca-config"
     - LFS_REPOS="crtm"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,10 +66,6 @@ include_directories( ${IODA_INCLUDE_DIRS} )
 ecbuild_use_package( PROJECT ufo VERSION 0.1.0 REQUIRED )
 include_directories( ${UFO_INCLUDE_DIRS} )
 
-# ufo
-ecbuild_use_package( PROJECT ufo VERSION 0.1.0 REQUIRED )
-include_directories( ${UFO_INCLUDE_DIRS} )
-
 # fms
 ecbuild_use_package( PROJECT fms REQUIRED )
 include_directories( ${FMS_INCLUDE_DIRS} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,10 @@ include_directories( ${IODA_INCLUDE_DIRS} )
 ecbuild_use_package( PROJECT ufo VERSION 0.1.0 REQUIRED )
 include_directories( ${UFO_INCLUDE_DIRS} )
 
+# ufo
+ecbuild_use_package( PROJECT ufo VERSION 0.1.0 REQUIRED )
+include_directories( ${UFO_INCLUDE_DIRS} )
+
 # fms
 ecbuild_use_package( PROJECT fms REQUIRED )
 include_directories( ${FMS_INCLUDE_DIRS} )
@@ -78,6 +82,10 @@ include_directories( ${MOM6_INCLUDE_DIRS} )
 ecbuild_find_mpi( COMPONENTS CXX Fortran REQUIRED )
 ecbuild_include_mpi()
 link_libraries(${MPI_CXX_LIBRARIES} ${MPI_Fortran_LIBRARIES})
+
+# crtm
+ecbuild_use_package( PROJECT crtm VERSION 2.2.3 )
+include_directories( ${CRTM_INCLUDE_DIRS} )
 
 ################################################################################
 # Definitions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,6 @@ link_libraries(${MPI_CXX_LIBRARIES} ${MPI_Fortran_LIBRARIES})
 
 # crtm
 ecbuild_use_package( PROJECT crtm VERSION 2.2.3 )
-include_directories( ${CRTM_INCLUDE_DIRS} )
 
 ################################################################################
 # Definitions

--- a/src/soca/Fields/soca_interpfields_mod.F90
+++ b/src/soca/Fields/soca_interpfields_mod.F90
@@ -151,13 +151,15 @@ subroutine interp(fld, locs, vars, geoval, horiz_interp, traj)
      call nlev_from_ufovar(fld, vars, ivar, nval)
 
      ! Allocate GeoVaLs (fields at locations)
-     geoval%geovals(ivar)%nval = nval
-     if (.not.(allocated(geoval%geovals(ivar)%vals))) then
-        ! Number of obs in pe
-        nlocs = geoval%geovals(ivar)%nlocs
+     if (nval/=0) then
+        geoval%geovals(ivar)%nval = nval
+        if (.not.(allocated(geoval%geovals(ivar)%vals))) then
+           ! Number of obs in pe
+           nlocs = geoval%geovals(ivar)%nlocs
 
-        allocate(geoval%geovals(ivar)%vals(nval,nlocs))
-        geoval%linit = .true.
+           allocate(geoval%geovals(ivar)%vals(nval,nlocs))
+           geoval%linit = .true.
+        end if
      end if
 
      ! Allocate temporary geoval and 3d field for the current time window
@@ -185,7 +187,7 @@ subroutine interp(fld, locs, vars, geoval, horiz_interp, traj)
      case ("sea_water_cell_thickness")
         fld3d = fld%hocn(isc:iec,jsc:jec,1:nval)
 
-     case ("sea_surface_temperature")
+     case ("sea_surface_temperature","surface_temperature_where_sea")
         fld3d(isc:iec,jsc:jec,1) = fld%tocn(isc:iec,jsc:jec,1)
 
      case ("sea_surface_salinity")
@@ -213,7 +215,7 @@ subroutine interp(fld, locs, vars, geoval, horiz_interp, traj)
         fld3d(isc:iec,jsc:jec,1) = fld%ocnsfc%fric_vel(isc:iec,jsc:jec)
 
      case default
-        call abor1_ftn("soca_interpfields_mod:interp geoval does not exist")
+        !call abor1_ftn("soca_interpfields_mod:interp geoval does not exist")
      end select
 
      ! Apply forward interpolation: Model ---> Obs
@@ -357,6 +359,7 @@ subroutine nlev_from_ufovar(fld, vars, index_vars, nval)
 
   case ("sea_surface_height_above_geoid", &
         "sea_surface_temperature", &
+        "surface_temperature_where_sea", &
         "sea_surface_salinity", &
         "sea_floor_depth_below_sea_surface", &
         "sea_area_fraction", &
@@ -374,7 +377,8 @@ subroutine nlev_from_ufovar(fld, vars, index_vars, nval)
      nval = fld%geom%nzo
 
   case default
-     call abor1_ftn("soca_interpfields_mod: Could not set nval")
+     nval = 0
+     !call abor1_ftn("soca_interpfields_mod: Could not set nval")
 
   end select
 

--- a/src/soca/Fields/soca_interpfields_mod.F90
+++ b/src/soca/Fields/soca_interpfields_mod.F90
@@ -138,7 +138,7 @@ subroutine interp(fld, locs, vars, geoval, horiz_interp, traj)
   real(kind=kind_real), allocatable :: gom_window(:,:)
   real(kind=kind_real), allocatable :: fld3d(:,:,:)
   integer :: iii(3), bumpid=1111
-print *,"==================================== in"
+
   ! Sanity check
   call check(fld)
 
@@ -150,7 +150,6 @@ print *,"==================================== in"
   do ivar = 1, vars%nv
      ! Set number of levels/categories (nval)
      call nlev_from_ufovar(fld, vars, ivar, nval)
-     print *,'************* var *********** :',trim(vars%fldnames(ivar)), nval
      if (nval==0) cycle
 
      ! Allocate GeoVaLs (fields at locations)
@@ -162,7 +161,6 @@ print *,"==================================== in"
         allocate(geoval%geovals(ivar)%vals(nval,nlocs))
         geoval%linit = .true.
      end if
-     print *,'************* nlocs *********** :',nlocs
 
      ! Allocate temporary geoval and 3d field for the current time window
      allocate(gom_window(nval,locs%nlocs))
@@ -237,7 +235,7 @@ print *,"==================================== in"
      ! Deallocate temporary arrays
      deallocate(fld3d)
      deallocate(gom_window)
-print *,"==================================== out"
+
   end do
 
 end subroutine interp

--- a/src/soca/Geometry/Geometry.cc
+++ b/src/soca/Geometry/Geometry.cc
@@ -19,13 +19,15 @@ namespace soca {
   // -----------------------------------------------------------------------------
   Geometry::Geometry(const eckit::Configuration & conf,
                      const eckit::mpi::Comm & comm)
-    : comm_(comm) {
+    : comm_(comm), atmconf_(conf), initatm_(initAtm(conf)) {
     const eckit::Configuration * configc = &conf;
     soca_geo_setup_f90(keyGeom_, &configc);
   }
   // -----------------------------------------------------------------------------
   Geometry::Geometry(const Geometry & other)
-    : comm_(other.comm_) {
+    : comm_(other.comm_),
+      atmconf_(other.atmconf_),
+      initatm_(initAtm(other.atmconf_)) {
     const int key_geo = other.keyGeom_;
     soca_geo_clone_f90(key_geo, keyGeom_);
   }

--- a/src/soca/Geometry/Geometry.h
+++ b/src/soca/Geometry/Geometry.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "eckit/mpi/Comm.h"
+#include "eckit/config/LocalConfiguration.h"
 
 #include "oops/util/ObjectCounter.h"
 #include "oops/util/Printable.h"
@@ -42,12 +43,20 @@ namespace soca {
       const int& toFortran() const {return keyGeom_;}
       void gridgen(const eckit::Configuration &) const;
       const eckit::mpi::Comm & getComm() const {return comm_;}
+      eckit::LocalConfiguration  getAtmConf() const {return atmconf_;}
+      bool  getAtmInit() const {return initatm_;}
+      bool initAtm(const eckit::Configuration & conf) const
+      {
+        return conf.getBool("notocean.init", false);
+      }
 
    private:
       Geometry & operator=(const Geometry &);
       void print(std::ostream &) const;
       int keyGeom_;
       const eckit::mpi::Comm & comm_;
+      eckit::LocalConfiguration atmconf_;
+      bool initatm_;
   };
   // -----------------------------------------------------------------------------
 

--- a/src/soca/State/State.cc
+++ b/src/soca/State/State.cc
@@ -84,16 +84,18 @@ namespace soca {
   void State::getValues(const ufo::Locations & locs,
                         const oops::Variables & vars,
                         ufo::GeoVaLs & cols) const {
+    std::cout << "77777777777777777777777777777777" << std::endl;
     if (fields_->geometry()->getAtmInit())
       {
+        // Get atm geovals
+        // The variables in vars that are also defined in soca will be
+        // over-written in the interpolation call bellow
         getValuesFromFile(locs, vars, cols);
-        std::cout << "before" << std::endl;
-        std::cout << cols << std::endl;
+        Log::trace() << cols << std::endl;
       }
-    // Get ocean geovals and over-write above geovals if necessary
+    // Get ocean geovals
     fields_->getValues(locs, vars, cols);
-    std::cout << "after:" << cols << std::endl;
-    std::cout << cols << std::endl;
+    Log::trace() << cols << std::endl;
   }
   // -----------------------------------------------------------------------------
   void State::getValues(const ufo::Locations & locs,
@@ -108,7 +110,6 @@ namespace soca {
   void State::getValuesFromFile(const ufo::Locations & locs,
                                 const oops::Variables & vars,
                                 ufo::GeoVaLs & atmgom) const {
-
     // Get Atm configuration
     eckit::LocalConfiguration conf(fields_->geometry()->getAtmConf());
 

--- a/src/soca/State/State.cc
+++ b/src/soca/State/State.cc
@@ -84,7 +84,6 @@ namespace soca {
   void State::getValues(const ufo::Locations & locs,
                         const oops::Variables & vars,
                         ufo::GeoVaLs & cols) const {
-    std::cout << "77777777777777777777777777777777" << std::endl;
     if (fields_->geometry()->getAtmInit())
       {
         // Get atm geovals
@@ -92,7 +91,7 @@ namespace soca {
         // over-written in the interpolation call bellow
         getValuesFromFile(locs, vars, cols);
         Log::trace() << cols << std::endl;
-      }
+        }
     // Get ocean geovals
     fields_->getValues(locs, vars, cols);
     Log::trace() << cols << std::endl;

--- a/src/soca/State/State.cc
+++ b/src/soca/State/State.cc
@@ -90,11 +90,9 @@ namespace soca {
         // The variables in vars that are also defined in soca will be
         // over-written in the interpolation call bellow
         getValuesFromFile(locs, vars, cols);
-        Log::trace() << cols << std::endl;
         }
     // Get ocean geovals
     fields_->getValues(locs, vars, cols);
-    Log::trace() << cols << std::endl;
   }
   // -----------------------------------------------------------------------------
   void State::getValues(const ufo::Locations & locs,

--- a/src/soca/State/State.h
+++ b/src/soca/State/State.h
@@ -67,6 +67,10 @@ namespace soca {
                      ufo::GeoVaLs &,
                      GetValuesTraj &) const;
 
+      void getValuesFromFile(const ufo::Locations &,
+                                     const oops::Variables &,
+                                     ufo::GeoVaLs &) const;
+
       /// Interpolate full fields
       ///  void changeResolution(const State & xx);
 

--- a/src/soca/State/State.h
+++ b/src/soca/State/State.h
@@ -50,7 +50,7 @@ namespace soca {
 
       /// Constructor, destructor
       State(const Geometry &, const oops::Variables &,
-            const util::DateTime &);  // Is it used?
+            const util::DateTime &);
       State(const Geometry &, const oops::Variables &,
             const eckit::Configuration &);
       State(const Geometry &, const State &);
@@ -67,9 +67,10 @@ namespace soca {
                      ufo::GeoVaLs &,
                      GetValuesTraj &) const;
 
+      /// Read interpolated GeoVaLs at observation location
       void getValuesFromFile(const ufo::Locations &,
-                                     const oops::Variables &,
-                                     ufo::GeoVaLs &) const;
+                             const oops::Variables &,
+                             ufo::GeoVaLs &) const;
 
       /// Interpolate full fields
       ///  void changeResolution(const State & xx);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -98,15 +98,6 @@ list( APPEND soca_obs
   Data/Obs/gmi_gpm_obs.nc
 )
 
-list( APPEND crtm_coef
-  ${crtm_SOURCE_DIR}/fix/SpcCoeff/Little_Endian/gmi_gpm.SpcCoeff.bin
-  ${crtm_SOURCE_DIR}/fix/TauCoeff/ODPS/Little_Endian/gmi_gpm.TauCoeff.bin
-  ${crtm_SOURCE_DIR}/fix/CloudCoeff/Little_Endian/CloudCoeff.bin
-  ${crtm_SOURCE_DIR}/fix/AerosolCoeff/Little_Endian/AerosolCoeff.bin
-  ${crtm_SOURCE_DIR}/fix/EmisCoeff/MW_Water/Little_Endian/FASTEM6.MWwater.EmisCoeff.bin
-)
-
-
 # Create Data directory for test input/output and symlink all files
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testinput)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testoutput)
@@ -151,13 +142,23 @@ foreach(FILENAME ${soca_obs})
            ${CMAKE_CURRENT_BINARY_DIR}/Data/${filename} )
 endforeach(FILENAME)
 
-# Link CRTM coeff
-foreach(FILENAME ${crtm_coef})
-     get_filename_component(filename ${FILENAME} NAME )
-     execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
-           ${FILENAME}
-           ${CMAKE_CURRENT_BINARY_DIR}/Data/${filename} )
-endforeach(FILENAME)
+if( ${CRTM_FOUND} )
+  list( APPEND crtm_coef
+    ${crtm_SOURCE_DIR}/fix/SpcCoeff/Little_Endian/gmi_gpm.SpcCoeff.bin
+    ${crtm_SOURCE_DIR}/fix/TauCoeff/ODPS/Little_Endian/gmi_gpm.TauCoeff.bin
+    ${crtm_SOURCE_DIR}/fix/CloudCoeff/Little_Endian/CloudCoeff.bin
+    ${crtm_SOURCE_DIR}/fix/AerosolCoeff/Little_Endian/AerosolCoeff.bin
+    ${crtm_SOURCE_DIR}/fix/EmisCoeff/MW_Water/Little_Endian/FASTEM6.MWwater.EmisCoeff.bin
+  )
+
+  # Link CRTM coeff
+  foreach(FILENAME ${crtm_coef})
+       get_filename_component(filename ${FILENAME} NAME )
+       execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
+             ${FILENAME}
+             ${CMAKE_CURRENT_BINARY_DIR}/Data/${filename} )
+  endforeach(FILENAME)
+endif()
 
 # Create directory for BUMP output
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bump)
@@ -331,10 +332,11 @@ soca_add_test( NAME enspert
 soca_add_test( NAME geometry
                SRC  TestGeometry.cc
                TEST_DEPENDS test_soca_gridgen )
-
-soca_add_test( NAME geometryatm
-               SRC  TestGeometry.cc
-               TEST_DEPENDS test_soca_gridgen )
+if( ${CRTM_FOUND} )
+  soca_add_test( NAME geometryatm
+                 SRC  TestGeometry.cc
+                 TEST_DEPENDS test_soca_gridgen )
+endif()
 
 soca_add_test( NAME state
                SRC  TestState.cc
@@ -457,9 +459,11 @@ soca_add_test( NAME hofx3d
                EXE  soca_hofx3d.x
                TEST_DEPENDS test_soca_gridgen )
 
-soca_add_test( NAME hofx3dcrtm
-               EXE  soca_hofx3d.x
-               TEST_DEPENDS test_soca_gridgen )
+if( ${CRTM_FOUND} )
+ soca_add_test( NAME hofx3dcrtm
+                EXE  soca_hofx3d.x
+                TEST_DEPENDS test_soca_gridgen )
+endif()
 
 soca_add_test( NAME hofx
                EXE  soca_hofx.x

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,7 @@ list( APPEND soca_test_input
   testinput/gridgen.yml
   testinput/hofx.yml
   testinput/hofx3d.yml
+  testinput/hofx3dcrtm.yml
   testinput/increment.yml
   testinput/linearmodel.yml
   testinput/marine2ioda.yml
@@ -59,6 +60,7 @@ list( APPEND soca_test_ref
   testref/forecast_mom6.test
   testref/hofx.test
   testref/hofx3d.test
+  testref/hofx3dcrtm.test
   testref/parameters_bump_cov_lct.test
 )
 
@@ -92,7 +94,18 @@ list( APPEND soca_obs
   Data/Obs/prof.nc
   Data/Obs/sss.nc
   Data/Obs/sst.nc
+  Data/Obs/gmi_gpm_geoval.nc
+  Data/Obs/gmi_gpm_obs.nc
 )
+
+list( APPEND crtm_coef
+  ${crtm_SOURCE_DIR}/fix/SpcCoeff/Little_Endian/gmi_gpm.SpcCoeff.bin
+  ${crtm_SOURCE_DIR}/fix/TauCoeff/ODPS/Little_Endian/gmi_gpm.TauCoeff.bin
+  ${crtm_SOURCE_DIR}/fix/CloudCoeff/Little_Endian/CloudCoeff.bin
+  ${crtm_SOURCE_DIR}/fix/AerosolCoeff/Little_Endian/AerosolCoeff.bin
+  ${crtm_SOURCE_DIR}/fix/EmisCoeff/MW_Water/Little_Endian/FASTEM6.MWwater.EmisCoeff.bin
+)
+
 
 # Create Data directory for test input/output and symlink all files
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testinput)
@@ -129,13 +142,20 @@ ecbuild_add_resources( TARGET   soca_test_scripts
                        SOURCES_PACK
                        ${soca_test_input}
                        )
-
 # Link to SOCA obs
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Data)
 foreach(FILENAME ${soca_obs})
      get_filename_component(filename ${FILENAME} NAME )
      execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
            ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}
+           ${CMAKE_CURRENT_BINARY_DIR}/Data/${filename} )
+endforeach(FILENAME)
+
+# Link CRTM coeff
+foreach(FILENAME ${crtm_coef})
+     get_filename_component(filename ${FILENAME} NAME )
+     execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
+           ${FILENAME}
            ${CMAKE_CURRENT_BINARY_DIR}/Data/${filename} )
 endforeach(FILENAME)
 
@@ -434,6 +454,10 @@ soca_add_test( NAME dirac_horizfilt
 
 # h(x) executables
 soca_add_test( NAME hofx3d
+               EXE  soca_hofx3d.x
+               TEST_DEPENDS test_soca_gridgen )
+
+soca_add_test( NAME hofx3dcrtm
                EXE  soca_hofx3d.x
                TEST_DEPENDS test_soca_gridgen )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -463,6 +463,7 @@ soca_add_test( NAME hofx3dcrtm
 
 soca_add_test( NAME hofx
                EXE  soca_hofx.x
+               NOTRAPFPE
                TEST_DEPENDS test_soca_gridgen )
 
 # TODO enshofx currently breaks compare.py

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -142,23 +142,39 @@ foreach(FILENAME ${soca_obs})
            ${CMAKE_CURRENT_BINARY_DIR}/Data/${filename} )
 endforeach(FILENAME)
 
+
+# Link CRTM coeff
 if( ${CRTM_FOUND} )
+
+  # determine where to look for coefficients
+  set( CRTM_FIX_DIR_DOCSTRING
+      "Path to the CRTM fix directory, needs to be set if CRTM was not built as part of this bundle.")
+  set( CRTM_FIX_DIR NOTFOUND CACHE PATH ${CRTM_FIX_DIR_DOCSTRING})
+  if( NOT CRTM_FIX_DIR AND EXISTS ${crtm_SOURCE_DIR}/fix)
+    set( CRTM_FIX_DIR ${crtm_SOURCE_DIR}/fix CACHE PATH ${CRTM_FIX_DIR_DOCSTRING} FORCE)
+  elseif( NOT CRTM_FIX_DIR )
+    message(FATAL_ERROR
+      "CRTM was not built as part of the bundle, CRTM_FIX_DIR must be set")
+  endif()
+
+  # the coefficient files needed
   list( APPEND crtm_coef
-    ${crtm_SOURCE_DIR}/fix/SpcCoeff/Little_Endian/gmi_gpm.SpcCoeff.bin
-    ${crtm_SOURCE_DIR}/fix/TauCoeff/ODPS/Little_Endian/gmi_gpm.TauCoeff.bin
-    ${crtm_SOURCE_DIR}/fix/CloudCoeff/Little_Endian/CloudCoeff.bin
-    ${crtm_SOURCE_DIR}/fix/AerosolCoeff/Little_Endian/AerosolCoeff.bin
-    ${crtm_SOURCE_DIR}/fix/EmisCoeff/MW_Water/Little_Endian/FASTEM6.MWwater.EmisCoeff.bin
+    SpcCoeff/Little_Endian/gmi_gpm.SpcCoeff.bin
+    TauCoeff/ODPS/Little_Endian/gmi_gpm.TauCoeff.bin
+    CloudCoeff/Little_Endian/CloudCoeff.bin
+    AerosolCoeff/Little_Endian/AerosolCoeff.bin
+    EmisCoeff/MW_Water/Little_Endian/FASTEM6.MWwater.EmisCoeff.bin
   )
 
-  # Link CRTM coeff
+  # link the files
   foreach(FILENAME ${crtm_coef})
        get_filename_component(filename ${FILENAME} NAME )
        execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
-             ${FILENAME}
+             ${CRTM_FIX_DIR}/${FILENAME}
              ${CMAKE_CURRENT_BINARY_DIR}/Data/${filename} )
   endforeach(FILENAME)
 endif()
+
 
 # Create directory for BUMP output
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bump)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -332,11 +332,11 @@ soca_add_test( NAME enspert
 soca_add_test( NAME geometry
                SRC  TestGeometry.cc
                TEST_DEPENDS test_soca_gridgen )
-if( ${CRTM_FOUND} )
-  soca_add_test( NAME geometryatm
-                 SRC  TestGeometry.cc
-                 TEST_DEPENDS test_soca_gridgen )
-endif()
+
+soca_add_test( NAME geometryatm
+               SRC  TestGeometry.cc
+               TEST_DEPENDS test_soca_gridgen )
+
 
 soca_add_test( NAME state
                SRC  TestState.cc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ list( APPEND soca_test_input
   testinput/forecast_identity_cice.yml
   testinput/forecast_mom6.yml
   testinput/geometry.yml
+  testinput/geometryatm.yml
   testinput/gridgen.yml
   testinput/hofx.yml
   testinput/hofx3d.yml
@@ -308,6 +309,10 @@ soca_add_test( NAME enspert
 # Tests of class interfaces
 #-------------------------------------------------------------------------------
 soca_add_test( NAME geometry
+               SRC  TestGeometry.cc
+               TEST_DEPENDS test_soca_gridgen )
+
+soca_add_test( NAME geometryatm
                SRC  TestGeometry.cc
                TEST_DEPENDS test_soca_gridgen )
 

--- a/test/Data/Obs/gmi_gpm_geoval.nc
+++ b/test/Data/Obs/gmi_gpm_geoval.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f63509831f2b5b9debcc810420cfd5f05fa9da222ea0b25d235abda5d96e54e0
+size 94775

--- a/test/Data/Obs/gmi_gpm_obs.nc
+++ b/test/Data/Obs/gmi_gpm_obs.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f731250144ad72034470612df0d8ca71d25ff28034f322b05aa6eb8543391634
+size 41499

--- a/test/testinput/geometryatm.yml
+++ b/test/testinput/geometryatm.yml
@@ -1,0 +1,38 @@
+Geometry:
+  num_ice_cat: 5
+  num_ice_lev: 4
+  num_sno_lev: 1
+  read_soca_grid: grid
+  atm_state:
+    init: true
+    date_begin: 2018-04-14T00:00:00Z
+    date_end: 2018-04-16T00:00:00Z
+    variables: &atm_vars [air_temperature,
+                humidity_mixing_ratio,
+                air_pressure,
+                air_pressure_levels,
+                effective_radius_of_cloud_liquid_water_particle,
+                effective_radius_of_cloud_ice_particle,
+                mass_content_of_cloud_ice_in_atmosphere_layer,
+                mass_content_of_cloud_liquid_water_in_atmosphere_layer,
+                mole_fraction_of_carbon_dioxide_in_air,
+                mole_fraction_of_ozone_in_air,
+                surface_wind_from_direction,
+                soil_type,
+                leaf_area_index,
+                vegetation_type_index,
+                surface_wind_speed,
+                surface_snow_thickness,
+                vegetation_area_fraction,
+                land_type_index,
+                volume_fraction_of_condensed_water_in_soil,
+                soil_temperature,
+                surface_temperature_where_snow,
+                surface_temperature_where_ice,
+                surface_temperature_where_land,
+                surface_snow_area_fraction,
+                ice_area_fraction,
+                land_area_fraction,
+                water_area_fraction,
+                surface_temperature_where_sea ]
+    filename: gmi_gpm_geoval_2018041500_m.nc4

--- a/test/testinput/hofx.yml
+++ b/test/testinput/hofx.yml
@@ -78,7 +78,7 @@ Observations:
       simulate:
         variables: [sea_water_temperature]
     ObsOperator:
-      name: InsituTemperature      
+      name: InsituTemperature
     Covariance:
       covariance: diagonal
 

--- a/test/testinput/hofx3dcrtm.yml
+++ b/test/testinput/hofx3dcrtm.yml
@@ -1,0 +1,83 @@
+Geometry:
+  num_ice_cat: 5
+  num_ice_lev: 4
+  num_sno_lev: 1
+  read_soca_grid: grid
+  notocean:
+    init: true
+    date_begin: 2018-04-14T00:00:00Z
+    date_end: 2018-04-16T00:00:00Z
+    variables: [air_temperature,
+                humidity_mixing_ratio]
+    filename: gmi_gpm_geoval_2018041500_m.nc4
+    ObsSpace:
+      name: None
+      ObsDataIn:  {obsfile: gmi_gpm_obs_2018041500_m.nc4}
+      ObsDataOut:  {obsfile: ./Data/atm_out.nc}
+      simulate:   {variables: [ None ]}
+    date_begin: 2018-04-14T00:00:00Z
+    date_end: 2018-04-16T00:00:00Z
+    variables: [air_temperature,
+                humidity_mixing_ratio,
+                air_pressure,
+                air_pressure_levels,
+                effective_radius_of_cloud_liquid_water_particle,
+                effective_radius_of_cloud_ice_particle,
+                mass_content_of_cloud_ice_in_atmosphere_layer,
+                mass_content_of_cloud_liquid_water_in_atmosphere_layer,
+                mole_fraction_of_carbon_dioxide_in_air,
+                mole_fraction_of_ozone_in_air,
+                surface_wind_from_direction,
+                soil_type,
+                leaf_area_index,
+                vegetation_type_index,
+                surface_wind_speed,
+                surface_snow_thickness,
+                vegetation_area_fraction,
+                land_type_index,
+                volume_fraction_of_condensed_water_in_soil,
+                soil_temperature,
+                surface_temperature_where_snow,
+                surface_temperature_where_ice,
+                surface_temperature_where_land,
+                surface_snow_area_fraction,
+                ice_area_fraction,
+                land_area_fraction,
+                water_area_fraction,
+                surface_temperature_where_sea ]
+    filename: gmi_gpm_geoval_2018041500_m.nc4
+
+Initial Condition:
+  read_from_file: 1
+  date: 2018-04-15T00:00:00Z
+  basename: ./INPUT/
+  ocn_filename: MOM.res.nc
+  ice_filename: ice_model.res.nc
+  sfc_filename: sfc.res.nc
+  variables: [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
+
+Assimilation Window:
+  Begin: 2018-04-15T00:00:00Z
+  Length: P2D
+
+Observations:
+  ObsTypes:
+
+  - ObsOperator:
+      name: CRTM
+      Absorbers: [H2O,O3,CO2]
+      Clouds: [Water, Ice]
+      LinearObsOperator:
+        Absorbers: [H2O,O3,CO2]
+        Clouds: [Water]
+      ObsOptions:
+        Sensor_ID: gmi_gpm
+        EndianType: little_endian
+        CoefficientPath: Data/
+    ObsSpace:
+      name: gmi_gpm
+      ObsDataIn:
+        obsfile: gmi_gpm_obs_2018041500_m.nc4
+      simulate:
+        variables: [brightness_temperature]
+        channels: 1-13

--- a/test/testinput/hofx3dcrtm.yml
+++ b/test/testinput/hofx3dcrtm.yml
@@ -9,10 +9,10 @@ Geometry:
     date_end: 2018-04-16T00:00:00Z
     variables: [air_temperature,
                 humidity_mixing_ratio]
-    filename: gmi_gpm_geoval_2018041500_m.nc4
+    filename: ./Data/gmi_gpm_geoval.nc
     ObsSpace:
       name: None
-      ObsDataIn:  {obsfile: gmi_gpm_obs_2018041500_m.nc4}
+      ObsDataIn:  {obsfile: ./Data/gmi_gpm_obs.nc}
       ObsDataOut:  {obsfile: ./Data/atm_out.nc}
       simulate:   {variables: [ None ]}
     date_begin: 2018-04-14T00:00:00Z
@@ -45,7 +45,7 @@ Geometry:
                 land_area_fraction,
                 water_area_fraction,
                 surface_temperature_where_sea ]
-    filename: gmi_gpm_geoval_2018041500_m.nc4
+    filename: Data/gmi_gpm_geoval.nc
 
 Initial Condition:
   read_from_file: 1
@@ -77,7 +77,7 @@ Observations:
     ObsSpace:
       name: gmi_gpm
       ObsDataIn:
-        obsfile: gmi_gpm_obs_2018041500_m.nc4
+        obsfile: Data/gmi_gpm_obs.nc
       simulate:
         variables: [brightness_temperature]
         channels: 1-13

--- a/test/testinput/state.yml
+++ b/test/testinput/state.yml
@@ -13,7 +13,6 @@ StateTest:
     ice_filename: ice_model.res.nc
     sfc_filename: sfc.res.nc
     variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
-      
     remap_filename: ./INPUT/MOM.res.nc
   norm-file: 9898.1892609204206
   date: *date

--- a/test/testref/hofx3dcrtm.test
+++ b/test/testref/hofx3dcrtm.test
@@ -1,0 +1,14 @@
+Test     : Initial state:
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023503
+Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
+Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
+Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
+Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
+Test     : H(x): gmi_gpm nobs= 156 Min=79.777575, Max=265.383973, RMS=202.519531


### PR DESCRIPTION
## Description
**Oil spill is contained!** None of the atmospheric variables are mentioned anywhere in the code (except yaml files), so far ...
Revisiting aborted [PR#255](https://github.com/JCSDA/soca/pull/255.) ... and more. This feature branch adds the possibility of using the CRTM ufo in hofx3d (not tested yet with hofx):
- Atmospheric geovals are pre-computed (fv3-jedi) and read inside of getvalue
- Ocean surface (just sst for now) is provided by soca through getvalue.

Is a change of answers expected from this PR? **NO but overflow issue in adt hofx. No clue why. @travissluka and @aerorahul said they'll fix it.**

### Issue(s) addressed
- closes #246 
- Partially  addresses #248, #247, #254 

### What's not too flash
The atmospheric "geometry" and "state" are part of the soca geometry. Not pretty but I can't think of a better way that would work.

## Testing
How were these changes tested? **hofx3dcrtm and geometryatm ctest**
What compilers / HPCs was it tested with? **gcc only**
Are the changes covered by ctests? (If not, tests should be added first.) **YES geometryatm test**

## Dependencies
Need the CRTM
