### PR TITLE
randomize only the  fields listed in the yaml

### DIFF
--- a/src/soca/Fields/soca_ocnsfc_mod.F90
+++ b/src/soca/Fields/soca_ocnsfc_mod.F90
@@ -112,17 +112,28 @@ subroutine soca_ocnsfc_abs(self)
 end subroutine soca_ocnsfc_abs
 
 ! ------------------------------------------------------------------------------
-subroutine soca_ocnsfc_random(self)
+subroutine soca_ocnsfc_random(self, fields)
   class(soca_ocnsfc_type), intent(inout) :: self
+  character(len=5), allocatable, intent(in) :: fields(:)
 
+  integer :: ff
   integer :: rseed = 1
 
   ! set random values
-  call normal_distribution(self%sw_rad, 0.0_kind_real, 1.0_kind_real, rseed)
-  call normal_distribution(self%lw_rad, 0.0_kind_real, 1.0_kind_real, rseed)
-  call normal_distribution(self%latent_heat, 0.0_kind_real, 1.0_kind_real, rseed)
-  call normal_distribution(self%sens_heat, 0.0_kind_real, 1.0_kind_real, rseed)
-  call normal_distribution(self%fric_vel, 0.0_kind_real, 1.0_kind_real, rseed)
+  do ff = 1, size(fields)
+    select case(fields(ff))
+    case("sw")
+      call normal_distribution(self%sw_rad, 0.0_kind_real, 1.0_kind_real, rseed)
+    case("lw")
+      call normal_distribution(self%lw_rad, 0.0_kind_real, 1.0_kind_real, rseed)
+    case("lhf")
+      call normal_distribution(self%latent_heat, 0.0_kind_real, 1.0_kind_real, rseed)
+    case("shf")
+      call normal_distribution(self%sens_heat, 0.0_kind_real, 1.0_kind_real, rseed)
+    case("us")
+      call normal_distribution(self%fric_vel, 0.0_kind_real, 1.0_kind_real, rseed)
+    end select
+  end do
 
   ! mask out land, set to zero
   self%sw_rad = self%sw_rad * self%geom%mask2d
@@ -131,6 +142,8 @@ subroutine soca_ocnsfc_random(self)
   self%sens_heat = self%sens_heat * self%geom%mask2d
   self%fric_vel = self%fric_vel * self%geom%mask2d
 
+  ! update domains
+  ! TODO: if/when ever needed
 end subroutine soca_ocnsfc_random
 
 ! ------------------------------------------------------------------------------

--- a/src/soca/Fields/soca_seaice_mod.F90
+++ b/src/soca/Fields/soca_seaice_mod.F90
@@ -120,15 +120,24 @@ subroutine soca_seaice_zeros(self)
 end subroutine soca_seaice_zeros
 
 ! ------------------------------------------------------------------------------
-subroutine soca_seaice_random(self)
+subroutine soca_seaice_random(self, fields)
   class(soca_seaice_type), intent(inout) :: self
-  integer :: i
+  character(len=5), allocatable, intent(in) :: fields(:)
+
+  integer :: i, ff
   integer, parameter :: rseed = 1
 
   ! set random values
-  call normal_distribution(self%cicen, 0.0_kind_real, 1.0_kind_real, rseed)
-  call normal_distribution(self%hicen, 0.0_kind_real, 1.0_kind_real, rseed)
-  call normal_distribution(self%hsnon, 0.0_kind_real, 1.0_kind_real, rseed)
+  do ff=1, size(fields)
+    select case(fields(ff))
+    case("cicen")
+      call normal_distribution(self%cicen, 0.0_kind_real, 1.0_kind_real, rseed)
+    case("hicen")
+      call normal_distribution(self%hicen, 0.0_kind_real, 1.0_kind_real, rseed)
+    case("hsnon")
+      call normal_distribution(self%hsnon, 0.0_kind_real, 1.0_kind_real, rseed)
+    end select
+  end do
 
   ! mask out land, set to zero
   do i=1, self%geom%ice_column%ncat+1


### PR DESCRIPTION
## Description

All ocean/ice/sfc fields were being randomized when `Fields::random()` was called. This was causing problems when calculating norms with the upcoming addition of the `geometryIterator` test if not all fields were to be used. Now, only the fields used in the yaml file will be randomized, the rest will remain 0.0.

## Testing
* no change in the test answers (`enshofx` is currently failing due to unrelated reasons)
* @frolovsa the geometryIterator test should pass now when this is merged into your branch
