### PR TITLE
u and v added along with corresponding geometry

### DIFF
--- a/src/soca/Fields/soca_fields.interface.F90
+++ b/src/soca/Fields/soca_fields.interface.F90
@@ -558,8 +558,8 @@ subroutine soca_fieldnum_c(c_key_fld, nx, ny, nzo, nzi, ncat, nf) bind(c,name='s
 
   call soca_field_registry%get(c_key_fld,fld)
 
-  nx = fld%geom%nx
-  ny = fld%geom%ny
+  nx = size(fld%geom%lon,1)
+  ny = size(fld%geom%lon,2)
   nzo = fld%geom%nzo
   nzi = fld%geom%nzi
   ncat = fld%geom%ncat

--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -977,7 +977,7 @@ subroutine soca_fields_read(fld, f_conf, vdate)
             ! TODO remove hardcoded variable names here
             ! TODO Add u and v. Remapping u and v will require interpolating h 
             case ('tocn','socn')
-              if (field%mask(i,j).eq.1) then
+              if (associated(field%mask) .and. field%mask(i,j).eq.1) then
                 varocn_ij = field%val(i,j,:)
                 call remapping_core_h(remapCS, nz, h_common_ij, varocn_ij,&
                       &nz, hocn_ij, varocn2_ij)

--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -130,6 +130,7 @@ subroutine soca_field_copy(self, rhs)
   self%cf_name = rhs%cf_name
   self%io_name = rhs%io_name
   self%io_file = rhs%io_file
+  self%mask => rhs%mask
 end subroutine soca_field_copy
 
 

--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -43,7 +43,6 @@ public :: soca_fields, soca_field
 type :: soca_field
   character(len=:),     allocatable :: name       !< the internally used name of the field
   integer                           :: nz         !< the number of levels
-  logical                           :: masked     !< if true, land mask should be applied
   real(kind=kind_real), allocatable :: val(:,:,:) !< the actual data
   real(kind=kind_real),     pointer :: mask(:,:) => null() !< field mask
   character(len=:),     allocatable :: cf_name    !< the (optional) name needed by UFO
@@ -180,28 +179,22 @@ subroutine soca_fields_init_vars(self, vars)
     self%fields(i)%name = trim(vars(i))
 
     ! determine number of levels, and if masked
-    self%fields(i)%masked = .false.
     select case(self%fields(i)%name)
     case ('tocn','socn','hocn')
       nz = self%geom%nzo
-      self%fields(i)%masked = .true.
-      self%fields(i)%mask =>self%geom%mask2d
+      self%fields(i)%mask => self%geom%mask2d
     case ('uocn')
       nz = self%geom%nzo
-      self%fields(i)%masked = .true.
-      self%fields(i)%mask =>self%geom%mask2du
+      self%fields(i)%mask => self%geom%mask2du
     case ('vocn')
       nz = self%geom%nzo
-      self%fields(i)%masked = .true.
-      self%fields(i)%mask =>self%geom%mask2dv
+      self%fields(i)%mask => self%geom%mask2dv
     case ('hicen','hsnon', 'cicen')
       nz = self%geom%ncat
-      self%fields(i)%masked = .true.
-      self%fields(i)%mask =>self%geom%mask2d
+      self%fields(i)%mask => self%geom%mask2d
     case ('ssh')
       nz = 1
-      self%fields(i)%masked = .true.
-      self%fields(i)%mask =>self%geom%mask2d
+      self%fields(i)%mask => self%geom%mask2d
     case ('sw', 'lhf', 'shf', 'lw', 'us')
       nz = 1
     case default
@@ -518,7 +511,7 @@ subroutine soca_fields_random(self)
   ! mask out land, set to zero
   do i=1,size(self%fields)
     field => self%fields(i)
-    if (.not. field%masked ) cycle
+    if (.not. associated(field%mask) ) cycle
     do z=1,field%nz
       field%val(:,:,z) = field%val(:,:,z) * field%mask(:,:)
     end do

--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -45,7 +45,7 @@ type :: soca_field
   integer                           :: nz         !< the number of levels
   logical                           :: masked     !< if true, land mask should be applied
   real(kind=kind_real), allocatable :: val(:,:,:) !< the actual data
-  real(kind=kind_real),     pointer :: mask(:,:)  !< field mask
+  real(kind=kind_real),     pointer :: mask(:,:) => null() !< field mask
   character(len=:),     allocatable :: cf_name    !< the (optional) name needed by UFO
   character(len=:),     allocatable :: io_name    !< the (optional) name use in the restart IO
   character(len=:),     allocatable :: io_file    !< the (optional) restart file domain

--- a/src/soca/Model/soca_model.interface.F90
+++ b/src/soca/Model/soca_model.interface.F90
@@ -60,8 +60,8 @@ subroutine c_soca_setup(c_conf, c_key_geom, c_key_model) bind (c,name='soca_setu
   call soca_model_registry%get(c_key_model, model)
 
   ! Get local grid size
-  model%nx = geom%nx
-  model%ny = geom%ny
+  model%nx =  size(geom%lon,1)
+  model%ny = size(geom%lon,2)
 
   ! Setup time step
   call f_conf%get_or_die("tstep", str)

--- a/test/testinput/forecast_mom6.yml
+++ b/test/testinput/forecast_mom6.yml
@@ -8,7 +8,7 @@ model:
   name: SOCA
   tstep: PT1H
   advance_mom6: 1
-  variables: [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
+  variables: [cicen, hicen, socn, tocn, ssh, hocn, uocn, vocn, sw, lhf, shf, lw, us]
 
 initial:
   read_from_file: 1

--- a/test/testref/forecast_mom6.test
+++ b/test/testref/forecast_mom6.test
@@ -1,4 +1,4 @@
-Test     : Initial state: 
+Test     : Initial state:
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023503
 Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
@@ -6,19 +6,23 @@ Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
 Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000241
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002019
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     : Final state: 
+Test     : Final state:
 Test     :   Valid time: 2018-04-15T06:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023503
 Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
-Test     :    socn   min=   10.718537   max=   40.441636   mean=   34.545194
-Test     :    tocn   min=   -1.888294   max=   31.764659   mean=    6.018086
+Test     :    socn   min=   10.718537   max=   40.441636   mean=   34.545192
+Test     :    tocn   min=   -1.888294   max=   31.764659   mean=    6.018085
 Test     :     ssh   min=   -1.905847   max=    0.908715   mean=   -0.276542
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628049
+Test     :    uocn   min=   -0.837073   max=    0.678109   mean=    0.000408
+Test     :    vocn   min=   -0.894579   max=    0.944747   mean=    0.000457
 Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225


### PR DESCRIPTION
## Description
Addition of u,v in field and model and associated geometry (lon, lat and mask).
Slight change of answer in the forecast test when u and v are used and passed between soca and mom6 (type change is not reversible).

### Issue(s) addressed
This is 1 of many pr's that are needed to address epic #282.
closes #283
closes #284  

## Testing
Tested with singularity/gcc and hera/intel18
Changes are covered in the forecast_mom6 test
