### PR TITLE
use oops_variables 

### DIFF
--- a/src/soca/Covariance/ErrorCovariance.cc
+++ b/src/soca/Covariance/ErrorCovariance.cc
@@ -35,10 +35,9 @@ namespace soca {
     // bkg: Background state, invariant wrt outer-loop.
     time_ = util::DateTime(conf.getString("date"));
     const eckit::Configuration * configc = &conf;
-    oops::Variables vars(conf);
-    const eckit::Configuration * confvars = &vars.toFortran();
+    vars_ = oops::Variables(conf);
     soca_b_setup_f90(keyFtnConfig_, &configc, resol.toFortran(),
-                     bkg.fields().toFortran(), &confvars);
+                     bkg.fields().toFortran(), vars_);
     Log::trace() << "ErrorCovariance created" << std::endl;
   }
 

--- a/src/soca/Covariance/ErrorCovariance.h
+++ b/src/soca/Covariance/ErrorCovariance.h
@@ -52,6 +52,7 @@ namespace soca {
       boost::scoped_ptr<const Geometry> geom_;
       boost::scoped_ptr<const State> traj_;
       util::DateTime time_;
+      oops::Variables vars_;
   };
   // -----------------------------------------------------------------------------
 

--- a/src/soca/Covariance/soca_covariance.interface.F90
+++ b/src/soca/Covariance/soca_covariance.interface.F90
@@ -7,7 +7,7 @@ module soca_covariance_mod_c
 
 use iso_c_binding
 use fckit_configuration_module, only: fckit_configuration
-use variables_mod, only: oops_vars, oops_vars_create
+use oops_variables_mod
 use soca_geom_mod, only : soca_geom
 use soca_geom_mod_c, only : soca_geom_registry
 use soca_fields_mod, only: soca_field, copy
@@ -44,19 +44,19 @@ subroutine c_soca_b_setup(c_key_self, c_conf, c_key_geom, c_key_bkg, c_vars) &
   type(c_ptr),       intent(in) :: c_conf       !< The configuration
   integer(c_int),    intent(in) :: c_key_geom   !< Geometry
   integer(c_int),    intent(in) :: c_key_bkg    !< Background
-  type(c_ptr),       intent(in) :: c_vars       !< List of variables
+  type(c_ptr),value, intent(in) :: c_vars       !< List of variables
 
   type(soca_cov),   pointer :: self
   type(soca_geom),  pointer :: geom
   type(soca_field), pointer :: bkg
-  type(oops_vars)           :: vars
+  type(oops_variables)      :: vars
 
   call soca_geom_registry%get(c_key_geom, geom)
   call soca_cov_registry%init()
   call soca_cov_registry%add(c_key_self)
   call soca_cov_registry%get(c_key_self, self)
   call soca_field_registry%get(c_key_bkg,bkg)
-  call oops_vars_create(fckit_configuration(c_vars), vars)
+  vars = oops_variables(c_vars)
   call soca_cov_setup(self, fckit_configuration(c_conf), geom, bkg, vars)
 
 end subroutine c_soca_b_setup

