### PR TITLE
Feature/oc viirs modis

### DIFF
--- a/scripts/obs/README.md
+++ b/scripts/obs/README.md
@@ -17,6 +17,14 @@ chmod 600 ~/.netrc
 echo 'machine podaac-tools.jpl.nasa.gov login USERNAME_from_Drive_API_Credentials password PASSWORD_from_Drive_API_Credentials' >> ~/.netrc
 ```
 
+Similarly, for ocean color data hosted at the NASA's Ocean Biology Processing Group (OBPG/OB.DAAC), e.g. from MODIS-Aqua, data access requires users to login to the OceanColor Web's data access points using their Earthdata Login credentials:
+
+* Users need to register at https://urs.earthdata.nasa.gov and record USERNAME and PASSWD as their Earthdata Login credentials.
+
+* Users need to modify the following script before attempting to download MODIS-Aqua ocean color data:
+  source.coastwatch_oc_viirs_modis.sh: replacing USERNAME and PASSWD with their Login credentials in the following line:
+  wget -q -O - $source_dir |grep OC| wget --user=USERNAME --password=PASSWD --auth-no-challenge=on --base https://oceandata.sci.gsfc.nasa.gov/ -N --wait=0.5 --random-wait --force-html -i -
+     
 ## How to use
 The users have to modify the following three variables at the get_obs.sh, according to their choices:
 

--- a/scripts/obs/get_obs.sh
+++ b/scripts/obs/get_obs.sh
@@ -64,6 +64,14 @@ while [[ $date -le $date_end ]]; do
     #bash source.nesdis_sst_avhrr.sh l2p $date $output_path
     bash source.nesdis_sst_avhrr.sh l3u $date $output_path
 
+    ##------------------------------------------------------------
+    ## Ocean Color
+    ## L2 data from VIIRS/JPSS1, VIIRS/SNPP, MODIS-Aqua
+    ##------------------------------------------------------------
+    #bash source.coastwatch_oc_viirs_modis.sh snpp $date $output_path
+    bash source.coastwatch_oc_viirs_modis.sh jpss1 $date $output_path
+    bash source.coastwatch_oc_viirs_modis.sh aqua $date $output_path 
+
 date=$(date -d "$date + 1 day" +%Y%m%d)
 
 done

--- a/scripts/obs/source.coastwatch_oc_viirs_modis.sh
+++ b/scripts/obs/source.coastwatch_oc_viirs_modis.sh
@@ -43,7 +43,7 @@ mkdir -p $d
 cd $d
 
 if [[ $lvl == "aqua" ]]; then
-    wget -q -O - $source_dir |grep OC| wget --user=liuxiao37k --password=myEMC2020 --auth-no-challenge=on --base https://oceandata.sci.gsfc.nasa.gov/ -N --wait=0.5 --random-wait --force-html -i -
+    wget -q -O - $source_dir |grep OC| wget --user=USERNAME --password=PASSWD --auth-no-challenge=on --base https://oceandata.sci.gsfc.nasa.gov/ -N --wait=0.5 --random-wait --force-html -i -
 else
     wget -r -nc -np -nH -nd -A $file_sfx  $source_dir
 fi

--- a/scripts/obs/source.coastwatch_oc_viirs_modis.sh
+++ b/scripts/obs/source.coastwatch_oc_viirs_modis.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Downloads NOAA Coastwatch retrievals for L2 Ocean Color
+# MODIS-AQUA, VIIRS-JPSS1(NOAA-20), VIIRS-SNPP
+
+set -e
+set -u
+
+usage="usage: $0 [jpss1|snpp|aqua] yyyymmdd output_path"
+if [[ $# != 3 ]]; then
+    echo $usage
+    exit 1
+fi
+
+date=$2
+yr=${date:0:4}
+dy=$(date -d "$date" "+%j")
+
+lvl=$1
+if [[ $lvl == "snpp" ]]; then
+    source="ftp://ftpcoastwatch.noaa.gov/pub/socd1/mecb/coastwatch/viirs/nrt/L2"
+elif [[ $lvl == "jpss1" ]]; then    
+    source="ftp://ftpcoastwatch.noaa.gov/pub/socd2/mecb/coastwatch/viirs/n20/nrt/L2"
+elif [[ $lvl == "aqua" ]]; then
+    source="https://oceandata.sci.gsfc.nasa.gov/MODIS-Aqua/L2"
+else
+    echo $usage
+    exit 1
+fi
+
+file_sfx='*.nc'
+
+if [[ $lvl == "aqua" ]]; then
+    out_dir="$3/oc.modis_${lvl}.nasagsfc"
+else
+    out_dir="$3/oc.viirs_${lvl}.coastwatch"
+fi
+
+source_dir=$source/${yr}/${dy}/
+echo $source_dir
+pwd=$(pwd)
+d=$out_dir/$date
+mkdir -p $d
+cd $d
+
+if [[ $lvl == "aqua" ]]; then
+    wget -q -O - $source_dir |grep OC| wget --user=liuxiao37k --password=myEMC2020 --auth-no-challenge=on --base https://oceandata.sci.gsfc.nasa.gov/ -N --wait=0.5 --random-wait --force-html -i -
+else
+    wget -r -nc -np -nH -nd -A $file_sfx  $source_dir
+fi
+    
+cd $pwd
+


### PR DESCRIPTION
## Description

This PR adds a script (source.coastwatch_oc_viirs_modis.sh) to support the retrievals of L2 ocean color data from VIIRS/JPSS1, VIIRS/S-NPP, and MODIS-Aqua.
get_obs.sh is updated to include these retrievals.
README.md is updated to include a description of prerequisites for downloading MODIS-Aqua data as Login credentials are needed.

### Issue(s) addressed

- addresses #324 

## Testing

Testing for MODIS-Aqua data retrieval requires Earthdata Login credentials; please see README.md. Testing for VIIRS-JPSS1 or VIIRS-SNPP does not have such requirement.


