### PR TITLE
fix issue with ufo 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
     - BUILD_OPT=""
     - BUILD_OPT_CRTM="-DBUILD_CRTM=ON"
     - BUILD_OPT_OOPS="-DENABLE_OOPS_TOYMODELS=OFF"
+    - BUILD_OPT_UFO="-DLOCAL_PATH_TESTFILES_IODA=NONE"
     - BUILD_OPT_SOCA="-DSOCA_TESTS_FORC_DEFAULT_TOL=ON -DCRTM_FIX_DIR=../../repo.src/crtm/fix"
     - MATCH_REPOS="atlas saber oops ioda ioda-converters ufo soca soca-config"
     - LFS_REPOS="crtm"


### PR DESCRIPTION
## Description

A work around to https://github.com/JCSDA/ufo/pull/835 breaking TravisCI builds for SOCA

`LOCAL_PATH_TESTFILES_IODA` is set to a nonsense value so that the sections of the UFO `CMakeLists.txt` that are having problems are skipped.

## Testing

TravisCI tests now work.
