### PR TITLE
fix gmi_gpm_obs.nc file

### DIFF
--- a/test/Data/Obs/gmi_gpm_obs.nc
+++ b/test/Data/Obs/gmi_gpm_obs.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f731250144ad72034470612df0d8ca71d25ff28034f322b05aa6eb8543391634
-size 41499
+oid sha256:924be98c9a37be77232d9adcb8ee883b89c0e6d168ab8de02fe03f8874d1f2a2
+size 41829


### PR DESCRIPTION
## Description

The format of the `gmi_gpm_obs.nc` file has been fixed in soca to comply (partially) with the ioda standards. This is needed for a pending change to ioda.


## Testing
There is no change in behavior currently, but this PR allows the `test_soca_hofx3dcrtm` test to pass when using the `feature/file_frames` branch of ioda (JCSDA/ioda/pull/372)

## Note
I have only updated the gmi obs file in soca. There is also a similar file used by ufo that I have not updated (since it does not impact the pending ioda PR). @HamidehGMAO The ioda-converter still needs to be fixed and used to replace the those netcdf files in order to address JCSDA/ioda/issues/249