### PR TITLE
Seaice mask removal

### DIFF
--- a/src/soca/Covariance/soca_covariance_mod.F90
+++ b/src/soca/Covariance/soca_covariance_mod.F90
@@ -63,7 +63,7 @@ subroutine soca_cov_setup(self, f_conf, geom, bkg, vars)
   type(oops_vars),           intent(in) :: vars   !< List of variables
 
   character(len=3)  :: domain
-  integer :: isc, iec, jsc, jec, i, j, ivar
+  integer :: isc, iec, jsc, jec, ivar
   logical :: init_seaice, init_ocean
 
   ! Setup list of variables to apply B on

--- a/test/testref/3dhyb.test
+++ b/test/testref/3dhyb.test
@@ -1,21 +1,21 @@
 Test     : CostJb   : Nonlinear Jb = 0
 Test     : CostJo   : Nonlinear Jo(ADT) = 194.065, nobs = 100, Jo/n = 1.94065, err = 0.1
 Test     : CostFunction: Nonlinear J = 194.065
-Test     : RPCGMinimizer: reduction in residual norm = 0.571368
+Test     : RPCGMinimizer: reduction in residual norm = 0.675585
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023986
-Test     :   hicen   min=   -0.000472   max=    2.923064   mean=    0.115990
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023978
+Test     :   hicen   min=   -0.000697   max=    2.923064   mean=    0.115987
 Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.571616
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.012725
-Test     :     ssh   min=   -2.359612   max=    0.919958   mean=   -0.291925
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.564245
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.013077
+Test     :     ssh   min=   -2.407961   max=    0.924766   mean=   -0.288858
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
 Test     :      lw   min=    0.000000   max=   88.036087   mean=   48.153824
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
-Test     : CostJb   : Nonlinear Jb = 3.758645
-Test     : CostJo   : Nonlinear Jo(ADT) = 139.020750, nobs = 100, Jo/n = 1.390208, err = 0.100000
-Test     : CostFunction: Nonlinear J = 142.779396
+Test     : CostJb   : Nonlinear Jb = 2.674116
+Test     : CostJo   : Nonlinear Jo(ADT) = 150.470099, nobs = 100, Jo/n = 1.504701, err = 0.100000
+Test     : CostFunction: Nonlinear J = 153.144215

--- a/test/testref/3dhybfgat.test
+++ b/test/testref/3dhybfgat.test
@@ -1,20 +1,20 @@
 Test     : CostJb   : Nonlinear Jb = 0
 Test     : CostJo   : Nonlinear Jo(ADT) = 58.4626, nobs = 31, Jo/n = 1.88589, err = 0.1
 Test     : CostFunction: Nonlinear J = 58.4626
-Test     : RPCGMinimizer: reduction in residual norm = 0.372874
+Test     : RPCGMinimizer: reduction in residual norm = 0.416261
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023951
-Test     :   hicen   min=   -0.000490   max=    2.923064   mean=    0.115987
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.551394
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.014342
-Test     :     ssh   min=   -1.923570   max=    0.912664   mean=   -0.282494
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023959
+Test     :   hicen   min=   -0.000387   max=    2.923064   mean=    0.115986
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.553138
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.014140
+Test     :     ssh   min=   -1.923466   max=    0.919469   mean=   -0.283437
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     : CostJb   : Nonlinear Jb = 1.170076
-Test     : CostJo   : Nonlinear Jo(ADT) = 56.465658, nobs = 31, Jo/n = 1.821473, err = 0.100000
-Test     : CostFunction: Nonlinear J = 57.635734
+Test     : CostJb   : Nonlinear Jb = 1.064204
+Test     : CostJo   : Nonlinear Jo(ADT) = 56.430327, nobs = 31, Jo/n = 1.820333, err = 0.100000
+Test     : CostFunction: Nonlinear J = 57.494531

--- a/test/testref/3dvar_godas.test
+++ b/test/testref/3dvar_godas.test
@@ -7,7 +7,7 @@ Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 398.357, nobs = 205, Jo/
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 2511.53, nobs = 218, Jo/n = 11.5208, err = 0.608197
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 392.024, nobs = 89, Jo/n = 4.40476, err = 0.1
 Test     : CostFunction: Nonlinear J = 44044.3