--- a/src/soca/Fields/Fields.cc
+++ b/src/soca/Fields/Fields.cc
@@ -32,15 +32,13 @@ namespace soca {
                  const util::DateTime & time):
     geom_(new Geometry(geom)), vars_(vars), time_(time)
   {
-    const eckit::Configuration * conf = &vars_.toFortran();
-    soca_field_create_f90(keyFlds_, geom_->toFortran(), &conf);
+    soca_field_create_f90(keyFlds_, geom_->toFortran(), vars_);
   }
   // -----------------------------------------------------------------------------
   Fields::Fields(const Fields & other, const bool copy)
     : geom_(other.geom_), vars_(other.vars_), time_(other.time_)
   {
-    const eckit::Configuration * conf = &vars_.toFortran();
-    soca_field_create_f90(keyFlds_, geom_->toFortran(), &conf);
+    soca_field_create_f90(keyFlds_, geom_->toFortran(), vars_);
     if (copy) {
       soca_field_copy_f90(keyFlds_, other.keyFlds_);
     } else {
@@ -51,24 +49,21 @@ namespace soca {
   Fields::Fields(const Fields & other)
     : geom_(other.geom_), vars_(other.vars_), time_(other.time_)
   {
-    const eckit::Configuration * conf = &vars_.toFortran();
-    soca_field_create_f90(keyFlds_, geom_->toFortran(), &conf);
+    soca_field_create_f90(keyFlds_, geom_->toFortran(), vars_);
     soca_field_copy_f90(keyFlds_, other.keyFlds_);
   }
   // -----------------------------------------------------------------------------
   Fields::Fields(const Fields & other, const Geometry & geom)
     : geom_(new Geometry(geom)), vars_(other.vars_), time_(other.time_)
   {
-    const eckit::Configuration * conf = &vars_.toFortran();
-    soca_field_create_f90(keyFlds_, geom_->toFortran(), &conf);
+    soca_field_create_f90(keyFlds_, geom_->toFortran(), vars_);
     soca_field_change_resol_f90(keyFlds_, other.keyFlds_);
   }
   // -----------------------------------------------------------------------------
   Fields::Fields(const Fields & other, const oops::Variables & vars)
     : geom_(other.geom_), vars_(vars), time_(other.time_)
   {
-    const eckit::Configuration * conf = &vars_.toFortran();
-    soca_field_create_f90(keyFlds_, geom_->toFortran(), &conf);
+    soca_field_create_f90(keyFlds_, geom_->toFortran(), vars_);
     soca_field_copy_f90(keyFlds_, other.keyFlds_);
   }
   // -----------------------------------------------------------------------------
@@ -132,8 +127,7 @@ namespace soca {
   void Fields::getValues(const ufo::Locations & locs,
                          const oops::Variables & vars,
                          ufo::GeoVaLs & gom) const {
-    const eckit::Configuration * conf = &vars.toFortran();
-    soca_field_interp_nl_f90(keyFlds_, locs.toFortran(), &conf,
+    soca_field_interp_nl_f90(keyFlds_, locs.toFortran(), vars,
                              gom.toFortran());
   }
 
@@ -142,8 +136,7 @@ namespace soca {
                          const oops::Variables & vars,
                          ufo::GeoVaLs & gom,
                          const GetValuesTraj & traj) const {
-    const eckit::Configuration * conf = &vars.toFortran();
-    soca_field_interp_nl_traj_f90(keyFlds_, locs.toFortran(), &conf,
+    soca_field_interp_nl_traj_f90(keyFlds_, locs.toFortran(), vars,
                                   gom.toFortran(), traj.toFortran());
   }
 
@@ -152,8 +145,7 @@ namespace soca {
                            const oops::Variables & vars,
                            ufo::GeoVaLs & gom,
                            const GetValuesTraj & traj) const {
-    const eckit::Configuration * conf = &vars.toFortran();
-    soca_field_interp_tl_f90(keyFlds_, locs.toFortran(), &conf,
+    soca_field_interp_tl_f90(keyFlds_, locs.toFortran(), vars,
                              gom.toFortran(), traj.toFortran());
   }
   // -----------------------------------------------------------------------------
@@ -161,8 +153,7 @@ namespace soca {
                            const oops::Variables & vars,
                            const ufo::GeoVaLs & gom,
                            const GetValuesTraj & traj) {
-    const eckit::Configuration * conf = &vars.toFortran();
-    soca_field_interp_ad_f90(keyFlds_, locs.toFortran(), &conf,
+    soca_field_interp_ad_f90(keyFlds_, locs.toFortran(), vars,
                              gom.toFortran(), traj.toFortran());
   }
   // -----------------------------------------------------------------------------

--- a/src/soca/Fields/soca_fields.interface.F90
+++ b/src/soca/Fields/soca_fields.interface.F90
@@ -13,7 +13,7 @@ use fckit_configuration_module, only: fckit_configuration
 use kinds, only: kind_real
 use unstructured_grid_mod, only: unstructured_grid, unstructured_grid_registry
 use datetime_mod, only: datetime, c_f_datetime
-use variables_mod, only: oops_vars, oops_vars_create
+use oops_variables_mod
 use ufo_locs_mod_c, only: ufo_locs_registry
 use ufo_locs_mod, only: ufo_locs
 use ufo_geovals_mod_c, only: ufo_geovals_registry
@@ -55,18 +55,18 @@ contains
 subroutine soca_field_create_c(c_key_self, c_key_geom, c_vars) bind(c,name='soca_field_create_f90')
   integer(c_int), intent(inout) :: c_key_self !< Handle to field
   integer(c_int),    intent(in) :: c_key_geom !< Geometry
-  type(c_ptr),       intent(in) :: c_vars     !< List of variables
+  type(c_ptr),value, intent(in) :: c_vars     !< List of variables
 
   type(soca_field), pointer :: self
   type(soca_geom),  pointer :: geom
-  type(oops_vars)           :: vars
+  type(oops_variables)      :: vars
 
   call soca_geom_registry%get(c_key_geom, geom)
   call soca_field_registry%init()
   call soca_field_registry%add(c_key_self)
   call soca_field_registry%get(c_key_self,self)
 
-  call oops_vars_create(fckit_configuration(c_vars), vars)
+  vars = oops_variables(c_vars)  
   call create(self, geom, vars)
 
 end subroutine soca_field_create_c
@@ -418,18 +418,18 @@ end subroutine soca_field_rms_c
 ! ------------------------------------------------------------------------------
 
 subroutine soca_field_interp_nl_c(c_key_fld,c_key_loc,c_vars,c_key_gom) bind(c,name='soca_field_interp_nl_f90')
-  integer(c_int), intent(in) :: c_key_fld
-  integer(c_int), intent(in) :: c_key_loc
-  type(c_ptr),    intent(in) :: c_vars     !< List of requested variables
-  integer(c_int), intent(in) :: c_key_gom
+  integer(c_int),     intent(in) :: c_key_fld
+  integer(c_int),     intent(in) :: c_key_loc
+  type(c_ptr), value, intent(in) :: c_vars     !< List of requested variables
+  integer(c_int),     intent(in) :: c_key_gom
 
   type(soca_field),  pointer :: fld
   type(ufo_locs),    pointer :: locs
   type(ufo_geovals), pointer :: gom
-  type(oops_vars)            :: vars
+  type(oops_variables)       :: vars
 
-  call oops_vars_create(fckit_configuration(c_vars), vars)
 
+  vars = oops_variables(c_vars)
   call soca_field_registry%get(c_key_fld,fld)
   call ufo_locs_registry%get(c_key_loc,locs)
   call ufo_geovals_registry%get(c_key_gom,gom)
@@ -443,17 +443,17 @@ end subroutine soca_field_interp_nl_c
 subroutine soca_field_interp_nl_traj_c(c_key_fld,c_key_loc,c_vars,c_key_gom,c_key_traj) bind(c,name='soca_field_interp_nl_traj_f90')
   integer(c_int),           intent(in) :: c_key_fld
   integer(c_int),           intent(in) :: c_key_loc
-  type(c_ptr),              intent(in) :: c_vars     !< List of requested variables
+  type(c_ptr), value,       intent(in) :: c_vars     !< List of requested variables
   integer(c_int),           intent(in) :: c_key_gom
   integer(c_int), optional, intent(in) :: c_key_traj !< Trajectory for interpolation/transforms
 
   type(soca_field),      pointer :: fld
   type(ufo_locs),        pointer :: locs
-  type(oops_vars)                :: vars
+  type(oops_variables)           :: vars
   type(ufo_geovals),     pointer :: gom
   type(soca_getvaltraj), pointer :: traj
 
-  call oops_vars_create(fckit_configuration(c_vars), vars)
+  vars = oops_variables(c_vars)
 
   call soca_field_registry%get(c_key_fld,fld)
   call ufo_locs_registry%get(c_key_loc,locs)
@@ -469,17 +469,17 @@ end subroutine soca_field_interp_nl_traj_c
 subroutine soca_field_interp_tl_c(c_key_fld,c_key_loc,c_vars,c_key_gom,c_key_traj) bind(c,name='soca_field_interp_tl_f90')
   integer(c_int),           intent(in) :: c_key_fld
   integer(c_int),           intent(in) :: c_key_loc
-  type(c_ptr),              intent(in) :: c_vars     !< List of requested variables
+  type(c_ptr), value,       intent(in) :: c_vars     !< List of requested variables
   integer(c_int),           intent(in) :: c_key_gom
   integer(c_int), optional, intent(in) :: c_key_traj !< Trajectory for interpolation/transforms
 
   type(soca_field),      pointer :: fld
   type(ufo_locs),        pointer :: locs
-  type(oops_vars)                :: vars
+  type(oops_variables)           :: vars
   type(ufo_geovals),     pointer :: gom
   type(soca_getvaltraj), pointer :: traj
 
-  call oops_vars_create(fckit_configuration(c_vars), vars)
+  vars = oops_variables(c_vars)
 
   call soca_field_registry%get(c_key_fld,fld)
   call ufo_locs_registry%get(c_key_loc,locs)
@@ -493,19 +493,19 @@ end subroutine soca_field_interp_tl_c
 ! ------------------------------------------------------------------------------
 
 subroutine soca_field_interp_ad_c(c_key_fld,c_key_loc,c_vars,c_key_gom,c_key_traj) bind(c,name='soca_field_interp_ad_f90')
-  integer(c_int), intent(in) :: c_key_fld
-  integer(c_int), intent(in) :: c_key_loc
-  type(c_ptr),    intent(in) :: c_vars     !< List of requested variables
-  integer(c_int), intent(in) :: c_key_gom
-  integer(c_int), intent(in) :: c_key_traj !< Trajectory for interpolation/transforms
+  integer(c_int),     intent(in) :: c_key_fld
+  integer(c_int),     intent(in) :: c_key_loc
+  type(c_ptr), value, intent(in) :: c_vars     !< List of requested variables
+  integer(c_int),     intent(in) :: c_key_gom
+  integer(c_int),     intent(in) :: c_key_traj !< Trajectory for interpolation/transforms
 
   type(soca_field),      pointer :: fld
   type(ufo_locs),        pointer :: locs
-  type(oops_vars)                :: vars
+  type(oops_variables)           :: vars
   type(ufo_geovals),     pointer :: gom
   type(soca_getvaltraj), pointer :: traj
 
-  call oops_vars_create(fckit_configuration(c_vars), vars)
+  vars = oops_variables(c_vars)
 
   call soca_field_registry%get(c_key_fld,fld)
   call ufo_locs_registry%get(c_key_loc,locs)

--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -17,7 +17,7 @@ use unstructured_grid_mod, only: unstructured_grid, &
 use datetime_mod, only: datetime, datetime_set
 use duration_mod, only: duration
 use kinds, only: kind_real
-use variables_mod, only: oops_vars
+use oops_variables_mod
 use fms_mod,    only: read_data, write_data, set_domain
 use fms_io_mod, only: fms_io_init, fms_io_exit, &
                       register_restart_field, restart_file_type, &
@@ -83,7 +83,9 @@ contains
 subroutine create_constructor(self, geom, vars)
   type(soca_field),          intent(inout) :: self
   type(soca_geom),  pointer, intent(inout) :: geom
-  type(oops_vars),              intent(in) :: vars
+  type(oops_variables),         intent(in) :: vars
+
+  integer :: i
 
   ! Allocate
   call soca_field_alloc(self, geom)
@@ -92,9 +94,11 @@ subroutine create_constructor(self, geom, vars)
   self%geom => geom
 
   ! Set fields numbers and names
-  self%nf   = vars%nv
+  self%nf   = vars%nvars()
   allocate(self%fldnames(self%nf))
-  self%fldnames(:)=vars%fldnames(:)
+  do i=1,self%nf
+    self%fldnames(i)=vars%variable(i)
+  end do 
 
   call check(self)
 

--- a/src/soca/Fortran.h
+++ b/src/soca/Fortran.h
@@ -60,7 +60,7 @@ namespace soca {
     //  Fields
     // -----------------------------------------------------------------------------
     void soca_field_create_f90(F90flds &, const F90geom &,
-                               const eckit::Configuration * const *);
+                               const oops::Variables &);
     void soca_field_delete_f90(F90flds &);
     void soca_field_copy_f90(const F90flds &, const F90flds &);
     void soca_field_zero_f90(const F90flds &);
@@ -85,21 +85,21 @@ namespace soca {
                                    const util::DateTime * const *);
     void soca_field_interp_nl_f90(const F90flds &,
                                   const F90locs &,
-                                  const eckit::Configuration * const *,
+                                  const oops::Variables &,
                                   const F90goms &);
     void soca_field_interp_nl_traj_f90(const F90flds &,
                                        const F90locs &,
-                                       const eckit::Configuration * const *,
+                                       const oops::Variables &,
                                        const F90goms &,
                                        const F90getvaltraj &);
     void soca_field_interp_tl_f90(const F90flds &,
                                   const F90locs &,
-                                  const eckit::Configuration * const *,
+                                  const oops::Variables &,
                                   const F90goms &,
                                   const F90getvaltraj &);
     void soca_field_interp_ad_f90(const F90flds &,
                                   const F90locs &,
-                                  const eckit::Configuration * const *,
+                                  const oops::Variables &,
                                   const F90goms &,
                                   const F90getvaltraj &);
 

--- a/src/soca/Fortran.h
+++ b/src/soca/Fortran.h
@@ -8,6 +8,8 @@
 #ifndef SOCA_FORTRAN_H_
 #define SOCA_FORTRAN_H_
 
+#include "oops/base/Variables.h"
+
 // Forward declarations
 namespace eckit {
   class Configuration;
@@ -138,7 +140,7 @@ namespace soca {
     // -----------------------------------------------------------------------------
     void soca_b_setup_f90(F90bmat &, const eckit::Configuration * const *,
                           const F90geom &, const F90flds &,
-                          const eckit::Configuration * const *);
+                          const oops::Variables &);
     void soca_b_delete_f90(F90bmat &);
     void soca_b_mult_f90(const F90bmat &, const F90flds &,
                          const F90flds &);

--- a/src/soca/Transforms/HorizFilt/HorizFilt.cc
+++ b/src/soca/Transforms/HorizFilt/HorizFilt.cc
@@ -26,12 +26,11 @@ namespace soca {
                  const eckit::Configuration & conf):
     geom_(new Geometry(geom)), vars_(conf), traj_(traj) {
     const eckit::Configuration * configc = &conf;
-    const eckit::Configuration * confvars = &vars_.toFortran();
     soca_horizfilt_setup_f90(keyFtnConfig_,
                              &configc,
                              geom_->toFortran(),
                              traj_.fields().toFortran(),
-                             &confvars);
+                             vars_);
 
     // Get number of iterations
     niter_ = configc->getInt("niter");

--- a/src/soca/Transforms/HorizFilt/HorizFiltFortran.h
+++ b/src/soca/Transforms/HorizFilt/HorizFiltFortran.h
@@ -9,6 +9,7 @@
 #define SOCA_TRANSFORMS_HORIZFILT_HORIZFILTFORTRAN_H_
 
 #include "soca/Fortran.h"
+#include "oops/base/Variables.h"
 
 // Forward declarations
 namespace eckit {
@@ -22,7 +23,7 @@ namespace soca {
                                   const eckit::Configuration * const *,
                                   const F90geom &,
                                   const F90flds &,
-                                  const eckit::Configuration * const *);
+                                  const oops::Variables &);
     void soca_horizfilt_delete_f90(F90balopmat &);
     void soca_horizfilt_mult_f90(const F90balopmat &,
                                  const F90flds &,

--- a/src/soca/Transforms/HorizFilt/soca_horizfilt.interface.F90
+++ b/src/soca/Transforms/HorizFilt/soca_horizfilt.interface.F90
@@ -11,7 +11,7 @@ module c_soca_horizfilt_mod
   use soca_geom_mod, only : soca_geom
   use soca_fields_mod_c, only: soca_field_registry
   use soca_fields_mod
-  use variables_mod
+  use oops_variables_mod
 
   implicit none
 
@@ -46,19 +46,19 @@ contains
     type(c_ptr),       intent(in) :: c_conf       !< The configuration
     integer(c_int),    intent(in) :: c_key_geom   !< Geometry
     integer(c_int),    intent(in) :: c_key_traj   !< Trajectory
-    type(c_ptr),       intent(in) :: c_vars       !< List of variables
+    type(c_ptr),value, intent(in) :: c_vars       !< List of variables
 
     type(soca_horizfilt_type), pointer :: self
     type(soca_geom),           pointer :: geom
     type(soca_field),          pointer :: traj
-    type(oops_vars)                    :: vars
+    type(oops_variables)               :: vars
 
     call soca_geom_registry%get(c_key_geom, geom)
     call soca_field_registry%get(c_key_traj, traj)
     call soca_horizfilt_registry%init()
     call soca_horizfilt_registry%add(c_key_self)
     call soca_horizfilt_registry%get(c_key_self, self)
-    call oops_vars_create(fckit_configuration(c_vars), vars)
+    vars = oops_variables(c_vars)
     call soca_horizfilt_setup(self, fckit_configuration(c_conf), geom, traj, vars)
 
   end subroutine c_soca_horizfilt_setup

--- a/src/soca/Transforms/HorizFilt/soca_horizfilt_mod.F90
+++ b/src/soca/Transforms/HorizFilt/soca_horizfilt_mod.F90
@@ -18,7 +18,7 @@ module soca_horizfilt_mod
   use tools_func, only: fit_func
   use type_mpl, only: mpl_type
   use random_mod
-  use variables_mod
+  use oops_variables_mod
 
   implicit none
 
@@ -29,7 +29,7 @@ module soca_horizfilt_mod
   !> Fortran derived type to hold configuration data for horizfilt
   type, public :: soca_horizfilt_type
      type(soca_field),         pointer :: bkg            !< Background field (or first guess)
-     type(oops_vars)                   :: vars           !< Apply filtering to vars
+     type(oops_variables)              :: vars           !< Apply filtering to vars
      real(kind=kind_real), allocatable :: wgh(:,:,:,:)   !< Filtering weight
      real(kind=kind_real) :: scale_flow  !< Used with "flow" filter, sea surface height decorrelation scale
      real(kind=kind_real) :: scale_dist
@@ -52,7 +52,7 @@ contains
     type(fckit_configuration),     intent(in) :: f_conf !< The configuration
     type(soca_geom),               intent(in) :: geom   !< Geometry
     type(soca_field),              intent(in) :: traj   !< Trajectory
-    type(oops_vars),               intent(in) :: vars   !< List of variables
+    type(oops_variables),          intent(in) :: vars   !< List of variables
 
     integer :: i, j, ii, jj
     real(kind=kind_real) :: dist(-1:1,-1:1), sum_w, r_dist, r_flow
@@ -139,8 +139,8 @@ contains
     allocate(dxi(self%isd:self%ied,self%jsd:self%jed))
     allocate(dxo(self%isd:self%ied,self%jsd:self%jed))
 
-    do ivar = 1, self%vars%nv
-       select case (trim(self%vars%fldnames(ivar)))
+    do ivar = 1, self%vars%nvars()
+       select case (trim(self%vars%variable(ivar)))
 
        case ("ssh")
           dxi = dxin%ssh(:,:)
@@ -195,8 +195,8 @@ contains
     allocate(dxi(self%isd:self%ied,self%jsd:self%jed))
     allocate(dxo(self%isd:self%ied,self%jsd:self%jed))
 
-    do ivar = 1, self%vars%nv
-       select case (trim(self%vars%fldnames(ivar)))
+    do ivar = 1, self%vars%nvars()
+       select case (trim(self%vars%variable(ivar)))
 
        case ("ssh")
           dxi = dxin%ssh(:,:)


### PR DESCRIPTION
## Description

This PR uses the fortran interface that was recently added to `oops::Variables` 
- all instances of `oops_vars` in the soca Fortran code have been replaced by `oops_variables`
- some minor syntax changes to accommodate that
- interface code updated to handle how `oops_variables` is created

These changes are needed so that JCSDA/oops/issues/337 can continue.

### Issue(s) addressed
- fixes JCSDA/soca/issues/258

## Testing

- Tested with GCC7.4 and Intel19
- no change in answers
