### PR TITLE
Feature/travisci internal bundle

### DIFF
--- a/.github/travisci/build.sh
+++ b/.github/travisci/build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 #================================================================================
-# (C) Copyright 2019 UCAR
+# (C) Copyright 2019-2020 UCAR
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 #
-# This script build each repo, in the order listed in "$LIB_REPO $MAIN_REPO", if
+# This script builds each repo, in the order listed in "$LIB_REPO $MAIN_REPO", if
 # "prep.sh" has determined that it needs to be rebuilt.
 #
 # ccache is used to accelerate CXX files between builds. And upstream repos are

--- a/.github/travisci/prep.sh
+++ b/.github/travisci/prep.sh
@@ -16,7 +16,7 @@ set -e
 cwd=$(pwd)
 
 # we assume the MAIN_REPO contains its own bundle
-bundle_file=${WORK_DIR}/repo.src/${MAIN_REPO}/bundle/CMakeLists.txt
+bundle_file=$cwd/repo.src/${MAIN_REPO}/bundle/CMakeLists.txt
 
 
 # get a list of all repos listed in the bundle

--- a/.github/travisci/prep.sh
+++ b/.github/travisci/prep.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #================================================================================
-# (C) Copyright 2019 UCAR
+# (C) Copyright 2019-2020 UCAR
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 #
@@ -15,13 +15,12 @@ set -e
 
 cwd=$(pwd)
 
+# we assume the MAIN_REPO contains its own bundle
+bundle_file=${WORK_DIR}/repo.src/${MAIN_REPO}/bundle/CMakeLists.txt
 
-# checkout the bundle, and get a list of all repos listed in it
-rm -rf bundle
-git clone $BUNDLE_URL bundle
-(cd bundle && git checkout $BRANCH ||
- echo "bundle does not have branch $BRANCH, keeping default branch")
-bundle_repos=$(grep "ecbuild_bundle(" bundle/CMakeLists.txt | awk '{print $3}')
+
+# get a list of all repos listed in the bundle
+bundle_repos=$(grep "ecbuild_bundle(" $bundle_file | awk '{print $3}')
 
 
 # prepare a separate bundle for each upstream repo, determine version information,
@@ -37,7 +36,7 @@ for repo in $LIB_REPOS $MAIN_REPO; do
     repo_bundle_dir=repo.bundle/$repo
     rm -rf $repo_bundle_dir
     mkdir -p $repo_bundle_dir
-    cp $cwd/bundle/CMakeLists.txt $repo_bundle_dir/
+    cp $bundle_file $repo_bundle_dir/
     for r in $bundle_repos; do
         if [[ $repo != $r ]]; then
            sed -i "/.* PROJECT $r .*/d" $repo_bundle_dir/CMakeLists.txt

--- a/.github/travisci/stable_commit.sh
+++ b/.github/travisci/stable_commit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #================================================================================
-# (C) Copyright 2019 UCAR
+# (C) Copyright 2019-2020 UCAR
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 #
@@ -17,8 +17,8 @@ echo ""
 RELEASE_BRANCH=${RELEASE_BRANCH:-release/stable-nightly}
 
 cwd=$(pwd)
-git clone ${BUNDLE_URL} bundle.stable
-cd bundle.stable
+cd ${WORK_DIR}/repo.src/${MAIN_REPO}/bundle
+cp CMakeLists.txt CMakeLists.txt.new
 
 # get the git commit hash for the relevant involved branches 
 ref_develop=$(git rev-parse HEAD)
@@ -37,12 +37,13 @@ fi
 # setup git user info
 git config --global user.email "travis@travis-ci.org"
 git config --global user.name  "TravisCI"
-url=${BUNDLE_URL/github.com/"${GH_TOKEN}@github.com"}
+url=$(git remote get-url origin)
+url=${url/github.com/"${GH_TOKEN}@github.com"}
 git remote add origin-auth $url
 
 # check in the changes
 msg="nightly stable  $(date +%Y-%m-%d)"