-Test     : RPCGMinimizer: reduction in residual norm = 0.21392
+Test     : RPCGMinimizer: reduction in residual norm = 0.213921
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023948
@@ -22,12 +22,12 @@ Test     :     lhf   min=  -38.137279   max=  256.595258   mean=   64.433509
 Test     :     shf   min=  -58.949282   max=  201.374279   mean=    9.318215
 Test     :      lw   min=   -0.000000   max=   88.036094   mean=   48.153835
 Test     :      us   min=    0.004396   max=    0.019668   mean=    0.009437
-Test     : CostJb   : Nonlinear Jb = 0.527928
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 34796.477448, nobs = 201, Jo/n = 173.116803, err = 0.364832
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 3864.123883, nobs = 154, Jo/n = 25.091714, err = 0.356997
+Test     : CostJb   : Nonlinear Jb = 0.527930
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 34796.476477, nobs = 201, Jo/n = 173.116798, err = 0.364832
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 3864.123805, nobs = 154, Jo/n = 25.091713, err = 0.356997
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 105.066589, nobs = 50, Jo/n = 2.101332, err = 1.000000
 Test     : CostJo   : Nonlinear Jo(ADT) = 146.895886, nobs = 94, Jo/n = 1.562722, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 396.261879, nobs = 205, Jo/n = 1.932985, err = 0.897232
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 2509.926855, nobs = 218, Jo/n = 11.513426, err = 0.608197
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 390.652172, nobs = 89, Jo/n = 4.389350, err = 0.100000
-Test     : CostFunction: Nonlinear J = 42209.932640
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 396.261874, nobs = 205, Jo/n = 1.932985, err = 0.897232
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 2509.926851, nobs = 218, Jo/n = 11.513426, err = 0.608197
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 390.647778, nobs = 89, Jo/n = 4.389301, err = 0.100000
+Test     : CostFunction: Nonlinear J = 42209.927191

--- a/test/testref/3dvar_soca.test
+++ b/test/testref/3dvar_soca.test
@@ -7,7 +7,7 @@ Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 398.357, nobs = 205, Jo/
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 2511.53, nobs = 218, Jo/n = 11.5208, err = 0.608197
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 632.528, nobs = 89, Jo/n = 7.10706, err = 0.1
 Test     : CostFunction: Nonlinear J = 26137.4
-Test     : RPCGMinimizer: reduction in residual norm = 0.198569
+Test     : RPCGMinimizer: reduction in residual norm = 0.198571
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023535
@@ -21,12 +21,12 @@ Test     :     lhf   min=  -38.137479   max=  256.595222   mean=   64.433542
 Test     :     shf   min=  -58.949293   max=  201.374246   mean=    9.318213
 Test     :      lw   min=    0.000000   max=   88.036094   mean=   48.153834
 Test     :      us   min=    0.004396   max=    0.019669   mean=    0.009432
-Test     : CostJb   : Nonlinear Jb = 2.442112
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 19969.923248, nobs = 168, Jo/n = 118.868591, err = 0.359475
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 655.941645, nobs = 113, Jo/n = 5.804793, err = 0.349115
+Test     : CostJb   : Nonlinear Jb = 2.442131
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 19969.921942, nobs = 168, Jo/n = 118.868583, err = 0.359475
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 655.941632, nobs = 113, Jo/n = 5.804793, err = 0.349115
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 105.065720, nobs = 50, Jo/n = 2.101314, err = 1.000000
 Test     : CostJo   : Nonlinear Jo(ADT) = 130.818739, nobs = 87, Jo/n = 1.503664, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 398.290017, nobs = 205, Jo/n = 1.942878, err = 0.897232
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 2510.444269, nobs = 218, Jo/n = 11.515799, err = 0.608197
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 628.545690, nobs = 89, Jo/n = 7.062311, err = 0.100000
-Test     : CostFunction: Nonlinear J = 24401.471440
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 2510.444265, nobs = 218, Jo/n = 11.515799, err = 0.608197
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 628.529815, nobs = 89, Jo/n = 7.062133, err = 0.100000
+Test     : CostFunction: Nonlinear J = 24401.454261

