### PR TITLE
fix enshofx

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -226,13 +226,15 @@ set( SOCA_TESTS_FORC_TRAPFPE OFF CACHE BOOL
 #  TOL       - The tolerances to use for the test "float_tolerance int_tolerance"
 #              If none are given, ${SOCA_TESTS_DEFAULT_TOL} is used. Only used
 #              if an EXE with no NOCOMPARE flag set.
+#  MPI       - The number of MPI PEs to use. If not specified, ${SOCA_TESTS_MAX_MPI}
+#              will be used
 # TEST_DEPENDS - list of tests this test depends on
 #-------------------------------------------------------------------------------
 function(soca_add_test)
   # parse the passed arguments
   set(prefix     ARG)
   set(novals     NOCOMPARE NOTRAPFPE)
-  set(singlevals NAME EXE SRC CFG)
+  set(singlevals NAME EXE SRC CFG MPI)
   set(multivals  TEST_DEPENDS TOL)
   cmake_parse_arguments(${prefix}
                         "${novals}" "${singlevals}" "${multivals}"
@@ -257,6 +259,12 @@ function(soca_add_test)
     set ( CONFIG_FILE testinput/${ARG_NAME}.yml )
   endif()
 
+  # MPI PEs
+  set( MPI ${SOCA_TESTS_MAX_MPI} )
+  if ( ARG_MPI )
+    set( MPI ${ARG_MPI})
+  endif()
+
   # Are we building a unit test / or running a soca executable?
   if ( ARG_SRC )
     # building a unit test, therfore also assume no compare step
@@ -264,7 +272,7 @@ function(soca_add_test)
                       SOURCES executables/${ARG_SRC}
                       ARGS    ${CONFIG_FILE}
                       LIBS    soca
-                      MPI     ${SOCA_TESTS_MAX_MPI}
+                      MPI     ${MPI}
                       ENVIRONMENT ${TRAPFPE_ENV}
                       TEST_DEPENDS ${ARG_TEST_DEPENDS})
     set ( ARG_NOCOMPARE TRUE)
@@ -276,7 +284,7 @@ function(soca_add_test)
                       COMMAND "${CMAKE_BINARY_DIR}/bin/${ARG_EXE}"
                       ARGS    ${CONFIG_FILE}
                               testoutput/${ARG_NAME}.log
-                      MPI     ${SOCA_TESTS_MAX_MPI}
+                      MPI     ${MPI}
                       ENVIRONMENT ${TRAPFPE_ENV}
                       DEPENDS ${ARG_EXE}
                       TEST_DEPENDS ${ARG_TEST_DEPENDS})
@@ -490,6 +498,7 @@ soca_add_test( NAME hofx
 # Re-enable the comparison once that's fixed
 soca_add_test( NAME enshofx
                EXE  soca_enshofx.x
+               MPI 3
                NOCOMPARE
                NOTRAPFPE
                TEST_DEPENDS test_soca_enspert )

--- a/test/testinput/enshofx.yml
+++ b/test/testinput/enshofx.yml
@@ -1,3 +1,6 @@
+EnsembleApplication:
+  members: 3
+
 Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
@@ -33,7 +36,7 @@ Observations:
 
   - ObsSpace:
       name: CoolSkin
-      ObsDataOut: {obsfile: ./Data/sst.out.nc}
+      ObsDataOut: {obsfile: "./Data/enshofx.%{member}%.coolskin.nc"}
       ObsDataIn:  {obsfile: ./Data/sst.nc}
       simulate:
         variables: [sea_surface_temperature]
@@ -47,7 +50,7 @@ Observations:
 
   - ObsSpace:
       name: SeaSurfaceTemp
-      ObsDataOut: {obsfile: ./Data/sst.out.nc}
+      ObsDataOut: {obsfile: "./Data/enshofx.%{member}%.sst.nc"}
       ObsDataIn:  {obsfile: ./Data/sst.nc}
       simulate:
         variables: [sea_surface_temperature]
@@ -58,7 +61,7 @@ Observations:
 
   - ObsSpace:
       name: SeaSurfaceSalinity
-      ObsDataOut: {obsfile: ./Data/sss.out.nc}
+      ObsDataOut: {obsfile: "./Data/enshofx.%{member}%.sss.nc"}
       ObsDataIn:  {obsfile: ./Data/sss.nc}
       simulate:
         variables: [sea_surface_salinity]
@@ -69,7 +72,7 @@ Observations:
 
   - ObsSpace:
       name: ADT
-      ObsDataOut: {obsfile: ./Data/adt.out.nc}
+      ObsDataOut: {obsfile: "./Data/enshofx.%{member}%.adt.nc"}
       ObsDataIn:  {obsfile: ./Data/adt.nc}
       simulate:
         variables: [obs_absolute_dynamic_topography]
@@ -80,7 +83,7 @@ Observations:
 
   - ObsSpace:
       name: InsituTemperature
-      ObsDataOut: {obsfile: ./Data/prof.T.out.nc}
+      ObsDataOut: {obsfile: "./Data/enshofx.%{member}%.prof.T.nc"}
       ObsDataIn:  {obsfile: ./Data/prof.nc}
       simulate:
         variables: [sea_water_temperature]
@@ -91,7 +94,7 @@ Observations:
 
   - ObsSpace:
       name: InsituSalinity
-      ObsDataOut: {obsfile: ./Data/prof.S.out.nc}
+      ObsDataOut: {obsfile: "./Data/enshofx.%{member}%.prof.S.nc"}
       ObsDataIn:  {obsfile: ./Data/prof.nc}
       simulate:
         variables: [sea_water_salinity]
@@ -102,7 +105,7 @@ Observations:
 
   - ObsSpace:
       name: SeaIceFraction
-      ObsDataOut: {obsfile: ./Data/icec.out.nc}
+      ObsDataOut: {obsfile: "./Data/enshofx.%{member}%.icec.nc"}
       ObsDataIn:  {obsfile:  ./Data/icec.nc}
       simulate:
         variables: [sea_ice_area_fraction]


### PR DESCRIPTION
## Description

Fixes the `enshofx` test to work with the latest changes to OOPS. 
- `test_soca_enshofx` now runs with 3 PEs
- each obs output file is saved to a separate file for each ens member.
- the `soca_add_test` wrapper can now take an optional override to the number of MPI PEs to use




### Issue(s) addressed
- fixes JCSDA/soca/issues/265


## Testing
- `test_soca_enshofx` should pass now
- tested with gcc7.4 only
