### PR TITLE
combine run/compare steps in ctests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -283,6 +283,9 @@ function(soca_add_test)
     LIST(GET ARG_TOL 0 TOL_F)
     LIST(GET ARG_TOL 1 TOL_I)
 
+    # find the MPI command
+    set(MPI_CMD "${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MPI}")
+
     # running a soca executable.
     # This is run with the run wrapper, which will also optionally
     # run the comapre.py script afterwards
@@ -297,7 +300,7 @@ function(soca_add_test)
                               COMPARE_TESTNAME=${ARG_NAME}
                               COMPARE_TOL_F=${TOL_F}
                               COMPARE_TOL_I=${TOL_I}
-                              MPI_PES=${MPI}
+                              MPI_CMD=${MPI_CMD}
                               SKIP_COMPARE=${ARG_NOCOMPARE}
                       DEPENDS ${ARG_EXE}
                       TEST_DEPENDS ${ARG_TEST_DEPENDS})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -280,28 +280,28 @@ function(soca_add_test)
     set ( ARG_NOCOMPARE TRUE)
 
   else()
-    # running a soca executable
+    LIST(GET ARG_TOL 0 TOL_F)
+    LIST(GET ARG_TOL 1 TOL_I)
+
+    # running a soca executable.
+    # This is run with the run wrapper, which will also optionally
+    # run the comapre.py script afterwards
     ecbuild_add_test( TARGET  test_soca_${ARG_NAME}
-                      TYPE    EXE
-                      COMMAND "${CMAKE_BINARY_DIR}/bin/${ARG_EXE}"
-                      ARGS    ${CONFIG_FILE}
-                              testoutput/${ARG_NAME}.log
-                      MPI     ${MPI}
-                      ENVIRONMENT ${TRAPFPE_ENV}
+                      TYPE    SCRIPT
+                      COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test_wrapper.sh"
+                      ARGS    "${CMAKE_BINARY_DIR}/bin/${ARG_EXE}"
+                              ${CONFIG_FILE}
+                      ENVIRONMENT
+                              ${TRAPFPE_ENV}
+                              COMPARE_SCRIPT=${COMPARE_BIN}
+                              COMPARE_TESTNAME=${ARG_NAME}
+                              COMPARE_TOL_F=${TOL_F}
+                              COMPARE_TOL_I=${TOL_I}
+                              MPI_PES=${MPI}
+                              SKIP_COMPARE=${ARG_NOCOMPARE}
                       DEPENDS ${ARG_EXE}
                       TEST_DEPENDS ${ARG_TEST_DEPENDS})
   endif()
-
-  # compare the answers, if desired
-  IF(NOT ARG_NOCOMPARE)
-    ecbuild_add_test( TARGET  test_soca_${ARG_NAME}_compare
-                      TYPE    SCRIPT
-                      COMMAND "${COMPARE_BIN}"
-                      ARGS    testoutput/${ARG_NAME}.log
-                              testref/${ARG_NAME}.test
-                              ${ARG_TOL}
-                     TEST_DEPENDS test_soca_${ARG_NAME})
-  ENDIF()
 endfunction()
 
 

--- a/test/test_wrapper.sh
+++ b/test/test_wrapper.sh
@@ -5,7 +5,7 @@ echo ""
 echo "==============================================================================="
 echo "Running test executable"
 echo "==============================================================================="
-mpirun -n $MPI_PES $1 $2 testoutput/${COMPARE_TESTNAME}.log
+${MPI_CMD} $1 $2 testoutput/${COMPARE_TESTNAME}.log
 e=$?
 if [[ $e -gt 0 ]]; then
     echo -e "Failed to run executable. Error code: $e \n"

--- a/test/test_wrapper.sh
+++ b/test/test_wrapper.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# run the executable
+echo ""
+echo "==============================================================================="
+echo "Running test executable"
+echo "==============================================================================="
+mpirun -n $MPI_PES $1 $2 testoutput/${COMPARE_TESTNAME}.log
+e=$?
+if [[ $e -gt 0 ]]; then
+    echo -e "Failed to run executable. Error code: $e \n"
+    exit $e
+fi
+
+# run compare, if needed
+if [[ $SKIP_COMPARE == "FALSE" ]]; then
+    echo ""
+    echo "==============================================================================="
+    echo "Running compare script"
+    echo "==============================================================================="
+
+    $COMPARE_SCRIPT testoutput/${COMPARE_TESTNAME}.log testref/${COMPARE_TESTNAME}.test ${COMPARE_TOL_F} ${COMPARE_TOL_I}
+    e=$?
+    if [[ $e -gt 0 ]]; then
+        echo -e "Failed in the COMPARE step. Error code: $e \n"
+        exit $e
+    fi
+    echo -e "PASSED \n"
+fi


### PR DESCRIPTION
## Description

@ytremolet  wisely pointed out that we shouldn't have separate `run` and `compare` steps of the ctests. Combining these two steps into one lets us use `cmake --rerun-failed` now. 

A `test_wrapper.sh` script was added that is called by ctests and is responsible for running the run and compare steps together.