### PR TITLE
Allow multiple communicators

### DIFF
--- a/src/soca/Covariance/soca_covariance_mod.F90
+++ b/src/soca/Covariance/soca_covariance_mod.F90
@@ -9,7 +9,6 @@
 module soca_covariance_mod
 
 use fckit_configuration_module, only: fckit_configuration
-use fckit_mpi_module, only: fckit_mpi_comm
 use random_mod, only: normal_distribution
 use oops_variables_mod
 use type_bump, only: bump_type
@@ -236,8 +235,6 @@ subroutine soca_bump_correlation(self, horiz_convol, geom, f_conf, domain)
   real(kind_real), allocatable :: rv(:,:,:,:)     !< Vertical support radius
   real(kind_real), allocatable :: var(:,:,:,:)
 
-  type(fckit_mpi_comm) :: f_comm
-
   !--- Initialize geometry to be passed to NICAS
   ! Indices for compute domain (no halo)
   isc = geom%isc ; iec = geom%iec ; jsc = geom%jsc ; jec = geom%jec
@@ -268,7 +265,7 @@ subroutine soca_bump_correlation(self, horiz_convol, geom, f_conf, domain)
   vunit = 1.0d0
 
   ! Initialize bump namelist/parameters
-  call horiz_convol%nam%init(f_comm%size())
+  call horiz_convol%nam%init(geom%f_comm%size())
   horiz_convol%nam%verbosity = 'none'
   call horiz_convol%nam%from_conf(f_conf)
 
@@ -276,8 +273,7 @@ subroutine soca_bump_correlation(self, horiz_convol, geom, f_conf, domain)
   if (domain.eq.'ice') horiz_convol%nam%prefix = 'ice'
 
   ! Compute convolution weight
-  f_comm = fckit_mpi_comm()
-  call horiz_convol%setup_online(f_comm,nc0a,nl0,nv,nts,lon,lat,area,vunit,lmask)
+  call horiz_convol%setup_online(geom%f_comm,nc0a,nl0,nv,nts,lon,lat,area,vunit,lmask)
 
   if (horiz_convol%nam%new_nicas) then
      ! Allocation

--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -526,7 +526,6 @@ subroutine soca_fields_dotprod(fld1,fld2,zprod)
 
   real(kind=kind_real) :: local_zprod
   integer :: ii, jj, kk, n
-  type(fckit_mpi_comm) :: f_comm
   type(soca_field), pointer :: field1, field2
 
   ! make sure fields are same shape
@@ -562,8 +561,7 @@ subroutine soca_fields_dotprod(fld1,fld2,zprod)
   end do
 
   ! Get global dot product
-  f_comm = fckit_mpi_comm()
-  call f_comm%allreduce(local_zprod, zprod, fckit_mpi_sum())
+  call fld1%geom%f_comm%allreduce(local_zprod, zprod, fckit_mpi_sum())
 end subroutine soca_fields_dotprod
 
 
@@ -868,10 +866,7 @@ subroutine soca_fields_gpnorm(fld, nf, pstat)
   logical :: mask(fld%geom%isc:fld%geom%iec, fld%geom%jsc:fld%geom%jec)
   real(kind=kind_real) :: ocn_count, local_ocn_count, tmp(3)
   integer :: jj, isc, iec, jsc, jec
-  type(fckit_mpi_comm) :: f_comm
   type(soca_field), pointer :: field
-
-  f_comm = fckit_mpi_comm()
 
   ! Indices for compute domain
   isc = fld%geom%isc ; iec = fld%geom%iec
@@ -879,7 +874,7 @@ subroutine soca_fields_gpnorm(fld, nf, pstat)
 
   ! get the number of ocean grid cells
   local_ocn_count = sum(fld%geom%mask2d(isc:iec, jsc:jec))