-cat $cwd/bundle/CMakeLists.txt > CMakeLists.txt
+mv CMakeLists.txt.new CMakeLists.txt
 git add .
 git commit -m "$msg" $amend
 git push --set-upstream origin-auth $RELEASE_BRANCH

--- a/.github/travisci/stable_commit.sh
+++ b/.github/travisci/stable_commit.sh
@@ -17,7 +17,7 @@ echo ""
 RELEASE_BRANCH=${RELEASE_BRANCH:-release/stable-nightly}
 
 cwd=$(pwd)
-cd ${WORK_DIR}/repo.src/${MAIN_REPO}/bundle
+cd repo.src/${MAIN_REPO}/bundle
 cp CMakeLists.txt CMakeLists.txt.new
 
 # get the git commit hash for the relevant involved branches 

--- a/.github/travisci/stable_mark.sh
+++ b/.github/travisci/stable_mark.sh
@@ -18,7 +18,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # figure out what git hash is associated with each repo in the bundle.
 # Note that there are several places where this repo could exist.
-bundle_dir=${WORK_DIR}/repo.src/${MAIN_REPO}/bundle
+bundle_dir=$cwd/repo.src/${MAIN_REPO}/bundle
 bundle_repos=$(grep "ecbuild_bundle(" $bundle_dir/CMakeLists.txt | awk '{print $3}')
 for r in $bundle_repos; do
 

--- a/.github/travisci/stable_mark.sh
+++ b/.github/travisci/stable_mark.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #================================================================================
-# (C) Copyright 2019 UCAR
+# (C) Copyright 2019-2020 UCAR
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 #
@@ -18,7 +18,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # figure out what git hash is associated with each repo in the bundle.
 # Note that there are several places where this repo could exist.
-bundle_dir=$cwd/bundle
+bundle_dir=${WORK_DIR}/repo.src/${MAIN_REPO}/bundle
 bundle_repos=$(grep "ecbuild_bundle(" $bundle_dir/CMakeLists.txt | awk '{print $3}')
 for r in $bundle_repos; do
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ cache:
 # Download and prepare the repositories and setup the docker image
 # The working directory will then contain the following directories, with {repo}
 # being each repository listed in $LIB_REPOS and $MAIN_REPO
-#   ./bundle/             - The original main ecbuild bundle repository
 #   ./repo.bundle/{repo}/ - Modified versions of the bundle to individually build repos
 #   ./repo.src/{repo}/    - The source from github
 #   ./repo.build/{repo}/  - The build directory
@@ -131,8 +130,8 @@ script:
 after_success:
   - |
     # If this is a cron run, update the release/stable branch of the bundle
-    if [[ "$TRAVIS_EVENT_TYPE" == "cron" && "$TRAVIS_BRANCH" == "develop" ]]; then
+    #if [[ "$TRAVIS_EVENT_TYPE" == "cron" && "$TRAVIS_BRANCH" == "develop" ]]; then
         docker exec jcsda_container bash -c \
           'cd /jcsda/work && repo.src/${MAIN_REPO}/.github/travisci/stable_mark.sh'
         cd ${WORK_DIR} && ${WORK_DIR}/repo.src/${MAIN_REPO}/.github/travisci/stable_commit.sh
-    fi
+    #fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,8 +130,8 @@ script:
 after_success:
   - |
     # If this is a cron run, update the release/stable branch of the bundle
-    #if [[ "$TRAVIS_EVENT_TYPE" == "cron" && "$TRAVIS_BRANCH" == "develop" ]]; then
+    if [[ "$TRAVIS_EVENT_TYPE" == "cron" && "$TRAVIS_BRANCH" == "develop" ]]; then
         docker exec jcsda_container bash -c \
           'cd /jcsda/work && repo.src/${MAIN_REPO}/.github/travisci/stable_mark.sh'
         cd ${WORK_DIR} && ${WORK_DIR}/repo.src/${MAIN_REPO}/.github/travisci/stable_commit.sh
