### PR TITLE
Move SABER/OOPS interfaces to SABER

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ env:
     - BUNDLE_URL="https://github.com/JCSDA/soca-bundle.git"
     - MAIN_REPO=soca
     - LIB_REPOS="fms cvmix geokdtree mom6_da_hooks gsw mom6 crtm
-                 fckit atlas saber oops ioda ufo ioda-converters soca-config"
+                 fckit atlas oops saber ioda ufo ioda-converters soca-config"
     - BUILD_OPT=""
     - BUILD_OPT_CRTM="-DBUILD_CRTM=ON"
     - BUILD_OPT_OOPS="-DENABLE_OOPS_TOYMODELS=OFF"
     - BUILD_OPT_UFO="-DLOCAL_PATH_TESTFILES_IODA=NONE"
     - BUILD_OPT_SOCA="-DSOCA_TESTS_FORC_DEFAULT_TOL=ON -DCRTM_FIX_DIR=../../repo.src/crtm/fix"
-    - MATCH_REPOS="atlas saber oops ioda ioda-converters ufo soca soca-config"
+    - MATCH_REPOS="atlas oops saber ioda ioda-converters ufo soca soca-config"
     - LFS_REPOS="crtm"
 
     # secure token used to push changes to GitHub (user: travissluka)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,10 @@ include_directories( ${FCKIT_INCLUDE_DIRS} )
 ecbuild_use_package( PROJECT oops VERSION 0.1.0 REQUIRED )
 include_directories( ${OOPS_INCLUDE_DIRS} )
 
+# saber
+ecbuild_use_package( PROJECT saber VERSION 0.0.1 REQUIRED )
+include_directories( ${SABER_INCLUDE_DIRS} )
+
 # ioda
 ecbuild_use_package( PROJECT ioda VERSION 0.1.0 REQUIRED )
 include_directories( ${IODA_INCLUDE_DIRS} )

--- a/src/mains/3DVar.cc
+++ b/src/mains/3DVar.cc
@@ -14,11 +14,13 @@
 #include "ufo/instantiateObsFilterFactory.h"
 #include "oops/runs/Run.h"
 #include "oops/runs/Variational.h"
+#include "saber/oops/instantiateLocalizationFactory.h"
 
 int main(int argc,  char ** argv) {
   oops::Run run(argc, argv);
   soca::instantiateBalanceOpFactory();
   ufo::instantiateObsFilterFactory<soca::Traits>();
+  saber::instantiateLocalizationFactory<soca::Traits>();
   oops::Variational<soca::Traits> var;
   run.execute(var);
   return 0;

--- a/src/mains/CMakeLists.txt
+++ b/src/mains/CMakeLists.txt
@@ -1,6 +1,7 @@
 ecbuild_add_executable( TARGET  soca_dirac.x
                         SOURCES Dirac.cc
                         LIBS    soca
+                                saber
                       )
 
 ecbuild_add_executable( TARGET  soca_forecast.x
@@ -31,11 +32,13 @@ ecbuild_add_executable( TARGET  soca_enshofx.x
 ecbuild_add_executable( TARGET  soca_3dvar.x
                         SOURCES 3DVar.cc
                         LIBS    soca
+                                saber
                       )
 
 ecbuild_add_executable( TARGET  soca_parameters.x
                         SOURCES EstimateParams.cc
                         LIBS    soca
+                                saber
                       )
 
 ecbuild_add_executable( TARGET  soca_staticbinit.x

--- a/src/mains/Dirac.cc
+++ b/src/mains/Dirac.cc
@@ -13,10 +13,12 @@
 #include "soca/Transforms/instantiateBalanceOpFactory.h"
 #include "oops/runs/Dirac.h"
 #include "oops/runs/Run.h"
+#include "saber/oops/instantiateLocalizationFactory.h"
 
 int main(int argc,  char ** argv) {
-  soca::instantiateBalanceOpFactory();
   oops::Run run(argc, argv);
+  soca::instantiateBalanceOpFactory();
+  saber::instantiateLocalizationFactory<soca::Traits>();
   oops::Dirac<soca::Traits> dir;
   run.execute(dir);
   return 0;

--- a/src/mains/EstimateParams.cc
+++ b/src/mains/EstimateParams.cc
@@ -11,13 +11,13 @@
 
 #include "soca/Traits.h"
 #include "soca/Transforms/instantiateBalanceOpFactory.h"
-#include "oops/runs/EstimateParams.h"
+#include "saber/oops/EstimateParams.h"
 #include "oops/runs/Run.h"
 
 int main(int argc,  char ** argv) {
   soca::instantiateBalanceOpFactory();
   oops::Run run(argc, argv);
-  oops::EstimateParams<soca::Traits> dir;
+  saber::EstimateParams<soca::Traits> dir;
   run.execute(dir);
   return 0;
 }

--- a/src/soca/CMakeLists.txt
+++ b/src/soca/CMakeLists.txt
@@ -24,7 +24,7 @@ endfunction()
 ecbuild_add_library( TARGET   soca
                      SOURCES ${soca_src_files}
                      LIBS     ${LAPACK_LIBRARIES} ${NETCDF_LIBRARIES}
-                              eckit eckit_mpi fckit oops ioda ufo fms mom6
+                              eckit eckit_mpi fckit oops saber ioda ufo fms mom6
                      INSTALL_HEADERS LISTED
                      LINKER_LANGUAGE ${SOCA_LINKER_LANGUAGE}
                     )


### PR DESCRIPTION
This PR moves all the SABER-related stuff from OOPS to SABER. The main goal is to reverse the order of dependencies. With this PR and the associated one for SABER:
 - OOPS is independent from SABER.
 - SABER (optionally) depends on OOPS.

Some modifications are required in SOCA:
 - add `saber` in `CMakeLists.txt`, since it is not coming automatically with OOPS now,
 - change `EstimateParams` calls (moved from OOPS to SABER)
 - new `instanstiantiateXXX` related to SABER factories (localization only for SOCA).