### PR TITLE
soca works without cicen

### DIFF
--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -794,11 +794,13 @@ subroutine soca_fields_read(fld, f_conf, vdate)
   ! iread = 1 (state) or 3 (increment): Read restart file
   if ((iread==1).or.(iread==3)) then
     ! Read sea-ice
-    if(.not. f_conf%get("seaice_model", seaice_model)) seaice_model = "sis2"
+    seaice_model = ""
     if(f_conf%get("ice_filename", str)) then
       call f_conf%get_or_die("basename", basename)
       filename = trim(basename)//trim(str)
+      if(.not. f_conf%get("seaice_model", seaice_model)) seaice_model = "sis2"
     end if
+
     select case(seaice_model)
     case ('sis2')
       call fms_io_init()
@@ -868,7 +870,6 @@ subroutine soca_fields_read(fld, f_conf, vdate)
       end do
 
     end select
-
 
     ! filename for ocean
     call f_conf%get_or_die("basename", str)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ list( APPEND soca_test_input
   testinput/static_socaerror_init.yml
   testinput/static_socaerror_test.yml
   testinput/varchange_balance.yml
+  testinput/varchange_balance_TSSSH.yml
   testinput/varchange_bkgerrfilt.yml
   testinput/varchange_bkgerrgodas.yml
   testinput/varchange_bkgerrsoca.yml
@@ -398,6 +399,10 @@ soca_add_test( NAME linearmodel
                             test_soca_static_socaerror_init )
 
 soca_add_test( NAME varchange_balance
+               SRC  TestVariableChange.cc
+               TEST_DEPENDS test_soca_gridgen )
+
+soca_add_test( NAME varchange_balance_TSSSH
                SRC  TestVariableChange.cc
                TEST_DEPENDS test_soca_gridgen )
 

--- a/test/testinput/varchange_balance_TSSSH.yml
+++ b/test/testinput/varchange_balance_TSSSH.yml
@@ -1,0 +1,27 @@
+test_framework_runtime_config: "--log_level=test_suite"
+
+Geometry:
+  num_ice_cat: 5
+  num_ice_lev: 4
+  num_sno_lev: 1
+  read_soca_grid: grid
+
+State:
+  read_from_file: 1
+  date: 2018-04-15T00:00:00Z
+  basename: ./INPUT/
+  ocn_filename: MOM.res.nc
+  variables: &soca_vars [socn, tocn, ssh, hocn]
+
+LinearVariableChangeTests:
+- varchange: BalanceSOCA
+  toleranceInverse: 1e-12
+  testinverse: 1
+  dsdtmax: 1.0
+  dsdzmin: 3.0e-3
+  dtdzmin: 1.0e-3
+  nlayers: 10
+  inputVariables:
+    variables: *soca_vars
+  outputVariables:
+    variables: *soca_vars


### PR DESCRIPTION
## Description

I know that ice is awesome, but soca-realtime is currently not using ice in its 3dvar. This PR restores the capability to run soca without ice.
- switched a line in `soca_fields_mod` so that it doesn't try to read an ice restart file if no filename is given
- added `%has('cicen')` statements to the balance operator so that it skips sections of the code if no `cicen` is given

## Testing

- A new test (`test_soca_varchange_balance_TSSSH`) was added that tests only the T/S/SSH parts of the balance. (similarly, when U/V balance is eventually added, a `_TSSSHUV` test should be added)
- no other tests are impacted, passes on gcc and intel19, confirmed to be working with soca-realtime