-    #fi
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 # TravisCI configuration script
 #
 # The following environment variables need to be defined:
-#   BUNDLE_URL  - location of the main bundle repository for this project
 #   MAIN_REPO   - The name of this repo being tested, as spelled in the bundle
 #   LIB_REPOS   - A list of the dependency repos, in the order that they are to be
 #                 built. If the script detects a repo needs to be rebuit, all repos
@@ -13,11 +12,13 @@
 #                 unless listed in $MATCH_REPOS
 #   LFS_REPOS   - All repos in $LIB_REPO will not use git-lfs when checked out
 #                 unless listed in $LFS_REPOS
+#
+# NOTE: these scripts have been changed to assume the bundle CMakeLists.txt
+#  is in this repository directly
 #================================================================================
 
 env:
   global:
-    - BUNDLE_URL="https://github.com/JCSDA/soca-bundle.git"
     - MAIN_REPO=soca
     - LIB_REPOS="fms cvmix geokdtree mom6_da_hooks gsw mom6 crtm
                  fckit atlas oops saber ioda ufo ioda-converters soca-config"

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,8 +80,8 @@ before_install:
     # what TravisCI auto checks out (because TravisCI handles PR merges specially)
     WORK_DIR=$HOME/work
     mkdir -p $WORK_DIR/repo.src; cd $WORK_DIR
-    REPO_CACHE=$HOME/repo.cache ${TRAVIS_BUILD_DIR}/.github/travisci/prep.sh
     mv ${TRAVIS_BUILD_DIR} ${WORK_DIR}/repo.src/${MAIN_REPO}
+    REPO_CACHE=$HOME/repo.cache ${WORK_DIR}/repo.src/${MAIN_REPO}/.github/travisci/prep.sh
 
   - |
     # alter file permissions

--- a/README.md
+++ b/README.md
@@ -8,5 +8,20 @@ JEDI encapsulation of MOM6
 
 This software is licensed under the terms of the Apache Licence Version 2.0 which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 
