### PR TITLE
add atlas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,12 @@ env:
     - BUNDLE_URL="https://github.com/JCSDA/soca-bundle.git"
     - MAIN_REPO=soca
     - LIB_REPOS="fms cvmix geokdtree mom6_da_hooks gsw mom6 crtm
-                 fckit saber oops ioda ufo ioda-converters soca-config"
+                 fckit atlas saber oops ioda ufo ioda-converters soca-config"
     - BUILD_OPT=""
     - BUILD_OPT_CRTM="-DBUILD_CRTM=ON"
     - BUILD_OPT_OOPS="-DENABLE_OOPS_TOYMODELS=OFF"
     - BUILD_OPT_SOCA="-DSOCA_TESTS_FORC_DEFAULT_TOL=ON -DCRTM_FIX_DIR=../../repo.src/crtm/fix"
-    - MATCH_REPOS="saber oops ioda ioda-converters ufo soca soca-config"
+    - MATCH_REPOS="atlas saber oops ioda ioda-converters ufo soca soca-config"
     - LFS_REPOS="crtm"
 
     # secure token used to push changes to GitHub (user: travissluka)


### PR DESCRIPTION
## Description

Add atlas to the travis CI tests



## Testing

Travis CI should pass now


## Dependencies

requires https://github.com/JCSDA/soca-bundle/pull/19 to be merged as well
