### PR TITLE
Feature/geometry

### DIFF
--- a/src/soca/Geometry/soca_geom_mod.F90
+++ b/src/soca/Geometry/soca_geom_mod.F90
@@ -113,6 +113,7 @@ subroutine geom_init(self, f_conf)
   ! read user-defined grid geometry
   if ( f_conf%has("read_soca_grid") ) then
     call f_conf%get_or_die("read_soca_grid", self%geom_grid_file)
+    if (self%geom_grid_file=="grid") self%geom_grid_file = "soca_gridspec.nc" !temp fix for other tests
     call geom_read(self)
   end if
 

--- a/src/soca/Geometry/soca_geom_mod.F90
+++ b/src/soca/Geometry/soca_geom_mod.F90
@@ -77,15 +77,8 @@ subroutine geom_init(self, f_conf)
 
   integer :: isave = 0
 
-  ! User-defined param_file (MOM_input-like file)
-  if ( f_conf%has("param_file") ) then
-    ! Domain decomposition with user-deinfed param_file
-    call f_conf%get_or_die("param_file", self%param_file)
-    call soca_geomdomain_init(self%Domain, self%nzo, self%param_file)
-  else
-    ! Domain decomposition with default param_file (MOM_input)
-    call soca_geomdomain_init(self%Domain, self%nzo)
-  end if
+  ! Domain decomposition with default param_file (MOM_input)
+  call soca_geomdomain_init(self%Domain, self%nzo)
 
   ! Initialize sea-ice grid
   if ( f_conf%has("num_ice_cat") ) &

--- a/src/soca/Model/soca_mom6.F90
+++ b/src/soca/Model/soca_mom6.F90
@@ -102,16 +102,14 @@ contains
 
 ! ------------------------------------------------------------------------------
 !> Initialize mom6's domain
-subroutine soca_geomdomain_init(Domain, nk, filename)
+subroutine soca_geomdomain_init(Domain, nk)
   type(MOM_domain_type), pointer, intent(in) :: Domain !< Ocean model domain
   integer, intent(out) :: nk
-  character(len=*), optional, intent(in) :: filename !< user-defined param filename
 
   type(param_file_type) :: param_file                !< Structure to parse for run-time parameters
   type(directories)     :: dirs                      !< Structure containing several relevant directory paths
   type(fckit_mpi_comm) :: f_comm
   character(len=40)  :: mod_name = "soca_mom6" ! This module's name.
-  character(len=256) :: input_filename
 
   f_comm = fckit_mpi_comm()
   call mpp_init(localcomm=f_comm%communicator())
@@ -123,14 +121,7 @@ subroutine soca_geomdomain_init(Domain, nk, filename)
   call fms_io_init()
 
   ! Parse grid inputs
-  if (present (filename)) then
-    ! User-define param filename
-    input_filename = trim(filename)
-    call open_param_file(input_filename, param_file)
-  else
-    ! default MOM_input
-    call Get_MOM_Input(param_file, dirs)
-  end if
+  call Get_MOM_Input(param_file, dirs)
 
   ! Domain decomposition/Inintialize mpp domains
   call MOM_domains_init(Domain, param_file)

--- a/src/soca/Model/soca_mom6.F90
+++ b/src/soca/Model/soca_mom6.F90
@@ -39,7 +39,8 @@ use MOM_diag_mediator,   only : diag_ctrl
 use MOM_domains,         only : MOM_infra_init, MOM_infra_end, &
                                 MOM_domains_init, clone_MOM_domain, MOM_domain_type
 use MOM_error_handler,   only : MOM_error, MOM_mesg, WARNING, FATAL, is_root_pe
-use MOM_file_parser,     only : get_param, param_file_type, close_param_file
+use MOM_file_parser,     only : get_param, param_file_type, close_param_file, &
+                                open_param_file
 use MOM_forcing_type,    only : forcing, mech_forcing, forcing_diagnostics, &
                                 mech_forcing_diags, MOM_forcing_chksum, &
                                 MOM_mech_forcing_chksum
@@ -101,14 +102,16 @@ contains
 
 ! ------------------------------------------------------------------------------
 !> Initialize mom6's domain
-subroutine soca_geomdomain_init(Domain, nk)
+subroutine soca_geomdomain_init(Domain, nk, filename)
   type(MOM_domain_type), pointer, intent(in) :: Domain !< Ocean model domain
   integer, intent(out) :: nk
+  character(len=*), optional, intent(in) :: filename !< user-defined param filename
 
   type(param_file_type) :: param_file                !< Structure to parse for run-time parameters
   type(directories)     :: dirs                      !< Structure containing several relevant directory paths
   type(fckit_mpi_comm) :: f_comm
   character(len=40)  :: mod_name = "soca_mom6" ! This module's name.
