### PR TITLE
Feature/colocate

### DIFF
--- a/src/mains/AddIncrement.cc
+++ b/src/mains/AddIncrement.cc
@@ -1,0 +1,17 @@
+/*
+ * (C) Copyright 2020-2020 UCAR.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#include "soca/Traits.h"
+#include "oops/runs/AddIncrement.h"
+#include "oops/runs/Run.h"
+
+int main(int argc,  char ** argv) {
+  oops::Run run(argc, argv);
+  oops::AddIncrement<soca::Traits> addincrement;
+  run.execute(addincrement);
+  return 0;
+}

--- a/src/mains/CMakeLists.txt
+++ b/src/mains/CMakeLists.txt
@@ -72,3 +72,8 @@ ecbuild_add_executable( TARGET  soca_convertstate.x
                         SOURCES ConvertState.cc
                         LIBS    soca
                       )
+
+ecbuild_add_executable( TARGET  soca_addincrement.x
+                        SOURCES AddIncrement.cc
+                        LIBS    soca
+                      )

--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -26,6 +26,10 @@ use soca_geom_mod, only : soca_geom
 use soca_fieldsutils_mod, only: soca_genfilename, fldinfo
 use soca_utils, only: soca_mld
 
+use horiz_interp_mod, only : horiz_interp_type
+use horiz_interp_spherical_mod, only : horiz_interp_spherical_new, horiz_interp_spherical
+use tools_const, only: deg2rad
+
 implicit none
 
 private
@@ -40,6 +44,9 @@ type :: soca_field
   integer                           :: nz         !< the number of levels
   real(kind=kind_real), allocatable :: val(:,:,:) !< the actual data
   real(kind=kind_real),     pointer :: mask(:,:) => null() !< field mask
+  real(kind=kind_real),     pointer :: lon(:,:) => null()  !< field lon
+  real(kind=kind_real),     pointer :: lat(:,:) => null()  !< field lat
+  character(len=1)                  :: c_grid_loc !< "h", "u" or "v"
   character(len=:),     allocatable :: cf_name    !< the (optional) name needed by UFO
   character(len=:),     allocatable :: io_name    !< the (optional) name use in the restart IO
   character(len=:),     allocatable :: io_file    !< the (optional) restart file domain
@@ -50,6 +57,8 @@ contains
 
   procedure :: check_congruent => soca_field_check_congruent
   procedure :: update_halo     => soca_field_update_halo
+  procedure :: stencil_interp  => soca_field_stencil_interp
+
 end type soca_field
 
 ! ------------------------------------------------------------------------------
@@ -90,6 +99,7 @@ contains
 
   ! misc
   procedure :: update_halos => soca_fields_update_halos
+  procedure :: colocate  => soca_fields_colocate
 
 end type soca_fields
 
@@ -119,7 +129,6 @@ subroutine soca_field_copy(self, rhs)
   self%mask => rhs%mask
 end subroutine soca_field_copy
 
-
 ! ------------------------------------------------------------------------------
 !
 subroutine soca_field_update_halo(self, geom)
@@ -130,6 +139,25 @@ subroutine soca_field_update_halo(self, geom)
   call mpp_update_domains(self%val, geom%Domain%mpp_domain)
 end subroutine soca_field_update_halo
 
+! ------------------------------------------------------------------------------
+!
+subroutine soca_field_stencil_interp(self, geom, interp2d)
+  class(soca_field),     intent(inout) :: self
+  type(soca_geom), pointer, intent(in) :: geom
+  type(horiz_interp_type),  intent(in) :: interp2d
+
+  integer :: k
+  real(kind=kind_real), allocatable :: val(:,:,:)
+
+  allocate(val, mold=self%val)
+  val = self%val
+  do k = 1, self%nz
+     call horiz_interp_spherical(interp2d, &
+          & val(geom%isd:geom%ied, geom%jsd:geom%jed,k), &
+          & self%val(geom%isc:geom%iec, geom%jsc:geom%jec,k))
+  end do
+  call self%update_halo(geom)
+end subroutine soca_field_stencil_interp
 
 ! ------------------------------------------------------------------------------
 ! make sure the two fields are the same in terms of name, size, shape
@@ -176,6 +204,10 @@ subroutine soca_fields_init_vars(self, vars)
   do i=1,size(vars)
     self%fields(i)%name = trim(vars(i))
 
+    ! Default stencil grid loc is h-point
+    self%fields(i)%lon => self%geom%lon
+    self%fields(i)%lat => self%geom%lat
+
     ! determine number of levels, and if masked
     select case(self%fields(i)%name)
     case ('tocn','socn', 'hocn', 'layer_depth')
@@ -184,9 +216,13 @@ subroutine soca_fields_init_vars(self, vars)
     case ('uocn')
       nz = self%geom%nzo
       self%fields(i)%mask => self%geom%mask2du
+      self%fields(i)%lon => self%geom%lonu
+      self%fields(i)%lat => self%geom%latu
     case ('vocn')
       nz = self%geom%nzo
       self%fields(i)%mask => self%geom%mask2dv
+      self%fields(i)%lon => self%geom%lonv
+      self%fields(i)%lat => self%geom%latv
     case ('hicen','hsnon', 'cicen')
       nz = self%geom%ncat
       self%fields(i)%mask => self%geom%mask2d
@@ -209,6 +245,7 @@ subroutine soca_fields_init_vars(self, vars)
     ! set other variables associated with each field
     self%fields(i)%cf_name = ""
     self%fields(i)%io_name = ""
+    self%fields(i)%c_grid_loc = "h"
     select case(self%fields(i)%name)
     case ('tocn')
       self%fields(i)%cf_name = "sea_water_potential_temperature"
@@ -230,10 +267,12 @@ subroutine soca_fields_init_vars(self, vars)
       self%fields(i)%cf_name = "sea_water_zonal_current"
       self%fields(i)%io_file = "ocn"
       self%fields(i)%io_name = "u"
+      self%fields(i)%c_grid_loc = "u"
     case ('vocn')
       self%fields(i)%cf_name = "sea_water_meridional_current"
       self%fields(i)%io_file = "ocn"
       self%fields(i)%io_name = "v"
+      self%fields(i)%c_grid_loc = "v"
     case ('hicen')
       self%fields(i)%cf_name = "sea_ice_category_thickness"
       self%fields(i)%io_file = "ice"
@@ -1059,5 +1098,74 @@ subroutine soca_fields_write_rst(fld, f_conf, vdate)
   call fms_io_exit()
 
 end subroutine soca_fields_write_rst
+
+! ------------------------------------------------------------------------------
+!
+subroutine soca_fields_colocate(self, cgridlocout)
+  class(soca_fields),    intent(inout) :: self
+  character(len=1),         intent(in) :: cgridlocout !< colocate to cgridloc (u, v or h)
+
+  integer :: i, k
+  real(kind=kind_real), allocatable :: val(:,:,:)
+  real(kind=kind_real), pointer :: lon_out(:,:) => null()
+  real(kind=kind_real), pointer :: lat_out(:,:) => null()
+  type(soca_geom),  pointer :: g => null()
+  type(horiz_interp_type) :: interp2d
+
+  ! Associate lon_out and lat_out according to cgridlocout
+  select case(cgridlocout)
+  case ('u')
+    lon_out => self%geom%lonu
+    lat_out => self%geom%latu
+  case ('v')
+    lon_out => self%geom%lonv
+    lat_out => self%geom%latv
+  case ('h')
+    lon_out => self%geom%lon
+    lat_out => self%geom%lat
+  case default
+    call abor1_ftn('soca_fields::colocate(): unknown c-grid location '// cgridlocout)
+  end select
+
+  ! Apply interpolation to all fields, when necessary
+  do i=1,size(self%fields)
+
+    ! Check if already colocated
+    if (self%fields(i)%c_grid_loc == cgridlocout) cycle
+
+    ! Initialize fms spherical idw interpolation
+     g => self%geom
+     call horiz_interp_spherical_new(interp2d, &
+       & real(deg2rad*self%fields(i)%lon(g%isd:g%ied,g%jsd:g%jed), 8), &
+       & real(deg2rad*self%fields(i)%lat(g%isd:g%ied,g%jsd:g%jed), 8), &
+       & real(deg2rad*lon_out(g%isc:g%iec,g%jsc:g%jec), 8), &
+       & real(deg2rad*lat_out(g%isc:g%iec,g%jsc:g%jec), 8))
+
+    ! Make a temporary copy of field
+    if (allocated(val)) deallocate(val)
+    allocate(val, mold=self%fields(i)%val)
+    val = self%fields(i)%val
+
+    ! Interpolate all levels
+    do k = 1, self%fields(i)%nz
+      call self%fields(i)%stencil_interp(self%geom, interp2d)
+    end do
+
+    ! Update c-grid location
+    self%fields(i)%c_grid_loc = cgridlocout
+    select case(cgridlocout)
+    case ('u')
+      self%fields(i)%lon => self%geom%lonu
+      self%fields(i)%lat => self%geom%latu
+    case ('v')
+      self%fields(i)%lon => self%geom%lonv
+      self%fields(i)%lat => self%geom%latv
+    case ('h')
+      self%fields(i)%lon => self%geom%lon
+      self%fields(i)%lat => self%geom%lat
+    end select
+
+ end do
+end subroutine soca_fields_colocate
 
 end module soca_fields_mod

--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -27,7 +27,8 @@ use soca_fieldsutils_mod, only: soca_genfilename, fldinfo
 use soca_utils, only: soca_mld
 
 use horiz_interp_mod, only : horiz_interp_type
-use horiz_interp_spherical_mod, only : horiz_interp_spherical_new, horiz_interp_spherical
+use horiz_interp_spherical_mod, only : horiz_interp_spherical
+use horiz_interp_spherical_mod, only : horiz_interp_spherical_new, horiz_interp_spherical_del
 use tools_const, only: deg2rad
 
 implicit none
@@ -847,9 +848,9 @@ subroutine soca_fields_read(fld, f_conf, vdate)
       field => fld%fields(ii)
       if (field%io_name == "" ) cycle
       if ( field%nz == 1) then
-        call read_data(incr_filename, field%io_name, field%val(:,:,1), domain=fld%geom%Domain%mpp_domain)
+        call read_data(incr_filename, field%name, field%val(:,:,1), domain=fld%geom%Domain%mpp_domain)
       else
-        call read_data(incr_filename, field%io_name, field%val(:,:,:), domain=fld%geom%Domain%mpp_domain)
+        call read_data(incr_filename, field%name, field%val(:,:,:), domain=fld%geom%Domain%mpp_domain)
       end if
     end do
     call fms_io_exit()
@@ -1166,6 +1167,8 @@ subroutine soca_fields_colocate(self, cgridlocout)
     end select
 
  end do
+ call horiz_interp_spherical_del(interp2d)
+
 end subroutine soca_fields_colocate
 
 end module soca_fields_mod

--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -1115,12 +1115,13 @@ subroutine soca_fields_colocate(self, cgridlocout)
 
   ! Associate lon_out and lat_out according to cgridlocout
   select case(cgridlocout)
-  case ('u')
-    lon_out => self%geom%lonu
-    lat_out => self%geom%latu
-  case ('v')
-    lon_out => self%geom%lonv
-    lat_out => self%geom%latv
+  ! TODO: Test colocation to u and v grid
+  !case ('u')
+  !  lon_out => self%geom%lonu
+  !  lat_out => self%geom%latu
+  !case ('v')
+  !  lon_out => self%geom%lonv
+  !  lat_out => self%geom%latv
   case ('h')
     lon_out => self%geom%lon
     lat_out => self%geom%lat
@@ -1155,12 +1156,13 @@ subroutine soca_fields_colocate(self, cgridlocout)
     ! Update c-grid location
     self%fields(i)%c_grid_loc = cgridlocout
     select case(cgridlocout)
-    case ('u')
-      self%fields(i)%lon => self%geom%lonu
-      self%fields(i)%lat => self%geom%latu
-    case ('v')
-      self%fields(i)%lon => self%geom%lonv
-      self%fields(i)%lat => self%geom%latv
+    ! TODO: Test colocation to u and v grid
+    !case ('u')
+    !  self%fields(i)%lon => self%geom%lonu
+    !  self%fields(i)%lat => self%geom%latu
+    !case ('v')
+    !  self%fields(i)%lon => self%geom%lonv
+    !  self%fields(i)%lat => self%geom%latv
     case ('h')
       self%fields(i)%lon => self%geom%lon
       self%fields(i)%lat => self%geom%lat

--- a/src/soca/State/State.cc
+++ b/src/soca/State/State.cc
@@ -23,7 +23,7 @@
 
 #include "ufo/GeoVaLs.h"
 #include "ufo/Locations.h"
-
+#include "ioda/IodaTrait.h"
 using oops::Log;
 
 namespace soca {

--- a/src/soca/State/State.cc
+++ b/src/soca/State/State.cc
@@ -23,7 +23,7 @@
 
 #include "ufo/GeoVaLs.h"
 #include "ufo/Locations.h"
-#include "ioda/IodaTrait.h"
+
 using oops::Log;
 
 namespace soca {

--- a/src/soca/State/soca_state_mod.F90
+++ b/src/soca/State/soca_state_mod.F90
@@ -164,7 +164,6 @@ subroutine soca_state_add_incr(self, rhs)
   ! for each field that exists in incr, add to self
   do i=1,size(incr%fields)
     fld_r => incr%fields(i)
-    print *,'--------- adding incr for ',fld_r%name
     call self%get(fld_r%name, fld)
 
     select case (fld%name)

--- a/src/soca/State/soca_state_mod.F90
+++ b/src/soca/State/soca_state_mod.F90
@@ -164,6 +164,7 @@ subroutine soca_state_add_incr(self, rhs)
   ! for each field that exists in incr, add to self
   do i=1,size(incr%fields)
     fld_r => incr%fields(i)
+    print *,'--------- adding incr for ',fld_r%name
     call self%get(fld_r%name, fld)
 
     select case (fld%name)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@ list( APPEND soca_test_input
   testinput/3dvar_godas.yml
   testinput/3dvar_soca.yml
   testinput/3dvarfgat.yml
+  testinput/addincrement.yml
   testinput/checkpointmodel.yml
   testinput/convertstate.yml
   testinput/dirac_bump_cov.yml
@@ -50,6 +51,7 @@ list( APPEND soca_test_ref
   testref/3dvar_godas.test
   testref/3dvar_soca.test
   testref/3dvarfgat.test
+  testref/addincrement.test
   testref/checkpointmodel.test
   testref/convertstate.test
   testref/dirac_bump_cov.test
@@ -532,6 +534,10 @@ soca_add_test( NAME 3dvar_godas
                EXE  soca_3dvar.x
                TOL  2e-6 0
                TEST_DEPENDS test_soca_static_socaerror_init )
+
+soca_add_test( NAME addincrement
+               EXE  soca_addincrement.x
+               TEST_DEPENDS 3dvar_godas )
 
 soca_add_test( NAME 3dvarfgat
                EXE  soca_3dvar.x

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -535,8 +535,10 @@ soca_add_test( NAME 3dvar_godas
                TOL  2e-6 0
                TEST_DEPENDS test_soca_static_socaerror_init )
 
+# TODO: Remove NOCOMPARE when oops PR#585 is merged
 soca_add_test( NAME addincrement
                EXE  soca_addincrement.x
+               NOCOMPARE
                TEST_DEPENDS 3dvar_godas )
 
 soca_add_test( NAME 3dvarfgat

--- a/test/testinput/addincrement.yml
+++ b/test/testinput/addincrement.yml
@@ -1,0 +1,32 @@
+stateResol:
+  num_ice_cat: 5
+  num_ice_lev: 4
+  num_sno_lev: 1
+  read_soca_grid: grid
+
+incrementResol:
+  num_ice_cat: 5
+  num_ice_lev: 4
+  num_sno_lev: 1
+  read_soca_grid: grid
+
+state:
+  read_from_file: 1
+  basename: ./INPUT/
+  ocn_filename: MOM.res.nc
+  ice_filename: cice.res.nc
+  sfc_filename: sfc.res.nc
+  date: &bkg_date 2018-04-15T00:00:00Z
+  seaice_model: cice
+  variables: [cicen, hicen, hsnon, socn, tocn, ssh, hocn, uocn, vocn]
+
+increment:
+  read_from_file: 2
+  filename: ./incr.1.nc
+  variables: [hsnon, socn, tocn, hocn, uocn, vocn]
+
+output:
+  datadir: Data
+  exp: addincrement
+  type: an
+  seaice_model: cice

--- a/test/testinput/convertstate.yml
+++ b/test/testinput/convertstate.yml
@@ -1,3 +1,5 @@
+inputVariables:
+  variables: &soca_vars [tocn, socn, hocn, cicen, uocn, vocn]
 inputresolution:
   num_ice_cat: 5
   num_ice_lev: 4
@@ -8,8 +10,15 @@ outputresolution:
   num_ice_lev: 4
   num_sno_lev: 1
   read_soca_grid: grid
+varchange: Ana2Model
+rotate:
+  u: [uocn]
+  v: [vocn]
 inputVariables:
-  variables: [tocn, socn, hocn, cicen]
+  variables: *soca_vars
+outputVariables:
+  variables: *soca_vars
+
 states:
 - input:
      read_from_file: 1

--- a/test/testinput/enspert.yml
+++ b/test/testinput/enspert.yml
@@ -32,7 +32,7 @@ Covariance:
   pert_AICE: 0.1
   pert_HICE: 0.05
   variables: [ssh, cicen, hicen, tocn, socn]
-  
+
   variable_changes:
 
   - varchange: BkgErrFILT

--- a/test/testref/3dvar_godas.test
+++ b/test/testref/3dvar_godas.test
@@ -7,7 +7,7 @@ Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.787, nobs = 206, Jo/
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 355.419, nobs = 218, Jo/n = 1.63036, err = 0.608197
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 370.055, nobs = 89, Jo/n = 4.15792, err = 0.1
 Test     : CostFunction: Nonlinear J = 20180.3
-Test     : RPCGMinimizer: reduction in residual norm = 0.12446
+Test     : RPCGMinimizer: reduction in residual norm = 0.125615
 Test     : CostFunction::addIncrement: Analysis:
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023945

--- a/test/testref/3dvar_godas.test
+++ b/test/testref/3dvar_godas.test
@@ -8,18 +8,18 @@ Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 355.419, nobs = 218, Jo/n =
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 370.055, nobs = 89, Jo/n = 4.15792, err = 0.1
 Test     : CostFunction: Nonlinear J = 20180.3
 Test     : RPCGMinimizer: reduction in residual norm = 0.125615
-Test     : CostFunction::addIncrement: Analysis:
+Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023945
 Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.115987
 Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544426
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018518
-Test     :     ssh   min=   -1.924831   max=    0.927291   mean=   -0.276772
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018508
+Test     :     ssh   min=   -1.924818   max=    0.927291   mean=   -0.276772
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :      sw   min= -225.094294   max=   -0.033703   mean= -110.030712
-Test     :     lhf   min=  -38.137522   max=  256.595597   mean=   64.433606
-Test     :     shf   min=  -58.949308   max=  201.374218   mean=    9.318214
+Test     :      sw   min= -225.094645   max=   -0.033703   mean= -110.030705
+Test     :     lhf   min=  -38.137508   max=  256.595607   mean=   64.433604
+Test     :     shf   min=  -58.949308   max=  201.374218   mean=    9.318213
 Test     :      lw   min=    0.000000   max=   88.036091   mean=   48.153834
 Test     :      us   min=    0.004396   max=    0.019669   mean=    0.009428
 Test     :    uocn   min=   -0.858170   max=    0.700095   mean=   -0.000242

--- a/test/testref/3dvar_godas.test
+++ b/test/testref/3dvar_godas.test
@@ -7,29 +7,29 @@ Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.787, nobs = 206, Jo/
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 355.419, nobs = 218, Jo/n = 1.63036, err = 0.608197
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 370.055, nobs = 89, Jo/n = 4.15792, err = 0.1
 Test     : CostFunction: Nonlinear J = 20180.3
-Test     : RPCGMinimizer: reduction in residual norm = 0.125615
+Test     : RPCGMinimizer: reduction in residual norm = 0.12446
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023945
 Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.115987
 Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544426
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018508
-Test     :     ssh   min=   -1.924818   max=    0.927291   mean=   -0.276772
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018518
+Test     :     ssh   min=   -1.924831   max=    0.927291   mean=   -0.276772
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :      sw   min= -225.094645   max=   -0.033703   mean= -110.030705
-Test     :     lhf   min=  -38.137508   max=  256.595607   mean=   64.433604
-Test     :     shf   min=  -58.949308   max=  201.374218   mean=    9.318213
+Test     :      sw   min= -225.094294   max=   -0.033703   mean= -110.030712
+Test     :     lhf   min=  -38.137522   max=  256.595597   mean=   64.433606
+Test     :     shf   min=  -58.949308   max=  201.374218   mean=    9.318214
 Test     :      lw   min=    0.000000   max=   88.036091   mean=   48.153834
 Test     :      us   min=    0.004396   max=    0.019669   mean=    0.009428
 Test     :    uocn   min=   -0.858170   max=    0.700095   mean=   -0.000242
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002019
-Test     : CostJb   : Nonlinear Jb = 0.731597
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 16668.369841, nobs = 201, Jo/n = 82.927213, err = 0.364832
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 1232.946942, nobs = 154, Jo/n = 8.006149, err = 0.356997
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.012443, nobs = 51, Jo/n = 0.961028, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 212.797293, nobs = 95, Jo/n = 2.239972, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 346.983203, nobs = 206, Jo/n = 1.684384, err = 0.897281
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 353.912276, nobs = 218, Jo/n = 1.623451, err = 0.608197
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 368.686290, nobs = 89, Jo/n = 4.142543, err = 0.100000
-Test     : CostFunction: Nonlinear J = 19233.439885
+Test     : CostJb   : Nonlinear Jb = 0.725829
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 16669.863974, nobs = 201, Jo/n = 82.934647, err = 0.364832
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 1233.128490, nobs = 154, Jo/n = 8.007328, err = 0.356997
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.012369, nobs = 51, Jo/n = 0.961027, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 212.799704, nobs = 95, Jo/n = 2.239997, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 347.010703, nobs = 206, Jo/n = 1.684518, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 353.912597, nobs = 218, Jo/n = 1.623452, err = 0.608197
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 368.708602, nobs = 89, Jo/n = 4.142793, err = 0.100000
+Test     : CostFunction: Nonlinear J = 19235.162268

--- a/test/testref/3dvar_godas.test
+++ b/test/testref/3dvar_godas.test
@@ -22,9 +22,9 @@ Test     :     lhf   min=  -38.137508   max=  256.595607   mean=   64.433604
 Test     :     shf   min=  -58.949308   max=  201.374218   mean=    9.318213
 Test     :      lw   min=    0.000000   max=   88.036091   mean=   48.153834
 Test     :      us   min=    0.004396   max=    0.019669   mean=    0.009428
-Test     :    uocn   min=   -0.858174   max=    0.700064   mean=   -0.000241
-Test     :    vocn   min=   -0.766109   max=    1.437777   mean=    0.002019
-Test     : CostJb   : Nonlinear Jb = 0.731599
+Test     :    uocn   min=   -0.858170   max=    0.700095   mean=   -0.000242
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002019
+Test     : CostJb   : Nonlinear Jb = 0.731597
 Test     : CostJo   : Nonlinear Jo(CoolSkin) = 16668.369841, nobs = 201, Jo/n = 82.927213, err = 0.364832
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 1232.946942, nobs = 154, Jo/n = 8.006149, err = 0.356997
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.012443, nobs = 51, Jo/n = 0.961028, err = 1.000000
@@ -32,4 +32,4 @@ Test     : CostJo   : Nonlinear Jo(ADT) = 212.797293, nobs = 95, Jo/n = 2.239972
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 346.983203, nobs = 206, Jo/n = 1.684384, err = 0.897281
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 353.912276, nobs = 218, Jo/n = 1.623451, err = 0.608197
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 368.686290, nobs = 89, Jo/n = 4.142543, err = 0.100000
-Test     : CostFunction: Nonlinear J = 19233.439887
+Test     : CostFunction: Nonlinear J = 19233.439885

--- a/test/testref/convertstate.test
+++ b/test/testref/convertstate.test
@@ -4,9 +4,13 @@ Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023937
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000241
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002019
 Test     : Output state: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023937
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000203
+Test     :    vocn   min=   -0.766110   max=    1.437578   mean=    0.001929


### PR DESCRIPTION
## Description
Colocate increment to state in `add_incr`. Interpolation uses fms idw ... hu-hoooo .... For now.
**bug fix:** Geostrophic increment for u-v was added without colocation.
Change of answer expected in the 3dvar_godas test, which makes use of geostrophy.

### Issue(s) addressed
closes #315

## Testing
How were these changes tested? **Colocation called inside of 3dvar_godas**
What compilers / HPCs was it tested with? **gcc**
Are the changes covered by ctests? **yes**

## Dependencies
- ~[oops PR#585](https://github.com/JCSDA/oops/pull/585)~
Deferred to an other PR, we'll just have to remove the NOCOMPARE in the test and add the reference file. 