--- a/test/testref/3dvarfgat.test
+++ b/test/testref/3dvarfgat.test
@@ -7,13 +7,13 @@ Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 37.4198, nobs = 31, Jo/n
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 16.5727, nobs = 33, Jo/n = 0.502202, err = 0.61043
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 206.995, nobs = 24, Jo/n = 8.62478, err = 0.1
 Test     : CostFunction: Nonlinear J = 5995.64
-Test     : RPCGMinimizer: reduction in residual norm = 0.485677
+Test     : RPCGMinimizer: reduction in residual norm = 0.485367
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.027016
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.027011
 Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.546546
-Test     :    tocn   min=   -3.688477   max=   31.700465   mean=    6.004745
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.546547
+Test     :    tocn   min=   -3.689398   max=   31.700465   mean=    6.004739
 Test     :     ssh   min=   -1.923578   max=    0.927270   mean=   -0.277431
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
@@ -21,12 +21,12 @@ Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     : CostJb   : Nonlinear Jb = 1613.715097
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 4053.728406, nobs = 48, Jo/n = 84.452675, err = 0.387632
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 570.078192, nobs = 40, Jo/n = 14.251955, err = 0.391743
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 1.877760, nobs = 16, Jo/n = 0.117360, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 30.985162, nobs = 28, Jo/n = 1.106613, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 36.558880, nobs = 31, Jo/n = 1.179319, err = 0.908940
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 15.558150, nobs = 33, Jo/n = 0.471459, err = 0.610430
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 95.925289, nobs = 24, Jo/n = 3.996887, err = 0.100000
-Test     : CostFunction: Nonlinear J = 6418.426935
+Test     : CostJb   : Nonlinear Jb = 1615.203587
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 4053.421462, nobs = 48, Jo/n = 84.446280, err = 0.387632
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 570.127859, nobs = 40, Jo/n = 14.253196, err = 0.391743
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 1.877752, nobs = 16, Jo/n = 0.117360, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 30.985019, nobs = 28, Jo/n = 1.106608, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 36.558532, nobs = 31, Jo/n = 1.179307, err = 0.908940
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 15.557687, nobs = 33, Jo/n = 0.471445, err = 0.610430
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 95.988740, nobs = 24, Jo/n = 3.999531, err = 0.100000
+Test     : CostFunction: Nonlinear J = 6419.720638

--- a/test/testref/dirac_soca_cov.test
+++ b/test/testref/dirac_soca_cov.test
@@ -1,7 +1,7 @@
 Test     : Increment: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=   -0.048402   max=    0.000000   mean=   -0.000538
-Test     :   hicen   min=    0.000000   max=  100.000000   mean=    0.142306
+Test     :   hicen   min=    0.000000   max=  100.000000   mean=    0.167947
 Test     :    socn   min=   -0.047914   max=    0.267681   mean=    0.000355
 Test     :    tocn   min=    0.000000   max=    5.268716   mean=    0.023379
 Test     :     ssh   min=   -0.001998   max=    0.056011   mean=    0.000856

--- a/test/testref/dirac_socahyb_cov.test
+++ b/test/testref/dirac_socahyb_cov.test
@@ -1,10 +1,10 @@
 Test     : Increment: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.024201   max=    0.000046   mean=   -0.000239
-Test     :   hicen   min=   -0.000038   max=   50.000000   mean=    0.071153
-Test     :    socn   min=   -0.018760   max=    0.064532   mean=    0.000097
-Test     :    tocn   min=   -0.003953   max=    2.665595   mean=    0.010490
-Test     :     ssh   min=   -0.000060   max=    0.031706   mean=    0.000393
+Test     :   cicen   min=   -0.024201   max=    0.000117   mean=   -0.000239
+Test     :   hicen   min=   -0.000090   max=   50.000000   mean=    0.083973
+Test     :    socn   min=   -0.132970   max=    0.049350   mean=   -0.000208
+Test     :    tocn   min=   -0.002936   max=    2.742062   mean=    0.010635
+Test     :     ssh   min=   -0.003620   max=    0.034981   mean=    0.000434
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : Increment: 
 Test     :   Valid time: 2018-04-15T00:00:00Z

