### PR TITLE
fix garbage values in the halos

### DIFF
--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -787,14 +787,15 @@ subroutine soca_fields_read(fld, f_conf, vdate)
      call f_conf%get_or_die("remap_filename", str)
      remap_filename = str
      allocate(h_common(isd:ied,jsd:jed,nz))
+     h_common = 0.0_kind_real
 
      ! Read common vertical coordinate from file
      call fms_io_init()
-     idr = register_restart_field(ocean_remap_restart, remap_filename, 'h', hocn%val(:,:,:), &
+     idr = register_restart_field(ocean_remap_restart, remap_filename, 'h', h_common, &
           domain=fld%geom%Domain%mpp_domain)
      call restore_state(ocean_remap_restart, directory='')
+     call free_restart_type(ocean_remap_restart)
      call fms_io_exit()
-     h_common = hocn%val
   end if
 
   ! iread = 0: Invent state
@@ -823,6 +824,7 @@ subroutine soca_fields_read(fld, f_conf, vdate)
         select case(fld%fields(i)%name)
         case ('cicen')
           allocate(cicen_val(isd:ied, jsd:jed, fld%fields(i)%nz + 1))
+          cicen_val = 0.0_kind_real
           idr = register_restart_field(ice_restart, filename, 'part_size', &
                   cicen_val, &
                   domain=fld%geom%Domain%mpp_domain)
@@ -933,7 +935,11 @@ subroutine soca_fields_read(fld, f_conf, vdate)
     end do
 
     call restore_state(ocean_restart, directory='')
-    if (read_sfc) call restore_state(sfc_restart, directory='')
+    call free_restart_type(ocean_restart)
+    if (read_sfc) then
+      call restore_state(sfc_restart, directory='')
+      call free_restart_type(sfc_restart)
+    end if
     call fms_io_exit()
 
     ! Indices for compute domain
@@ -970,7 +976,7 @@ subroutine soca_fields_read(fld, f_conf, vdate)
             field => fld%fields(n)
             select case(field%name)
             ! TODO remove hardcoded variable names here
-            ! TODO Add u and v. Remapping u and v will require interpolating h 
+            ! TODO Add u and v. Remapping u and v will require interpolating h
             case ('tocn','socn')
               if (associated(field%mask) .and. field%mask(i,j).eq.1) then
                 varocn_ij = field%val(i,j,:)
@@ -986,17 +992,13 @@ subroutine soca_fields_read(fld, f_conf, vdate)
       end do
       hocn%val = h_common
       deallocate(h_common_ij, hocn_ij, varocn_ij, varocn2_ij)
+      call end_remapping(remapCS)
     end if
-    call end_remapping(remapCS)
 
     ! Update halo
     do n=1,size(fld%fields)
       field => fld%fields(n)
-      if (field%nz == 1) then
-        call mpp_update_domains(field%val(:,:,1), fld%geom%Domain%mpp_domain)
-      else
-        call mpp_update_domains(field%val, fld%geom%Domain%mpp_domain)
-      end if
+      call mpp_update_domains(field%val, fld%geom%Domain%mpp_domain)
     end do
 
     ! Set vdate if reading state

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -434,7 +434,6 @@ soca_add_test( NAME varchange_vertconv
 #-------------------------------------------------------------------------------
 soca_add_test( NAME ensvariance
                EXE  soca_ensvariance.x
-               NOTRAPFPE
                TEST_DEPENDS test_soca_enspert )
 
 soca_add_test( NAME parameters_bump_loc
@@ -444,7 +443,6 @@ soca_add_test( NAME parameters_bump_loc
 
 soca_add_test( NAME ensrecenter
                EXE  soca_ensrecenter.x
-               NOTRAPFPE
                TEST_DEPENDS test_soca_enspert )
 
 # TODO the next couple of tests are a little slow.
@@ -465,17 +463,14 @@ soca_add_test( NAME ensrecenter
 
 soca_add_test( NAME dirac_soca_cov
                EXE  soca_dirac.x
-               NOTRAPFPE
                TEST_DEPENDS test_soca_static_socaerror_init)
 
 soca_add_test( NAME dirac_socahyb_cov
                EXE  soca_dirac.x
-               NOTRAPFPE
                TEST_DEPENDS test_soca_parameters_bump_loc)
 
 soca_add_test( NAME dirac_horizfilt
                EXE  soca_dirac.x
-               NOTRAPFPE
                TEST_DEPENDS test_soca_static_socaerror_init)
 
 #ecbuild_add_test( TARGET  test_soca_localization


### PR DESCRIPTION
## Description

SIGFPE trapping was disabled in some of the ctests because of garbage being placed in the halos. This fixes that and re-enables trapping in the affected tests.

Turns out the temporary `cicen_val` was not initialized to zero, and so even after the halos were updated there was still garbage in the southern halos (because the southern halos aren't connected to anything!  doh🤦‍♂ )

`free_restart_type` was also thrown into a couple of places to silence FMS complaints

### Issue(s) addressed

- fixes #240 
- fixes #242 

## Testing
ctest was run about a dozen times with both gcc/debug and intel19/release, and no random SIGPFE errors were seen anymore