+See the [soca ReadTheDocs](https://jointcenterforsatellitedataassimilation-soca.readthedocs-hosted.com/en/latest/?badge=latest) page for more documentation.
 
-See the [soca-bundle](https://github.com/JCSDA/soca-bundle) and the [soca ReadTheDocs](https://jointcenterforsatellitedataassimilation-soca.readthedocs-hosted.com/en/latest/?badge=latest) page for more documentation.
+## Building
+
+1. If building as part of the larger SOCA coupled system, see the [soca-bundle](https://github.com/JCSDA/soca-bundle)
+
+2. Otherwise, for just the MOM6 SOCA component: unlike other JEDI projects, this project contains its own bundle, it can be built as follows
+```
+git clone https://github.com/JCSDA/soca.git
+mkdir -p soca_build
+cd soca_build
+ecbuild ../soca/bundle
+cd soca
+make -j 4
+```
+
+See the [JEDI Documentation](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/) for additional details on how to setup, build, and test JEDI projects.

--- a/bundle/.gitignore
+++ b/bundle/.gitignore
@@ -1,0 +1,17 @@
+atlas/
+crtm/
+cvmix/
+eckit/
+fckit/
+fms/
+geokdtree/
+gsw/
+ioda-converters/
+ioda/
+mom6/
+mom6_da_hooks/
+oops/
+saber/
+soca
+soca-config/
+ufo/

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -1,0 +1,59 @@
+# (C) COPYRIGHT 2018-2020 UCAR
+#
+# THIS SOFTWARE IS LICENSED UNDER THE TERMS OF THE APACHE LICENCE VERSION 2.0
+# WHICH CAN BE OBTAINED AT HTTP://WWW.APACHE.ORG/LICENSES/LICENSE-2.0.
+
+#
+# bundle for SOCA (ocean only)
+#
+
+project( soca-bundle C CXX Fortran )
+
+cmake_minimum_required( VERSION 3.8 FATAL_ERROR )
+
+include( ecbuild_bundle )
+
+set( ECBUILD_DEFAULT_BUILD_TYPE Release )
+set( ENABLE_MPI ON CACHE BOOL "Compile with MPI" )
+
+ecbuild_bundle_initialize()
+ecbuild_requires_macro_version( 2.7 )
+
+
+# Optional repositories
+
+option(BUILD_ECKIT "download and build eckit (not needed if in a jedi container)")
+if ( BUILD_ECKIT )
+  ecbuild_bundle( PROJECT eckit         GIT "https://github.com/JCSDA/eckit.git"           UPDATE BRANCH develop )
+endif ()
+
+option(BUILD_CRTM  "download and build CRTM")
+if ( BUILD_CRTM )
+  ecbuild_bundle( PROJECT crtm          GIT "https://github.com/JCSDA/crtm.git"            UPDATE BRANCH develop )
+endif ()
+
+option(BUILD_METIS "download and build METIS (required for points remapping in BUMP)")
+if ( BUILD_METIS )
+  ecbuild_bundle( PROJECT metis         GIT "https://github.com/JCSDA/metis.git"           UPDATE BRANCH develop )
+endif ()
+
+
+# required repositories
+
+ecbuild_bundle( PROJECT fckit           GIT "https://github.com/JCSDA/fckit.git"           UPDATE BRANCH develop )
+ecbuild_bundle( PROJECT atlas           GIT "https://github.com/JCSDA/atlas.git"           UPDATE BRANCH develop )
+ecbuild_bundle( PROJECT oops            GIT "https://github.com/JCSDA/oops.git"            UPDATE BRANCH develop )
+ecbuild_bundle( PROJECT saber           GIT "https://github.com/JCSDA/saber.git"           UPDATE BRANCH develop )
+ecbuild_bundle( PROJECT ioda            GIT "https://github.com/JCSDA/ioda.git"            UPDATE BRANCH develop )
+ecbuild_bundle( PROJECT ioda-converters GIT "https://github.com/JCSDA/ioda-converters.git" UPDATE BRANCH develop )
+ecbuild_bundle( PROJECT gsw             GIT "https://github.com/JCSDA/GSW-Fortran.git"     UPDATE BRANCH develop )
+ecbuild_bundle( PROJECT ufo             GIT "https://github.com/JCSDA/ufo.git"             UPDATE BRANCH develop )
+ecbuild_bundle( PROJECT fms             GIT "https://github.com/JCSDA/FMS.git"             UPDATE BRANCH dev/master-ecbuild )
+ecbuild_bundle( PROJECT cvmix           GIT "https://github.com/JCSDA/CVMix-src.git"       UPDATE BRANCH feature/ecbuild )
+ecbuild_bundle( PROJECT geokdtree       GIT "https://github.com/JCSDA/geoKdTree.git"       UPDATE BRANCH feature/ecbuild )
+ecbuild_bundle( PROJECT mom6_da_hooks   GIT "https://github.com/JCSDA/MOM6_DA_hooks.git"   UPDATE BRANCH feature/ecbuild )
+ecbuild_bundle( PROJECT mom6            GIT "https://github.com/JCSDA/MOM6.git"            UPDATE BRANCH dev/master-ecbuild )
+ecbuild_bundle( PROJECT soca-config     GIT "https://github.com/JCSDA/soca-config.git"     UPDATE BRANCH develop )
+ecbuild_bundle( PROJECT soca            SOURCE "../" )
+
+ecbuild_bundle_finalize()


### PR DESCRIPTION
## Description

The "bundle" `CMakeLists.txt` was moved internally into the `bundle/` directory. This mirrors what was done for soca-cice6. Now soca-cice6 and soca can each have  their own `release/stable-nightly` branch contained in their own repository. Slightly cleaner that way. soca-bundle will be reserved for coupled stuff.