--- a/test/testref/enspert.test
+++ b/test/testref/enspert.test
@@ -13,12 +13,12 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : Member 0 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023366
-Test     :   hicen   min=   -1.651350   max=    3.018419   mean=    0.103447
-Test     :    socn   min=   10.720592   max=   40.702819   mean=   34.551947
-Test     :    tocn   min=   -1.888466   max=   31.711197   mean=    6.009687
-Test     :     ssh   min=   -1.970955   max=    0.920021   mean=   -0.276850
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628058
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023692
+Test     :   hicen   min=   -1.799966   max=    2.600727   mean=    0.113427
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.553580
+Test     :    tocn   min=   -1.904627   max=   31.711654   mean=    6.008611
+Test     :     ssh   min=   -2.093515   max=    0.920883   mean=   -0.276810
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628062
 Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
@@ -26,12 +26,12 @@ Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
 Test     : Member 1 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023253
-Test     :   hicen   min=   -1.425462   max=    2.448354   mean=    0.069675
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.529382
-Test     :    tocn   min=   -1.888293   max=   31.711311   mean=    6.014526
-Test     :     ssh   min=   -1.923246   max=    0.921119   mean=   -0.276825
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628080
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023554
+Test     :   hicen   min=   -1.801901   max=    2.910159   mean=    0.114013
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.516568
+Test     :    tocn   min=   -1.908575   max=   31.711384   mean=    6.002744
+Test     :     ssh   min=   -2.081981   max=    0.921863   mean=   -0.276863
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628061
 Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
@@ -39,12 +39,12 @@ Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
 Test     : Member 2 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023559
-Test     :   hicen   min=   -1.552657   max=    2.481507   mean=    0.090478
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.537865
-Test     :    tocn   min=   -1.917313   max=   31.711402   mean=    6.012479
-Test     :     ssh   min=   -1.910509   max=    0.914423   mean=   -0.276520
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628128
+Test     :   cicen   min=    0.000000   max=    0.999822   mean=    0.023078
+Test     :   hicen   min=   -1.830576   max=    3.054364   mean=    0.101870
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.504884
+Test     :    tocn   min=   -1.888164   max=   31.711639   mean=    6.013555
+Test     :     ssh   min=   -1.990869   max=    0.911035   mean=   -0.276772
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628089
 Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
@@ -52,12 +52,12 @@ Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
 Test     : Member 3 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023225
-Test     :   hicen   min=   -1.515012   max=    2.532327   mean=    0.104401
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.556139
-Test     :    tocn   min=   -1.900505   max=   31.711050   mean=    6.009253
-Test     :     ssh   min=   -1.944583   max=    0.916620   mean=   -0.276076
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628163
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023272
+Test     :   hicen   min=   -1.749087   max=    2.215952   mean=    0.069014
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.538512
+Test     :    tocn   min=   -1.922205   max=   31.711116   mean=    6.009299
+Test     :     ssh   min=   -1.984494   max=    0.912326   mean=   -0.276585
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628102
 Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
@@ -65,12 +65,12 @@ Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
 Test     : Member 4 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023394
-Test     :   hicen   min=   -1.774887   max=    2.724659   mean=    0.088841
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.543251
-Test     :    tocn   min=   -1.929993   max=   31.711364   mean=    6.008445
-Test     :     ssh   min=   -1.896608   max=    0.918896   mean=   -0.275769
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628132
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023432
+Test     :   hicen   min=   -1.726175   max=    2.721787   mean=    0.101269
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.556085
+Test     :    tocn   min=   -1.892545   max=   31.711224   mean=    6.010431
+Test     :     ssh   min=   -1.936816   max=    0.913685   mean=   -0.276431
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628101
 Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225

