### PR TITLE
soca-mom6 forecast ctest with ocean_bgc

### DIFF
--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -211,7 +211,7 @@ subroutine soca_fields_init_vars(self, vars)
 
     ! determine number of levels, and if masked
     select case(self%fields(i)%name)
-    case ('tocn','socn', 'hocn', 'layer_depth')
+    case ('tocn','socn', 'hocn', 'layer_depth','chl')
       nz = self%geom%nzo
       self%fields(i)%mask => self%geom%mask2d
     case ('uocn')
@@ -274,6 +274,10 @@ subroutine soca_fields_init_vars(self, vars)
       self%fields(i)%io_file = "ocn"
       self%fields(i)%io_name = "v"
       self%fields(i)%c_grid_loc = "v"
+    case ('chl')
+      self%fields(i)%cf_name = "chlorophyll_concentration"
+      self%fields(i)%io_file = "ocn"
+      self%fields(i)%io_name = "chl"
     case ('hicen')
       self%fields(i)%cf_name = "sea_ice_category_thickness"
       self%fields(i)%io_file = "ice"
@@ -541,7 +545,7 @@ subroutine soca_fields_dotprod(fld1,fld2,zprod)
     ! determine which fields to use
     ! TODO: use all fields (this will change answers in the ctests)
     select case(field1%name)
-    case ("tocn","socn","ssh","uocn","vocn",&
+    case ("tocn","socn","ssh","uocn","vocn","chl",&
           "hicen", "sw", "lhf", "shf", "lw", "us", "cicen")
       continue
     case default
@@ -888,7 +892,7 @@ subroutine soca_fields_gpnorm(fld, nf, pstat)
     ! get local min/max/sum of each variable
     ! TODO: use all fields (this will change answers in the ctests)
     select case(fld%fields(jj)%name)
-    case("tocn", "socn", "ssh", "hocn", "uocn", "vocn", &
+    case("tocn", "socn", "ssh", "hocn", "uocn", "vocn", "chl",&
          "sw", "lw", "lhf", "shf", "us", "hicen", "hsnon", "cicen")
       continue
     case default

--- a/src/soca/Model/soca_mom6.F90
+++ b/src/soca/Model/soca_mom6.F90
@@ -95,6 +95,7 @@ type soca_mom6_config
   type(MOM_control_struct), pointer :: MOM_CSp  !< Tracer flow control structure.
   type(MOM_restart_CS),     pointer :: restart_CSp !< A pointer to the restart control structure
   type(surface_forcing_CS), pointer :: surface_forcing_CSp => NULL()
+  type(tracer_flow_control_CS), pointer :: tracer_flow_CSp  !< user-specfied tracer flow control structure.
 end type soca_mom6_config
 
 contains
@@ -152,7 +153,7 @@ subroutine soca_mom6_init(mom6_config, partial_init)
   integer :: unit, io_status, ierr
   logical :: offline_tracer_mode = .false.
 
-  type(tracer_flow_control_CS), pointer :: tracer_flow_CSp => NULL()
+  !type(tracer_flow_control_CS), pointer :: tracer_flow_CSp => NULL()
   type(diag_ctrl), pointer :: diag => NULL() !< Diagnostic structure
   character(len=4), parameter :: vers_num = 'v2.0'
   character(len=40)  :: mod_name = "soca_mom6" ! This module's name.
@@ -204,6 +205,7 @@ subroutine soca_mom6_init(mom6_config, partial_init)
   mom6_config%restart_CSp => NULL()
   mom6_config%grid => NULL()
   mom6_config%GV => NULL()
+  mom6_config%tracer_flow_CSp => NULL()
 
   ! Set mom6_config%Time to time parsed from mom6 config
   mom6_config%Time = Start_time
@@ -218,7 +220,7 @@ subroutine soca_mom6_init(mom6_config, partial_init)
       mom6_config%MOM_CSp, &
       mom6_config%restart_CSp, &
       offline_tracer_mode=offline_tracer_mode, diag_ptr=diag, &
-      tracer_flow_CSp=tracer_flow_CSp, Time_in=Time_in)
+      tracer_flow_CSp=mom6_config%tracer_flow_CSp, Time_in=Time_in)
 
   !US => mom6_config%scaling
   ! Continue initialization
@@ -239,7 +241,7 @@ subroutine soca_mom6_init(mom6_config, partial_init)
                             param_file,&
                             diag,&
                             mom6_config%surface_forcing_CSp,&