-  call f_comm%allreduce(local_ocn_count, ocn_count, fckit_mpi_sum())
+  call fld%geom%f_comm%allreduce(local_ocn_count, ocn_count, fckit_mpi_sum())
   mask = fld%geom%mask2d(isc:iec,jsc:jec) > 0.0
 
   ! calculate global min, max, mean for each field
@@ -900,9 +895,9 @@ subroutine soca_fields_gpnorm(fld, nf, pstat)
     call fldinfo(field%val(isc:iec,jsc:jec,:), mask, tmp)
 
     ! calculate global min/max/mean
-    call f_comm%allreduce(tmp(1), pstat(1,jj), fckit_mpi_min())
-    call f_comm%allreduce(tmp(2), pstat(2,jj), fckit_mpi_max())
-    call f_comm%allreduce(tmp(3), pstat(3,jj), fckit_mpi_sum())
+    call fld%geom%f_comm%allreduce(tmp(1), pstat(1,jj), fckit_mpi_min())
+    call fld%geom%f_comm%allreduce(tmp(2), pstat(2,jj), fckit_mpi_max())
+    call fld%geom%f_comm%allreduce(tmp(3), pstat(3,jj), fckit_mpi_sum())
     pstat(3,jj) = pstat(3,jj)/ocn_count
   end do
 end subroutine soca_fields_gpnorm

--- a/src/soca/Geometry/Geometry.cc
+++ b/src/soca/Geometry/Geometry.cc
@@ -25,7 +25,7 @@ namespace soca {
                      const eckit::mpi::Comm & comm)
     : comm_(comm), atmconf_(conf), initatm_(initAtm(conf)) {
     const eckit::Configuration * configc = &conf;
-    soca_geo_setup_f90(keyGeom_, &configc);
+    soca_geo_setup_f90(keyGeom_, &configc, &comm);
   }
   // -----------------------------------------------------------------------------
   Geometry::Geometry(const Geometry & other)