--- a/test/testref/ensrecenter.test
+++ b/test/testref/ensrecenter.test
@@ -1,88 +1,88 @@
-Test     : Original member 0 :
+Test     : Original member 0 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023366
-Test     :   hicen   min=   -0.001825   max=    0.003335   mean=    0.000114
-Test     :    socn   min=   10.720592   max=   40.702819   mean=   34.553394
-Test     :    tocn   min=   -1.888466   max=   31.711197   mean=    6.005076
-Test     :     ssh   min=   -1.970955   max=    0.920021   mean=   -0.276850
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023692
+Test     :   hicen   min=   -0.001989   max=    0.002874   mean=    0.000125
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.555594
+Test     :    tocn   min=   -1.904627   max=   31.711654   mean=    6.006925
+Test     :     ssh   min=   -2.093515   max=    0.920883   mean=   -0.276810
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     : Original member 1 :
+Test     : Original member 1 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023253
-Test     :   hicen   min=   -0.001575   max=    0.002705   mean=    0.000077
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.532234
-Test     :    tocn   min=   -1.888293   max=   31.711311   mean=    6.008071
-Test     :     ssh   min=   -1.923246   max=    0.921119   mean=   -0.276825
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023554
+Test     :   hicen   min=   -0.001991   max=    0.003216   mean=    0.000126
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.521257
+Test     :    tocn   min=   -1.908575   max=   31.711384   mean=    5.995765
+Test     :     ssh   min=   -2.081981   max=    0.921863   mean=   -0.276863
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     : Original member 2 :
+Test     : Original member 2 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023559
-Test     :   hicen   min=   -0.001716   max=    0.002742   mean=    0.000100
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.540875
-Test     :    tocn   min=   -1.917313   max=   31.711402   mean=    6.007760
-Test     :     ssh   min=   -1.910509   max=    0.914423   mean=   -0.276520
+Test     :   cicen   min=    0.000000   max=    0.999822   mean=    0.023078
+Test     :   hicen   min=   -0.002023   max=    0.003375   mean=    0.000113
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.509238
+Test     :    tocn   min=   -1.888164   max=   31.711639   mean=    6.003997
+Test     :     ssh   min=   -1.990869   max=    0.911035   mean=   -0.276772
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     : Original member 3 :
+Test     : Original member 3 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023225
-Test     :   hicen   min=   -0.001674   max=    0.002798   mean=    0.000115
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.558331
-Test     :    tocn   min=   -1.900505   max=   31.711050   mean=    6.004743
-Test     :     ssh   min=   -1.944583   max=    0.916620   mean=   -0.276076
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023272
+Test     :   hicen   min=   -0.001933   max=    0.002449   mean=    0.000076
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.541029
+Test     :    tocn   min=   -1.922205   max=   31.711116   mean=    5.998532
+Test     :     ssh   min=   -1.984494   max=    0.912326   mean=   -0.276585
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     : Original member 4 :
+Test     : Original member 4 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023394
-Test     :   hicen   min=   -0.001961   max=    0.003011   mean=    0.000098
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.547202
-Test     :    tocn   min=   -1.929985   max=   31.711364   mean=    6.000259
-Test     :     ssh   min=   -1.896608   max=    0.918896   mean=   -0.275769
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023432
+Test     :   hicen   min=   -0.001907   max=    0.003007   mean=    0.000112
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.558824
+Test     :    tocn   min=   -1.892495   max=   31.711224   mean=    5.997159
+Test     :     ssh   min=   -1.936816   max=    0.913685   mean=   -0.276431
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     : Ensemble mean:
+Test     : Ensemble mean: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    0.997358   mean=    0.023359
-Test     :   hicen   min=   -0.000911   max=    0.002438   mean=    0.000101
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.546407
-Test     :    tocn   min=   -1.888152   max=   31.711265   mean=    6.005182
-Test     :     ssh   min=   -1.906305   max=    0.918216   mean=   -0.276408
+Test     :   cicen   min=    0.000000   max=    0.994335   mean=    0.023406
+Test     :   hicen   min=   -0.000865   max=    0.002356   mean=    0.000110
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.537188
+Test     :    tocn   min=   -1.888324   max=   31.711403   mean=    6.000475
+Test     :     ssh   min=   -1.998151   max=    0.915959   mean=   -0.276692
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     : Recentered member 0 :
+Test     : Recentered member 0 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023459
-Test     :   hicen   min=   -0.001701   max=    2.265518   mean=    0.094264
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.551376
-Test     :    tocn   min=   -2.386023   max=   31.700397   mean=    6.017459
-Test     :     ssh   min=   -2.021285   max=    0.929088   mean=   -0.277232
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023734
+Test     :   hicen   min=   -0.001594   max=    2.265289   mean=    0.094265
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.562796
+Test     :    tocn   min=   -2.445484   max=   31.700715   mean=    6.024014
+Test     :     ssh   min=   -2.019849   max=    0.932207   mean=   -0.276908
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     : Recentered member 1 :
+Test     : Recentered member 1 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023346
-Test     :   hicen   min=   -0.001390   max=    2.265637   mean=    0.094226
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.530217
-Test     :    tocn   min=   -2.276606   max=   31.700510   mean=    6.020454
-Test     :     ssh   min=   -1.970418   max=    0.930186   mean=   -0.277207
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023587
+Test     :   hicen   min=   -0.001736   max=    2.265749   mean=    0.094266
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.528458
+Test     :    tocn   min=   -2.132910   max=   31.700446   mean=    6.012855
+Test     :     ssh   min=   -1.947384   max=    0.933187   mean=   -0.276962
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     : Recentered member 2 :
+Test     : Recentered member 2 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023655
-Test     :   hicen   min=   -0.001477   max=    2.265180   mean=    0.094249
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.538857
-Test     :    tocn   min=   -2.308100   max=   31.700601   mean=    6.020143
-Test     :     ssh   min=   -1.911376   max=    0.923489   mean=   -0.276903
+Test     :   cicen   min=    0.000000   max=    0.999822   mean=    0.023174
+Test     :   hicen   min=   -0.001897   max=    2.265773   mean=    0.094252
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.516439
+Test     :    tocn   min=   -2.254511   max=   31.700700   mean=    6.021086
+Test     :     ssh   min=   -1.915876   max=    0.922360   mean=   -0.276870
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     : Recentered member 3 :
+Test     : Recentered member 3 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023319
-Test     :   hicen   min=   -0.001430   max=    2.265074   mean=    0.094265
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.556314
-Test     :    tocn   min=   -2.271347   max=   31.700250   mean=    6.017126
-Test     :     ssh   min=   -1.917185   max=    0.925687   mean=   -0.276458
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023350
+Test     :   hicen   min=   -0.001881   max=    2.265037   mean=    0.094216
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.548230
+Test     :    tocn   min=   -2.101895   max=   31.700177   mean=    6.015622
+Test     :     ssh   min=   -1.896132   max=    0.923650   mean=   -0.276683
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     : Recentered member 4 :
+Test     : Recentered member 4 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023422
-Test     :   hicen   min=   -0.002058   max=    2.265847   mean=    0.094248
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.545185
-Test     :    tocn   min=   -2.374978   max=   31.700564   mean=    6.012642
-Test     :     ssh   min=   -1.910897   max=    0.927963   mean=   -0.276152
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023462
+Test     :   hicen   min=   -0.001643   max=    2.265409   mean=    0.094252
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.566025
+Test     :    tocn   min=   -2.199741   max=   31.700285   mean=    6.014248
+Test     :     ssh   min=   -1.863982   max=    0.925009   mean=   -0.276529
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064

