### PR TITLE
update docker image location

### DIFF
--- a/.github/travisci/Dockerfile
+++ b/.github/travisci/Dockerfile
@@ -1,4 +1,4 @@
-FROM  jcsda/docker:latest
+FROM  jcsda/docker-gnu-openmpi-dev:latest
 
 RUN cd /usr/local/src \
     && curl -L -O https://github.com/ccache/ccache/releases/download/v3.7.4/ccache-3.7.4.tar.gz \


### PR DESCRIPTION
## Description

update to use the correct latest docker image so that TravisCI builds will now pass. Recent update to ufo/ioda require latest version of ecbuild


### Issue(s) addressed
- closes #278

## Testing
TravisCI tests now pass

