### PR TITLE
Add Cloud_Fraction for CRTM

### DIFF
--- a/test/testinput/hofx3dcrtm.yml
+++ b/test/testinput/hofx3dcrtm.yml
@@ -67,6 +67,7 @@ Observations:
       name: CRTM
       Absorbers: [H2O,O3,CO2]
       Clouds: [Water, Ice]
+      Cloud_Fraction: 1.0
       LinearObsOperator:
         Absorbers: [H2O,O3,CO2]
         Clouds: [Water]


### PR DESCRIPTION
## Description
The added line in `hofx3dcrtm.yaml` ensures that SOCA continues to use a Cloud_Fraction of 1.0 in the CRTM operator.  The new default behavior in UFO-CRTM is to request a geoval from the model.  That is implemented in the associated UFO PR with the same branch name.  No change in results is expected.

### Issue(s) addressed
- fixes soca-related portion of https://github.com/jcsda/ufo/issues/786

## Testing
Ctests not conducted yet.  Need help from soca developers.

## Dependencies
- requires JCSDA/ufo/tree/feature/cloud_frac
- waiting on JCSDA/ufo/pull/786