--- a/src/soca/Geometry/GeometryFortran.h
+++ b/src/soca/Geometry/GeometryFortran.h
@@ -18,7 +18,9 @@ namespace eckit {
 namespace soca {
 
   extern "C" {
-    void soca_geo_setup_f90(F90geom &, const eckit::Configuration * const *);
+    void soca_geo_setup_f90(F90geom &,
+                            const eckit::Configuration * const *,
+                            const eckit::mpi::Comm *);
     void soca_geo_clone_f90(const F90geom &, F90geom &);
     void soca_geo_gridgen_f90(const F90geom &);
     void soca_geo_delete_f90(F90geom &);

--- a/src/soca/Geometry/soca_geom.interface.F90
+++ b/src/soca/Geometry/soca_geom.interface.F90
@@ -44,7 +44,7 @@ subroutine c_soca_geo_setup(c_key_self, c_conf, c_comm) bind(c,name='soca_geo_se
   call soca_geom_registry%add(c_key_self)
   call soca_geom_registry%get(c_key_self,self)
 
-  call self%init(fckit_configuration(c_conf), fckit_mpi_comm(c_comm) ) !f_comm)
+  call self%init(fckit_configuration(c_conf), fckit_mpi_comm(c_comm) )
 
 end subroutine c_soca_geo_setup
 

--- a/src/soca/Geometry/soca_geom.interface.F90
+++ b/src/soca/Geometry/soca_geom.interface.F90
@@ -7,6 +7,7 @@ module soca_geom_mod_c
 
 use iso_c_binding
 use fckit_configuration_module, only: fckit_configuration
+use fckit_mpi_module,           only: fckit_mpi_comm
 use soca_geom_mod, only: soca_geom
 
 implicit none
@@ -31,10 +32,11 @@ contains
 
 ! ------------------------------------------------------------------------------
 !> Setup geometry object
-subroutine c_soca_geo_setup(c_key_self, c_conf) bind(c,name='soca_geo_setup_f90')
+subroutine c_soca_geo_setup(c_key_self, c_conf, c_comm) bind(c,name='soca_geo_setup_f90')
 
-  integer(c_int), intent(inout) :: c_key_self
-  type(c_ptr),       intent(in) :: c_conf
+  integer(c_int),  intent(inout) :: c_key_self
+  type(c_ptr),        intent(in) :: c_conf
+  type(c_ptr), value, intent(in) :: c_comm
 
   type(soca_geom), pointer :: self
 
@@ -42,7 +44,7 @@ subroutine c_soca_geo_setup(c_key_self, c_conf) bind(c,name='soca_geo_setup_f90'
   call soca_geom_registry%add(c_key_self)
   call soca_geom_registry%get(c_key_self,self)
 
-  call self%init(fckit_configuration(c_conf))
+  call self%init(fckit_configuration(c_conf), fckit_mpi_comm(c_comm) ) !f_comm)
 
 end subroutine c_soca_geo_setup
 
@@ -92,13 +94,13 @@ subroutine c_soca_geo_delete(c_key_self) bind(c,name='soca_geo_delete_f90')
 end subroutine c_soca_geo_delete
 
 ! ------------------------------------------------------------------------------
-!> return begin and end of local geometry 
+!> return begin and end of local geometry
 subroutine c_soca_geo_start_end(c_key_self, ist, iend, jst, jend) bind(c, name='soca_geo_start_end_f90')
 
   implicit none
 
   integer(c_int), intent( in) :: c_key_self
-  integer(c_int), intent(out) :: ist, iend, jst, jend 
+  integer(c_int), intent(out) :: ist, iend, jst, jend
 
   type(soca_geom), pointer :: self
   call soca_geom_registry%get(c_key_self, self)

--- a/src/soca/Geometry/soca_geom_mod.F90
+++ b/src/soca/Geometry/soca_geom_mod.F90
@@ -158,6 +158,9 @@ subroutine geom_clone(self, other)
   class(soca_geom), intent( in) :: self
   class(soca_geom), intent(out) :: other
 
+  ! Clone communicator
+  other%f_comm = self%f_comm
+
   ! Clone fms domain and vertical levels
   other%Domain => self%Domain
   other%nzo = self%nzo

--- a/src/soca/Geometry/soca_geom_mod.F90
+++ b/src/soca/Geometry/soca_geom_mod.F90
@@ -74,9 +74,9 @@ contains
 ! ------------------------------------------------------------------------------
 !> Setup geometry object
 subroutine geom_init(self, f_conf, f_comm)
-  class(soca_geom), intent(out) :: self
+  class(soca_geom),         intent(out) :: self
   type(fckit_configuration), intent(in) :: f_conf
-  type(fckit_mpi_comm),        intent(in)    :: f_comm
+  type(fckit_mpi_comm),   intent(in)    :: f_comm
 
   integer :: isave = 0
 

--- a/src/soca/Geometry/soca_geom_mod.F90
+++ b/src/soca/Geometry/soca_geom_mod.F90
@@ -53,6 +53,7 @@ type :: soca_geom
     real(kind=kind_real), allocatable, dimension(:,:) :: rossby_radius
     logical :: save_local_domain = .false. ! If true, save the local geometry for each pe.
     character(len=:), allocatable :: geom_grid_file
+    type(fckit_mpi_comm) :: f_comm
 
     contains
     procedure :: init => geom_init
@@ -72,14 +73,18 @@ contains
 
 ! ------------------------------------------------------------------------------
 !> Setup geometry object
-subroutine geom_init(self, f_conf)
+subroutine geom_init(self, f_conf, f_comm)
   class(soca_geom), intent(out) :: self
   type(fckit_configuration), intent(in) :: f_conf
+  type(fckit_mpi_comm),        intent(in)    :: f_comm
 
   integer :: isave = 0
 
+  ! MPI communicator
+  self%f_comm = f_comm
+
   ! Domain decomposition
-  call soca_geomdomain_init(self%Domain, self%nzo)
+  call soca_geomdomain_init(self%Domain, self%nzo, f_comm)
 
   ! Initialize sea-ice grid
   if ( f_conf%has("num_ice_cat") ) &
@@ -299,10 +304,6 @@ subroutine geom_write(self)
   integer :: ns
   integer :: idr_geom
   type(restart_file_type) :: geom_restart
-  type(fckit_mpi_comm) :: f_comm
-
-  ! Setup Communicator
-  f_comm = fckit_mpi_comm()
 
   ! Save global domain
   call fms_io_init()
@@ -377,7 +378,7 @@ subroutine geom_write(self)
 
   if (self%save_local_domain) then
      ! Save local compute grid
-     pe = f_comm%rank()
+     pe = self%f_comm%rank()
 
      write (strpe,fmt) pe
      geom_output_pe='geom_output_'//trim(strpe)//'.nc'

--- a/src/soca/GetValues/soca_getvalues_mod.F90
+++ b/src/soca/GetValues/soca_getvalues_mod.F90
@@ -12,7 +12,6 @@ use kinds, only: kind_real
 use ufo_geovals_mod, only: ufo_geovals
 use ufo_locs_mod, only: ufo_locs, ufo_locs_time_mask
 use unstructured_interpolation_mod, only: unstrc_interp
-use fckit_mpi_module, only: fckit_mpi_comm
 use fckit_log_module, only : fckit_log
 
 implicit none
@@ -44,7 +43,6 @@ subroutine soca_getvalues_create(self, geom, locs)
   type(ufo_locs),           intent(in) :: locs
 
   integer :: isc, iec, jsc, jec, ni, nj
-  type(fckit_mpi_comm) :: f_comm
   integer :: nn, ngrid_in, ngrid_out
   character(len=8) :: wtype = 'barycent'
   real(kind=kind_real), allocatable :: lats_in(:), lons_in(:)
@@ -53,7 +51,6 @@ subroutine soca_getvalues_create(self, geom, locs)
   isc = geom%isc ; iec = geom%iec
   jsc = geom%jsc ; jec = geom%jec
 
-  f_comm = fckit_mpi_comm()
   ngrid_out = locs%nlocs
   nn = 3
 
@@ -65,7 +62,7 @@ subroutine soca_getvalues_create(self, geom, locs)
 
   lons_in = reshape(geom%lon(isc:iec,jsc:jec), (/ngrid_in/))
   lats_in = reshape(geom%lat(isc:iec,jsc:jec), (/ngrid_in/))
-  call self%horiz_interp%create(f_comm, nn, wtype, &
+  call self%horiz_interp%create(geom%f_comm, nn, wtype, &
                            ngrid_in, lats_in, lons_in, &
                            ngrid_out, locs%lat, locs%lon)
 
@@ -74,7 +71,7 @@ subroutine soca_getvalues_create(self, geom, locs)
   ngrid_in = count(geom%mask2d(isc:iec,jsc:jec) > 0)
   lons_in = pack(geom%lon(isc:iec,jsc:jec), mask=geom%mask2d(isc:iec,jsc:jec) > 0)
   lats_in = pack(geom%lat(isc:iec,jsc:jec), mask=geom%mask2d(isc:iec,jsc:jec) > 0)
-  call self%horiz_interp_masked%create(f_comm, nn, wtype, &
+  call self%horiz_interp_masked%create(geom%f_comm, nn, wtype, &
                            ngrid_in, lats_in, lons_in, &
                            ngrid_out, locs%lat, locs%lon)
 end subroutine soca_getvalues_create

--- a/src/soca/Increment/soca_increment_mod.F90
+++ b/src/soca/Increment/soca_increment_mod.F90
@@ -9,7 +9,6 @@ use soca_fields_mod
 use soca_geom_iter_mod, only : soca_geom_iter
 use kinds, only: kind_real
 use fckit_configuration_module, only: fckit_configuration
-use fckit_mpi_module, only: fckit_mpi_comm
 use random_mod, only: normal_distribution
 use unstructured_grid_mod, only: unstructured_grid, &
                                  allocate_unstructured_grid_coord, &
@@ -147,12 +146,8 @@ subroutine soca_increment_dirac(self, f_conf)
   integer :: isc, iec, jsc, jec
   integer :: ndir,n, z
   integer,allocatable :: ixdir(:),iydir(:),izdir(:),ifdir(:)
-  type(fckit_mpi_comm) :: f_comm
 
   type(soca_field), pointer :: field
-
-  ! Get MPI communicator
-  f_comm = fckit_mpi_comm()
 
   ! Get Diracs size
   ndir = f_conf%get_size("ixdir")

--- a/src/soca/Model/soca_model.interface.F90
+++ b/src/soca/Model/soca_model.interface.F90
@@ -59,10 +59,6 @@ subroutine c_soca_setup(c_conf, c_key_geom, c_key_model) bind (c,name='soca_setu
   call soca_model_registry%add(c_key_model)
   call soca_model_registry%get(c_key_model, model)
 
-  ! Get local grid size
-  model%nx =  size(geom%lon,1)
-  model%ny = size(geom%lon,2)
-
   ! Setup time step
   call f_conf%get_or_die("tstep", str)
   dtstep = trim(str)
@@ -86,7 +82,7 @@ subroutine c_soca_setup(c_conf, c_key_geom, c_key_model) bind (c,name='soca_setu
   endif
 
   ! Initialize mom6
-  call soca_setup(model)
+  call soca_setup(model, geom)
 
   if (allocated(str)) deallocate(str)
 

--- a/src/soca/Model/soca_model_mod.F90
+++ b/src/soca/Model/soca_model_mod.F90
@@ -7,8 +7,10 @@
 
 module soca_model_mod
 
+use fckit_mpi_module, only: fckit_mpi_comm
 use fms_io_mod, only : fms_io_init, fms_io_exit
 use kinds, only: kind_real
+use soca_geom_mod, only: soca_geom
 use soca_mom6, only: soca_mom6_config, soca_mom6_init, soca_mom6_end
 use soca_utils, only: soca_str2int
 use soca_state_mod
@@ -34,8 +36,6 @@ public :: soca_delete
 
 !> Fortran derived type to hold configuration data for the model
 type :: soca_model
-   integer :: nx                !< Zonal grid dimension
-   integer :: ny                !< Meridional grid dimension
    integer :: advance_mom6      !< call mom6 step if true
    real(kind=kind_real) :: dt0  !< dimensional time (seconds)
    type(soca_mom6_config) :: mom6_config  !< MOM6 data structure
@@ -48,9 +48,11 @@ contains
 
 ! ------------------------------------------------------------------------------
 !> Initialize model's data structure
-subroutine soca_setup(self)
+subroutine soca_setup(self, geom)
   type(soca_model), intent(inout) :: self
+  type(soca_geom),     intent(in) :: geom
 
+  self%mom6_config%f_comm = geom%f_comm
   call soca_mom6_init(self%mom6_config)
 
 end subroutine soca_setup

--- a/src/soca/Model/soca_mom6.F90
+++ b/src/soca/Model/soca_mom6.F90
@@ -95,22 +95,22 @@ type soca_mom6_config
   type(MOM_control_struct), pointer :: MOM_CSp  !< Tracer flow control structure.
   type(MOM_restart_CS),     pointer :: restart_CSp !< A pointer to the restart control structure
   type(surface_forcing_CS), pointer :: surface_forcing_CSp => NULL()
+  type(fckit_mpi_comm) :: f_comm
 end type soca_mom6_config
 
 contains
 
 ! ------------------------------------------------------------------------------
 !> Initialize mom6's domain
-subroutine soca_geomdomain_init(Domain, nk)
+subroutine soca_geomdomain_init(Domain, nk, f_comm)
   type(MOM_domain_type), pointer, intent(in) :: Domain !< Ocean model domain
-  integer, intent(out) :: nk
+  integer, intent(out)                       :: nk
+  type(fckit_mpi_comm),           intent(in) :: f_comm
 
   type(param_file_type) :: param_file                !< Structure to parse for run-time parameters
   type(directories)     :: dirs                      !< Structure containing several relevant directory paths
-  type(fckit_mpi_comm) :: f_comm
   character(len=40)  :: mod_name = "soca_mom6" ! This module's name.
 
-  f_comm = fckit_mpi_comm()
   call mpp_init(localcomm=f_comm%communicator())
 
   ! Initialize fms
@@ -164,13 +164,11 @@ subroutine soca_mom6_init(mom6_config, partial_init)
        ocean_nthreads, ncores_per_node, use_hyper_thread
   integer :: param_int
   logical :: a_partial_init = .false.
-  type(fckit_mpi_comm) :: f_comm
 
   ! Check if partial mom6 init is requiered
   if (present(partial_init)) a_partial_init = partial_init
 
-  f_comm = fckit_mpi_comm()
-  call MOM_infra_init(localcomm=f_comm%communicator())
+  call MOM_infra_init(localcomm=mom6_config%f_comm%communicator())
   call io_infra_init()
 
   ! Provide for namelist specification of the run length and calendar data.

--- a/src/soca/State/State.cc
+++ b/src/soca/State/State.cc
@@ -98,7 +98,11 @@ namespace soca {
   // -----------------------------------------------------------------------------
   State & State::operator+=(const Increment & dx) {
     ASSERT(validTime() == dx.validTime());
-    soca_state_add_incr_f90(toFortran(), dx.toFortran());
+    // Interpolate increment to analysis grid
+    Increment dx_hr(*geom_, dx);
+
+    // Add increment to background state
+    soca_state_add_incr_f90(toFortran(), dx_hr.toFortran());
     return *this;
   }
   // -----------------------------------------------------------------------------

--- a/src/soca/State/soca_state_mod.F90
+++ b/src/soca/State/soca_state_mod.F90
@@ -150,6 +150,10 @@ subroutine soca_state_add_incr(self, rhs)
      call incr%get("uocn", du)
      call incr%get("vocn", dv)
 
+     ! Initialize du and dv to 0
+     du%val = 0.0_kind_real
+     dv%val = 0.0_kind_real
+
      ! Compute the geostrophic increment
      call geostrophy%setup(self%geom, h%val)
      call geostrophy%tl(h%val, t%val, s%val,&

--- a/src/soca/State/soca_state_mod.F90
+++ b/src/soca/State/soca_state_mod.F90
@@ -145,7 +145,6 @@ subroutine soca_state_add_incr(self, rhs)
      call self%get("hocn", h)
 
      ! Make a copy of the increment and get the needed pointers
-     !call incr_geo%copy(rhs)
      call incr%get("tocn", dt)
      call incr%get("socn", ds)
      call incr%get("uocn", du)

--- a/src/soca/Utils/soca_geostrophy_mod.F90
+++ b/src/soca/Utils/soca_geostrophy_mod.F90
@@ -92,10 +92,10 @@ contains
     ! Compute horizontal inverse transformation metrics
     do j = geom%jsc, geom%jec
        do i = geom%isc, geom%iec
-          dlondi(i,j) = 0.5*deg2rad*(geom%lon(i+1,j)-geom%lon(i-1,j))
-          dlondj(i,j) = 0.5*deg2rad*(geom%lon(i,j+1)-geom%lon(i,j-1))
-          dlatdi(i,j) = 0.5*deg2rad*(geom%lat(i+1,j)-geom%lat(i-1,j))
-          dlatdj(i,j) = 0.5*deg2rad*(geom%lat(i,j+1)-geom%lat(i,j-1))
+          dlondi(i,j) = 0.5_kind_real*deg2rad*(geom%lon(i+1,j)-geom%lon(i-1,j))
+          dlondj(i,j) = 0.5_kind_real*deg2rad*(geom%lon(i,j+1)-geom%lon(i,j-1))
+          dlatdi(i,j) = 0.5_kind_real*deg2rad*(geom%lat(i+1,j)-geom%lat(i-1,j))
+          dlatdj(i,j) = 0.5_kind_real*deg2rad*(geom%lat(i,j+1)-geom%lat(i,j-1))
        end do
     end do
 
@@ -107,8 +107,8 @@ contains
     do k = 1, geom%nzo
        do j = geom%jsc, geom%jec
           do i = geom%isc, geom%iec
-             dzdi(i,j,k) = 0.5*(z(i+1,j,k)-z(i-1,j,k))
-             dzdj(i,j,k) = 0.5*(z(i,j+1,k)-z(i,j-1,k))
+             dzdi(i,j,k) = 0.5_kind_real*(z(i+1,j,k)-z(i-1,j,k))
+             dzdj(i,j,k) = 0.5_kind_real*(z(i,j+1,k)-z(i,j-1,k))
           end do
        end do
     end do
@@ -136,20 +136,21 @@ contains
     self%dkdz = dlondi*dlatdj-dlondj*dlatdi
 
     ! Zero out weights close to equator (no beta-plane proxi yet)
-    Lb = 1.55
+    Lb = 1.55_kind_real
     allocate(wb(geom%isd:geom%ied,geom%jsd:geom%jed))
     wb  =exp(-geom%lat**2/(2*Lb**2))
     self%icorio = 0.0
     where (geom%lat.ne.0.0)
-       self%icorio = (1.0-wb)/(2.0*1035.0*sin(deg2rad*geom%lat)*7.2921e-5)
+       self%icorio = (1.0_kind_real-wb)/&
+            (2.0_kind_real*1035.0_kind_real*sin(deg2rad*geom%lat)*7.2921e-5_kind_real)
     end where
 
     ! Compute weights for zonal and meridional derivatives
-    self%dxwgt = 0.0
-    where (geom%lat.ne.0.0)
-       self%dxwgt = 1.0/(req*cos(deg2rad*geom%lat))
+    self%dxwgt = 0.0_kind_real
+    where (geom%lat.ne.0.0_kind_real)
+       self%dxwgt = 1.0_kind_real/(req*cos(deg2rad*geom%lat))
     end where
-    self%dywgt = 1.0/req
+    self%dywgt = 1.0_kind_real/req
 
     ! Fill halo of grid metric parameters
     call mpp_update_domains(self%Jac, geom%Domain%mpp_domain)
@@ -221,7 +222,7 @@ contains
     call geom%thickness2depth(h, z)
 
     ! Density increment scaled by layer thickness at level k
-    drhoh = 0.0
+    drhoh = 0.0_kind_real
     do k = 1, nl
        rho0 = soca_rho(s(:,:,k), t(:,:,k), z(:,:,k), geom%lon, geom%lat)
        do j = geom%jsc, geom%jec


### PR DESCRIPTION
## Description
Finishing the work started in #208 : Pass the mpi communicator to the lower fortran levels.

**What bug does it fix, or what feature does it add?**
This should allow the use of multiple communicators, required to implement some of the oops applications. This PR should allow the implementation of the change of resolution (#206, #339 ), and EDA, possibly, unless I forgot something ...

Is a change of answers expected from this PR? **No**

### Issue(s) addressed
- closes #210 

## Testing
How were these changes tested? **Using the current ctests**
What compilers / HPCs was it tested with? **gcc 7.4, Intel 18**
Are the changes covered by ctests? **yes**

## Dependencies
None