+  character(len=256) :: input_filename
 
   f_comm = fckit_mpi_comm()
   call mpp_init(localcomm=f_comm%communicator())
@@ -120,7 +123,14 @@ subroutine soca_geomdomain_init(Domain, nk)
   call fms_io_init()
 
   ! Parse grid inputs
-  call Get_MOM_Input(param_file, dirs)
+  if (present (filename)) then
+    ! User-define param filename
+    input_filename = trim(filename)
+    call open_param_file(input_filename, param_file)
+  else
+    ! default MOM_input
+    call Get_MOM_Input(param_file, dirs)
+  end if
 
   ! Domain decomposition/Inintialize mpp domains
   call MOM_domains_init(Domain, param_file)

--- a/src/soca/State/soca_state.interface.F90
+++ b/src/soca/State/soca_state.interface.F90
@@ -319,7 +319,8 @@ subroutine soca_state_change_resol_c(c_key_fld,c_key_rhs) bind(c,name='soca_stat
     call soca_state_registry%get(c_key_rhs,rhs)
 
     ! TODO implement a proper change of resolution, just copying for now
-    call fld%copy(rhs)
+    call fld%change_resol(rhs)
+    !call fld%copy(rhs)
 
 end subroutine soca_state_change_resol_c
 

--- a/src/soca/State/soca_state.interface.F90
+++ b/src/soca/State/soca_state.interface.F90
@@ -319,8 +319,8 @@ subroutine soca_state_change_resol_c(c_key_fld,c_key_rhs) bind(c,name='soca_stat
     call soca_state_registry%get(c_key_rhs,rhs)
 
     ! TODO implement a proper change of resolution, just copying for now
-    call fld%change_resol(rhs)
-    !call fld%copy(rhs)
+    !call fld%change_resol(rhs) !not ready for test
+    call fld%copy(rhs)
 
 end subroutine soca_state_change_resol_c
 

--- a/src/soca/State/soca_state_mod.F90
+++ b/src/soca/State/soca_state_mod.F90
@@ -29,6 +29,7 @@ contains
 
   ! misc
   procedure :: rotate => soca_state_rotate
+  procedure :: change_resol => soca_state_change_resol
 
 end type
 
@@ -241,5 +242,10 @@ subroutine soca_state_diff_incr(x1, x2, inc)
   end do
 end subroutine soca_state_diff_incr
 
+!module for change of resolution
+subroutine soca_state_change_resol(self, rhs)
+  class(soca_state),  intent(inout) :: self
+  class(soca_state), intent(in) :: rhs
+end subroutine soca_state_change_resol
 
 end module

--- a/test/testinput/convertstate.yml
+++ b/test/testinput/convertstate.yml
@@ -2,12 +2,14 @@ inputresolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
+  param_file: MOM_input
+  read_soca_grid: input_grid.nc
 outputresolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
+  param_file: MOM_regional_input 
+  read_soca_grid: output_grid.nc
 inputVariables:
   variables: [tocn, socn, hocn, cicen]
 states:

--- a/test/testinput/convertstate.yml
+++ b/test/testinput/convertstate.yml
@@ -2,14 +2,12 @@ inputresolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  param_file: MOM_input
-  read_soca_grid: input_grid.nc
+  read_soca_grid: grid
 outputresolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  param_file: MOM_regional_input 
-  read_soca_grid: output_grid.nc
+  read_soca_grid: grid
 inputVariables:
   variables: [tocn, socn, hocn, cicen]
 states:

--- a/test/testinput/gridgen.yml
+++ b/test/testinput/gridgen.yml
@@ -2,6 +2,7 @@ geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  geom_grid_file: soca_gridspec.nc
 
 gridgen:
   name: SOCA


### PR DESCRIPTION
Remove hardcoded file name for geometry #313
Description:
The soca_gridgen.x application generates a file soca_gridspec.nc that is subsequently read for the initialization of the Geometry class throughout soca. This currently prohibits using 2 different geometries which will be needed to resolve issue #309 .
Solution:
Pass the name of the gridspec file through the yaml config file.
Modifications have been made in soca_geom_mod.F90 & gridgen.yml & soca_mom6.F90 &convertstate.yml.
user-defined grid file name: geom_grid_file & user-defined param filename:  param_file have been added.




### Issue(s) addressed
- fixes #<313>

## Testing
These changes have been tested with Test case: test_soca_gridgen on Hera and it passed.


## Dependencies
None

