### PR TITLE
Masked interpolation

### DIFF
--- a/src/soca/GetValuesTraj/soca_getvaltraj_mod.F90
+++ b/src/soca/GetValuesTraj/soca_getvaltraj_mod.F90
@@ -17,6 +17,7 @@ public :: soca_getvaltraj
 type :: soca_getvaltraj
  integer                 :: nobs
  type(unstrc_interp)     :: horiz_interp
+ type(unstrc_interp)     :: horiz_interp_masked
  logical                 :: interph_initialized = .false.
 end type soca_getvaltraj
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -512,7 +512,7 @@ soca_add_test( NAME enshofx
 # variational methods
 soca_add_test( NAME 3dvar_soca
                EXE  soca_3dvar.x
-               TOL  2e-9 0
+               TOL  4e-9 0
                NOTRAPFPE
                TEST_DEPENDS test_soca_static_socaerror_init )
 

--- a/test/testref/3dhyb.test
+++ b/test/testref/3dhyb.test
@@ -1,21 +1,21 @@
 Test     : CostJb   : Nonlinear Jb = 0
-Test     : CostJo   : Nonlinear Jo(ADT) = 208.829, nobs = 100, Jo/n = 2.08829, err = 0.1
-Test     : CostFunction: Nonlinear J = 208.829
-Test     : RPCGMinimizer: reduction in residual norm = 0.78136
+Test     : CostJo   : Nonlinear Jo(ADT) = 224.622, nobs = 100, Jo/n = 2.24622, err = 0.1
+Test     : CostFunction: Nonlinear J = 224.622
+Test     : RPCGMinimizer: reduction in residual norm = 0.815545
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023982
-Test     :   hicen   min=   -0.000742   max=    2.923064   mean=    0.115987
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023984
+Test     :   hicen   min=   -0.000780   max=    2.923064   mean=    0.115987
 Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.563886
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.012461
-Test     :     ssh   min=   -2.358252   max=    0.928962   mean=   -0.289384
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.564742
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.012210
+Test     :     ssh   min=   -2.383124   max=    0.931272   mean=   -0.289616
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
 Test     :      lw   min=    0.000000   max=   88.036087   mean=   48.153824
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
-Test     : CostJb   : Nonlinear Jb = 2.822052
-Test     : CostJo   : Nonlinear Jo(ADT) = 159.478442, nobs = 100, Jo/n = 1.594784, err = 0.100000
-Test     : CostFunction: Nonlinear J = 162.300494
+Test     : CostJb   : Nonlinear Jb = 3.147605
+Test     : CostJo   : Nonlinear Jo(ADT) = 168.433109, nobs = 100, Jo/n = 1.684331, err = 0.100000
+Test     : CostFunction: Nonlinear J = 171.580714

--- a/test/testref/3dhybfgat.test
+++ b/test/testref/3dhybfgat.test
@@ -1,20 +1,20 @@
 Test     : CostJb   : Nonlinear Jb = 0
-Test     : CostJo   : Nonlinear Jo(ADT) = 69.5157, nobs = 31, Jo/n = 2.24244, err = 0.1
-Test     : CostFunction: Nonlinear J = 69.5157
-Test     : RPCGMinimizer: reduction in residual norm = 0.432536
+Test     : CostJo   : Nonlinear Jo(ADT) = 88.4792, nobs = 31, Jo/n = 2.85417, err = 0.1
+Test     : CostFunction: Nonlinear J = 88.4792
+Test     : RPCGMinimizer: reduction in residual norm = 0.49077
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023957
-Test     :   hicen   min=   -0.000552   max=    2.923064   mean=    0.115986
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.553586
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.013243
-Test     :     ssh   min=   -1.924163   max=    0.930556   mean=   -0.284728
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023960
+Test     :   hicen   min=   -0.000636   max=    2.923064   mean=    0.115986
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.555082
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.012501
+Test     :     ssh   min=   -1.924143   max=    0.934308   mean=   -0.285627
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     : CostJb   : Nonlinear Jb = 1.544661
-Test     : CostJo   : Nonlinear Jo(ADT) = 66.130996, nobs = 31, Jo/n = 2.133258, err = 0.100000
-Test     : CostFunction: Nonlinear J = 67.675657
+Test     : CostJb   : Nonlinear Jb = 2.165284
+Test     : CostJo   : Nonlinear Jo(ADT) = 72.971009, nobs = 31, Jo/n = 2.353904, err = 0.100000
+Test     : CostFunction: Nonlinear J = 75.136294

--- a/test/testref/3dvar_godas.test
+++ b/test/testref/3dvar_godas.test
@@ -1,33 +1,33 @@
 Test     : CostJb   : Nonlinear Jb = 0
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 35223.3, nobs = 201, Jo/n = 175.24, err = 0.364832
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 3405.35, nobs = 177, Jo/n = 19.2393, err = 0.358623
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 48.8811, nobs = 50, Jo/n = 0.977623, err = 1
-Test     : CostJo   : Nonlinear Jo(ADT) = 165.962, nobs = 95, Jo/n = 1.74697, err = 0.1
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 421.5, nobs = 202, Jo/n = 2.08663, err = 0.899571
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 5221.12, nobs = 218, Jo/n = 23.9501, err = 0.608197
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 379.749, nobs = 89, Jo/n = 4.26684, err = 0.1
-Test     : CostFunction: Nonlinear J = 44865.8
-Test     : RPCGMinimizer: reduction in residual norm = 0.165135
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 17276.6, nobs = 201, Jo/n = 85.9534, err = 0.364832
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 1567.5, nobs = 177, Jo/n = 8.85591, err = 0.358623
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.0095, nobs = 51, Jo/n = 0.96097, err = 1
+Test     : CostJo   : Nonlinear Jo(ADT) = 212.909, nobs = 95, Jo/n = 2.24115, err = 0.1
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.787, nobs = 206, Jo/n = 1.69314, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 355.419, nobs = 218, Jo/n = 1.63036, err = 0.608197
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 370.055, nobs = 89, Jo/n = 4.15792, err = 0.1
+Test     : CostFunction: Nonlinear J = 20180.3
+Test     : RPCGMinimizer: reduction in residual norm = 0.125615
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023946
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023945
 Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.115987
 Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544426
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018651
-Test     :     ssh   min=   -1.924808   max=    0.927297   mean=   -0.276765
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018508
+Test     :     ssh   min=   -1.924818   max=    0.927291   mean=   -0.276772
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :      sw   min= -225.090239   max=   -0.033703   mean= -110.030441
-Test     :     lhf   min=  -38.137283   max=  256.595459   mean=   64.433527
-Test     :     shf   min=  -58.949294   max=  201.374257   mean=    9.318214
-Test     :      lw   min=   -0.000000   max=   88.036091   mean=   48.153835
-Test     :      us   min=    0.004396   max=    0.019670   mean=    0.009436
-Test     : CostJb   : Nonlinear Jb = 0.887042
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 34495.550586, nobs = 201, Jo/n = 171.619655, err = 0.364832
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 3047.031351, nobs = 154, Jo/n = 19.785918, err = 0.356997
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 48.883312, nobs = 50, Jo/n = 0.977666, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 165.851284, nobs = 95, Jo/n = 1.745803, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 419.501323, nobs = 202, Jo/n = 2.076739, err = 0.899571
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 5219.376893, nobs = 218, Jo/n = 23.942096, err = 0.608197
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 378.301488, nobs = 89, Jo/n = 4.250579, err = 0.100000
-Test     : CostFunction: Nonlinear J = 43775.383278
+Test     :      sw   min= -225.094645   max=   -0.033703   mean= -110.030705
+Test     :     lhf   min=  -38.137288   max=  256.595607   mean=   64.433605
+Test     :     shf   min=  -58.949294   max=  201.374260   mean=    9.318216
+Test     :      lw   min=   -0.000000   max=   88.036091   mean=   48.153834
+Test     :      us   min=    0.004396   max=    0.019669   mean=    0.009428
+Test     : CostJb   : Nonlinear Jb = 0.731596
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 16668.369856, nobs = 201, Jo/n = 82.927213, err = 0.364832
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 1232.946942, nobs = 154, Jo/n = 8.006149, err = 0.356997
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.012443, nobs = 51, Jo/n = 0.961028, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 212.797293, nobs = 95, Jo/n = 2.239972, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 346.983203, nobs = 206, Jo/n = 1.684384, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 353.912276, nobs = 218, Jo/n = 1.623451, err = 0.608197
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 368.686290, nobs = 89, Jo/n = 4.142543, err = 0.100000
+Test     : CostFunction: Nonlinear J = 19233.439898

--- a/test/testref/3dvar_soca.test
+++ b/test/testref/3dvar_soca.test
@@ -1,32 +1,32 @@
 Test     : CostJb   : Nonlinear Jb = 0
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 19289.4, nobs = 177, Jo/n = 108.979, err = 0.358623
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 800.929, nobs = 130, Jo/n = 6.16099, err = 0.350474
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 48.8811, nobs = 50, Jo/n = 0.977623, err = 1
-Test     : CostJo   : Nonlinear Jo(ADT) = 147.468, nobs = 87, Jo/n = 1.69503, err = 0.1
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 421.5, nobs = 202, Jo/n = 2.08663, err = 0.899571
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 5221.12, nobs = 218, Jo/n = 23.9501, err = 0.608197
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 699.902, nobs = 89, Jo/n = 7.86407, err = 0.1
-Test     : CostFunction: Nonlinear J = 26629.2
-Test     : RPCGMinimizer: reduction in residual norm = 0.148175
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 15230, nobs = 177, Jo/n = 86.0451, err = 0.358623
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 779.647, nobs = 144, Jo/n = 5.41421, err = 0.358729
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.0095, nobs = 51, Jo/n = 0.96097, err = 1
+Test     : CostJo   : Nonlinear Jo(ADT) = 159.451, nobs = 92, Jo/n = 1.73316, err = 0.1
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.787, nobs = 206, Jo/n = 1.69314, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 355.419, nobs = 218, Jo/n = 1.63036, err = 0.608197
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 679.22, nobs = 89, Jo/n = 7.63169, err = 0.1
+Test     : CostFunction: Nonlinear J = 17601.5
+Test     : RPCGMinimizer: reduction in residual norm = 0.120732
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023538
+Test     :   cicen   min=    0.000000   max=    0.999977   mean=    0.023533
 Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544411
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.019160
-Test     :     ssh   min=   -1.924609   max=    0.927287   mean=   -0.276726
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544410
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.019065
+Test     :     ssh   min=   -1.924604   max=    0.927287   mean=   -0.276729
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :      sw   min= -225.091857   max=   -0.033703   mean= -110.030632
-Test     :     lhf   min=  -38.137474   max=  256.595452   mean=   64.433576
-Test     :     shf   min=  -58.949309   max=  201.374214   mean=    9.318213
-Test     :      lw   min=    0.000000   max=   88.036091   mean=   48.153834
-Test     :      us   min=    0.004396   max=    0.019669   mean=    0.009429
-Test     : CostJb   : Nonlinear Jb = 3.367819
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 17652.749338, nobs = 168, Jo/n = 105.075889, err = 0.359475
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 684.471790, nobs = 114, Jo/n = 6.004139, err = 0.349061
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 48.882440, nobs = 50, Jo/n = 0.977649, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 147.440293, nobs = 87, Jo/n = 1.694716, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 421.436453, nobs = 202, Jo/n = 2.086319, err = 0.899571
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 5219.908966, nobs = 218, Jo/n = 23.944537, err = 0.608197
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 694.617871, nobs = 89, Jo/n = 7.804695, err = 0.100000
-Test     : CostFunction: Nonlinear J = 24872.874972
+Test     :      sw   min= -225.095115   max=   -0.033703   mean= -110.030855
+Test     :     lhf   min=  -38.137471   max=  256.595622   mean=   64.433653
+Test     :     shf   min=  -58.949308   max=  201.374221   mean=    9.318215
+Test     :      lw   min=    0.000000   max=   88.036091   mean=   48.153833
+Test     :      us   min=    0.004396   max=    0.019668   mean=    0.009421
+Test     : CostJb   : Nonlinear Jb = 2.942472
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 13970.543740, nobs = 168, Jo/n = 83.157998, err = 0.359475
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 684.856668, nobs = 125, Jo/n = 5.478853, err = 0.355607
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.011505, nobs = 51, Jo/n = 0.961010, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 159.427140, nobs = 92, Jo/n = 1.732904, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.730476, nobs = 206, Jo/n = 1.692866, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 354.376648, nobs = 218, Jo/n = 1.625581, err = 0.608197
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 674.376719, nobs = 89, Jo/n = 7.577267, err = 0.100000
+Test     : CostFunction: Nonlinear J = 16244.265369

--- a/test/testref/3dvarfgat.test
+++ b/test/testref/3dvarfgat.test
@@ -1,32 +1,32 @@
 Test     : CostJb   : Nonlinear Jb = 0
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 4714.88, nobs = 48, Jo/n = 98.2266, err = 0.387632
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 506.012, nobs = 46, Jo/n = 11.0003, err = 0.38937
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 1.76976, nobs = 16, Jo/n = 0.11061, err = 1
-Test     : CostJo   : Nonlinear Jo(ADT) = 43.6318, nobs = 29, Jo/n = 1.50455, err = 0.1
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 3118.67, nobs = 48, Jo/n = 64.9722, err = 0.387632
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 329.931, nobs = 46, Jo/n = 7.17242, err = 0.38937
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.48256, nobs = 17, Jo/n = 0.146033, err = 1
+Test     : CostJo   : Nonlinear Jo(ADT) = 86.7406, nobs = 29, Jo/n = 2.99106, err = 0.1
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 41.1264, nobs = 31, Jo/n = 1.32666, err = 0.90894
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.7824, nobs = 33, Jo/n = 0.447953, err = 0.61043
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 260.382, nobs = 24, Jo/n = 10.8492, err = 0.1
-Test     : CostFunction: Nonlinear J = 5582.58
-Test     : RPCGMinimizer: reduction in residual norm = 0.577971
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 255.973, nobs = 24, Jo/n = 10.6655, err = 0.1
+Test     : CostFunction: Nonlinear J = 3849.7
+Test     : RPCGMinimizer: reduction in residual norm = 0.612864
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.026866
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.026809
 Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.546786
-Test     :    tocn   min=   -3.954794   max=   31.700465   mean=    6.009958
-Test     :     ssh   min=   -1.925768   max=    0.927250   mean=   -0.277344
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.547189
+Test     :    tocn   min=   -3.959348   max=   31.700465   mean=    6.008517
+Test     :     ssh   min=   -1.925784   max=    0.927224   mean=   -0.277521
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     : CostJb   : Nonlinear Jb = 882.923850
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 3937.389108, nobs = 48, Jo/n = 82.028940, err = 0.387632
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 383.450063, nobs = 40, Jo/n = 9.586252, err = 0.391743
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 1.756771, nobs = 16, Jo/n = 0.109798, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 43.001748, nobs = 29, Jo/n = 1.482819, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 40.248754, nobs = 31, Jo/n = 1.298347, err = 0.908940
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.165227, nobs = 33, Jo/n = 0.429249, err = 0.610430
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 121.896648, nobs = 24, Jo/n = 5.079027, err = 0.100000
-Test     : CostFunction: Nonlinear J = 5424.832169
+Test     : CostJb   : Nonlinear Jb = 767.960487
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 2415.777403, nobs = 48, Jo/n = 50.328696, err = 0.387632
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 239.913897, nobs = 40, Jo/n = 5.997847, err = 0.391743
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.460112, nobs = 17, Jo/n = 0.144712, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 85.256250, nobs = 29, Jo/n = 2.939871, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 40.248023, nobs = 31, Jo/n = 1.298323, err = 0.908940
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.164223, nobs = 33, Jo/n = 0.429219, err = 0.610430
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 120.063988, nobs = 24, Jo/n = 5.002666, err = 0.100000
+Test     : CostFunction: Nonlinear J = 3685.844383

--- a/test/testref/checkpointmodel.test
+++ b/test/testref/checkpointmodel.test
@@ -14,12 +14,12 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023946
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023945
 Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.115987
 Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544426
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018651
-Test     :     ssh   min=   -1.924808   max=    0.927297   mean=   -0.276765
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018508
+Test     :     ssh   min=   -1.924818   max=    0.927291   mean=   -0.276772
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
@@ -28,12 +28,12 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : output background: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023946
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023945
 Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.115987
 Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
-Test     :    socn   min=   10.721046   max=   38.000000   mean=   34.539807
-Test     :    tocn   min=   -1.800000   max=   31.700465   mean=    6.018790
-Test     :     ssh   min=   -1.924808   max=    0.927297   mean=   -0.276765
+Test     :    socn   min=   10.721046   max=   38.000000   mean=   34.539806
+Test     :    tocn   min=   -1.800000   max=   31.700465   mean=    6.018647
+Test     :     ssh   min=   -1.924818   max=    0.927291   mean=   -0.276772
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000

--- a/test/testref/hofx.test
+++ b/test/testref/hofx.test
@@ -25,11 +25,11 @@ Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
 Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
 Test     : H(x): 
-Test     : CoolSkin nobs= 21 Min=2.304112, Max=24.874244, RMS=21.357216
-Test     : SeaSurfaceTemp nobs= 21 Min=5.767587, Max=29.793238, RMS=26.056270
-Test     : SeaSurfaceSalinity nobs= 9 Min=22.913254, Max=35.661500, RMS=33.533055
-Test     : ADT nobs= 14 Min=-0.323268, Max=1.487402, RMS=0.934586
+Test     : CoolSkin nobs= 21 Min=2.304112, Max=24.874244, RMS=21.397557
+Test     : SeaSurfaceTemp nobs= 21 Min=5.767587, Max=29.793238, RMS=26.104151
+Test     : SeaSurfaceSalinity nobs= 9 Min=33.356994, Max=35.661500, RMS=34.492936
+Test     : ADT nobs= 14 Min=-0.712938, Max=1.495788, RMS=1.001840
 Test     : InsituTemperature nobs= 10 Min=8.008760, Max=30.370147, RMS=23.734703
 Test     : InsituSalinity nobs= 10 Min=34.156561, Max=35.701557, RMS=35.026666
-Test     : SeaIceFraction nobs= 14 Min=0.000004, Max=0.999981, RMS=0.656201
+Test     : SeaIceFraction nobs= 14 Min=0.000004, Max=0.999981, RMS=0.683195
 Test     : End H(x)

--- a/test/testref/hofx3d.test
+++ b/test/testref/hofx3d.test
@@ -1,4 +1,4 @@
-Test     : Initial state:
+Test     : Initial state: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023503
 Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
@@ -11,10 +11,10 @@ Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
 Test     :      lw   min=   -0.000000   max=   88.036087   mean=   48.153824
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
-Test     : H(x): CoolSkin nobs= 201 Min=-4.375751, Max=25.239587, RMS=19.221059
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.649473, RMS=23.201498
-Test     : SeaSurfaceSalinity nobs= 100 Min=15.709018, Max=37.087544, RMS=33.641924
-Test     : ADT nobs= 100 Min=-1.251928, Max=1.420394, RMS=0.739929
-Test     : InsituTemperature nobs= 218 Min=5.953393, Max=30.431111, RMS=21.105740
-Test     : InsituSalinity nobs= 218 Min=29.352443, Max=35.992907, RMS=34.714945
-Test     : SeaIceFraction nobs= 100 Min=0.000000, Max=1.000000, RMS=0.631355
+Test     : H(x): CoolSkin nobs= 201 Min=-4.375751, Max=25.239587, RMS=20.067013
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.649473, RMS=24.170310
+Test     : SeaSurfaceSalinity nobs= 100 Min=31.245713, Max=37.087544, RMS=34.753009
+Test     : ADT nobs= 100 Min=-1.250816, Max=1.421506, RMS=0.757217
+Test     : InsituTemperature nobs= 218 Min=7.832734, Max=30.431111, RMS=21.287619
+Test     : InsituSalinity nobs= 218 Min=34.160244, Max=35.992907, RMS=35.036438
+Test     : SeaIceFraction nobs= 100 Min=0.000000, Max=1.000000, RMS=0.694504


### PR DESCRIPTION
## Description

horizontal interpolation was not taking the mask into consideration before, meaning a lot of zeros were getting interpolated in when in a gridbox near the coast.

This PR creates two sets of horizontal interpolation weights, one for masked grids, and one for unmasked. All fields except for `sea_area_fraction` are now interpolated using the masked grid.

The `hofx` and `3dvar` output looks happier now, minimum sss for hofx3d is now a more realistic 33psu (was 15psu), same thing for insitu S and SST values. 

I will do a quick test with RTS (real-time soca) before merging this to confirm all is well