--- a/test/testref/ensvariance.test
+++ b/test/testref/ensvariance.test
@@ -1,8 +1,8 @@
 Test     : Variance: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    0.001533   mean=    0.000012
+Test     :   cicen   min=    0.000000   max=    0.001836   mean=    0.000009
 Test     :   hicen   min=    0.000000   max=    0.000002   mean=    0.000000
-Test     :    socn   min=    0.000000   max=    2.480237   mean=    0.055171
-Test     :    tocn   min=    0.000000   max=    4.568691   mean=    0.028790
-Test     :     ssh   min=    0.000000   max=    0.097517   mean=    0.001154
+Test     :    socn   min=    0.000000   max=    2.134512   mean=    0.065596
+Test     :    tocn   min=    0.000000   max=    6.867970   mean=    0.029130
+Test     :     ssh   min=    0.000000   max=    0.096198   mean=    0.001283
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000


### PR DESCRIPTION
## Description
See issue #263: The sea-ice mask in B is removed, which changes all the tests making use of bump.
 
What bug does it fix, or what feature does it add? **Not a bug But also not a feature**
Is a change of answers expected from this PR? **Yes**

### Issue(s) addressed
- closes #263 
- May address an issue observed in #262 

## Testing
How were these changes tested? **ctest only**
What compilers / HPCs was it tested with?**gcc**
Are the changes covered by ctests? **yes**

## Dependencies
None