-                            tracer_flow_CSp)
+                            tracer_flow_CSp=mom6_config%tracer_flow_CSp)
 
   ! Get time step from MOM config. TODO: Get DT from DA config
   call get_param(param_file, mod_name, "DT", param_int, fail_if_missing=.true.)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@ list( APPEND soca_test_input
   testinput/forecast_identity.yml
   testinput/forecast_identity_cice.yml
   testinput/forecast_mom6.yml
+  testinput/forecast_mom6_bgc.yml
   testinput/geometry.yml
   testinput/geometry_iterator.yml
   testinput/geometryatm.yml
@@ -69,6 +70,7 @@ list( APPEND soca_test_ref
   testref/forecast_identity_cice.test
   testref/forecast_identity.test
   testref/forecast_mom6.test
+  testref/forecast_mom6_bgc.test
   testref/hofx_3d.test
   testref/hofx_3dcrtm.test
   testref/hofx_4d.test
@@ -83,6 +85,7 @@ list( APPEND soca_model_param
   Data/72x35x25/ice.bkgerror.nc
   Data/72x35x25/input.nml
   Data/72x35x25/MOM_input
+  Data/72x35x25/MOM_override
   Data/72x35x25/ocn.bkgerror.nc
   Data/godas_sst_bgerr.nc
   Data/rossrad.dat
@@ -96,6 +99,7 @@ list( APPEND soca_model_restarts
   Data/72x35x25/INPUT/cice.res.nc
   Data/72x35x25/INPUT/layer_coord25.nc
   Data/72x35x25/INPUT/MOM.res.nc
+  Data/72x35x25/INPUT/MOM.res.bgc.nc
   Data/72x35x25/INPUT/sfc.res.nc
   Data/72x35x25/INPUT/ocean_hgrid.nc
   Data/72x35x25/INPUT/ocean_topog.nc
@@ -343,6 +347,12 @@ soca_add_test( NAME forecast_identity_cice
 
 # Test mom6 forecast
 soca_add_test( NAME forecast_mom6
+               EXE  soca_forecast.x
+               NOTRAPFPE
+               TEST_DEPENDS test_soca_gridgen )
+
+# Test mom6_bgc forecast
+soca_add_test( NAME forecast_mom6_bgc
                EXE  soca_forecast.x
                NOTRAPFPE
                TEST_DEPENDS test_soca_gridgen )

--- a/test/Data/72x35x25/INPUT/MOM.res.nc
+++ b/test/Data/72x35x25/INPUT/MOM.res.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9abf4c1559878aeb9471e1efc8bf1207c2b33678e1ee60625e464560d29868d7
-size 4383692
+oid sha256:92c142af8de5666ed596a0cbd55fdedc3acccd438e06896967024e8e9060e168
+size 7945856

--- a/test/Data/72x35x25/input.nml
+++ b/test/Data/72x35x25/input.nml
@@ -3,7 +3,8 @@
         input_filename = 'r'
         restart_input_dir = 'INPUT/',
         restart_output_dir = 'RESTART/',
-        parameter_filename = 'MOM_input' /
+        parameter_filename = 'MOM_input'
+                             'MOM_override'/
 
  &diag_manager_nml
  /
@@ -26,3 +27,20 @@
        clock_grain='MODULE'
        domains_stack_size = 2000000
        clock_flags='SYNC' /
+
+ &generic_tracer_nml
+       do_generic_tracer=.true.
+       do_generic_age=.false.
+       do_generic_COBALT=.false.
+       do_generic_BLING=.true.
+       do_generic_miniBLING=.false.
+       do_generic_TOPAZ=.false.
+       force_update_fluxes=.true.
+/
+
+ &generic_bling_nml
+      do_carbon=.false.
+      bury_caco3=.false.
+      bury_pop=.false.
+      co2_calc='mocsy'
+/


### PR DESCRIPTION
## Description

This draft PR included necessary changes to mom6 and soca-mom6 interface in order to run soca-mom6 forecast with ocean biogeochemistry (ocean_bgc).

A new ctest forecast_mom6_bgc is created with "chl" extracted from the model and added to soca as a state variable. Additional ocean_bgc variables (e.g. poc) will be added in future PRs.

These updates depend on changes made in the other two draft PRs:
1) adding ocean_bgc to soca-bundle is required:
https://github.com/JCSDA/soca-bundle/pull/26
2) building ocean_bgc libraries into soca_forecast.x is required:
https://github.com/JCSDA/MOM6/pull/10

### Issue(s) addressed

The three PRs together:
- fixes JCSDA/soca-bundle/issues/25



## Testing

All 46 soca ctests, including the new ctest "forecast_mom6_bgc" were tested on Hera.

Notes: 

- A new file "MOM_override" is added to Data/72x35x25 in which a flag "USE_generic_tracer=True" activates ocean_bgc for all soca forecast ctests. "input.nml" is modified to let the model read in "MOM_override" and hence the flag. This does not affect the forecast ctests as ocean_bgc has no feedback to ocean physics except slowing down the tests for a little bit ~10% (in my opinion, ocean_bgc feedback to physics should be activated in the future).
- To deactivate ocean_bgc, set "USE_generic_tracer=False" or comment it out in  "MOM_override", and forecast_mom6_bgc ctest will fail.
- Perhaps a switch for ocean_bgc should be added in the yml file in lieu of using "MOM_override".
- MOM.res.nc is updated to include restarts for ocean_bgc variables.

## Dependencies

There two upstream repositories need to be merged first:
1. soca-bundle: branch = feature/ocean_bgc
https://github.com/JCSDA/soca-bundle/tree/feature/ocean_bgc
2. MOM6: branch = feature/ocean_bgc
https://github.com/JCSDA/MOM6/tree/feature/ocean_bgc
- waiting on JCSDA/soca-bundle/pull/26
- waiting on JCSDA/MOM6/pull/10
