### PR TITLE
untwist bad logic, tidy code, revive save of local geometry

### DIFF
--- a/src/soca/Geometry/soca_geom_mod.F90
+++ b/src/soca/Geometry/soca_geom_mod.F90
@@ -79,6 +79,7 @@ subroutine geom_init(self, f_conf, f_comm)
   type(fckit_mpi_comm),   intent(in)    :: f_comm
 
   integer :: isave = 0
+  logical :: full_init = .false.
 
   ! MPI communicator
   self%f_comm = f_comm
@@ -106,8 +107,12 @@ subroutine geom_init(self, f_conf, f_comm)
   ! Allocate geometry arrays
   call geom_allocate(self)
 
-  ! Read the geometry (created by gridgen)
-  call geom_read(self)
+  ! Check if a full initialization is requiered, default to false
+  if ( .not. f_conf%get("full_init", full_init) ) full_init = .false.
+
+  ! Read the geometry from file by default,
+  ! skip this step if a full init is requiered
+  if ( .not. full_init) call geom_read(self)
 
   ! Fill halo
   call mpp_update_domains(self%lon, self%Domain%mpp_domain)

--- a/src/soca/Geometry/soca_geom_mod.F90
+++ b/src/soca/Geometry/soca_geom_mod.F90
@@ -78,7 +78,6 @@ subroutine geom_init(self, f_conf, f_comm)
   type(fckit_configuration), intent(in) :: f_conf
   type(fckit_mpi_comm),   intent(in)    :: f_comm
 
-  integer :: isave = 0
   logical :: full_init = .false.
 
   ! MPI communicator
@@ -107,11 +106,11 @@ subroutine geom_init(self, f_conf, f_comm)
   ! Allocate geometry arrays
   call geom_allocate(self)
 
-  ! Check if a full initialization is requiered, default to false
+  ! Check if a full initialization is required, default to false
   if ( .not. f_conf%get("full_init", full_init) ) full_init = .false.
 
   ! Read the geometry from file by default,
-  ! skip this step if a full init is requiered
+  ! skip this step if a full init is required
   if ( .not. full_init) call geom_read(self)
 
   ! Fill halo
@@ -129,9 +128,9 @@ subroutine geom_init(self, f_conf, f_comm)
   call mpp_update_domains(self%cell_area, self%Domain%mpp_domain)
 
   ! Set output option for local geometry
-  if ( f_conf%has("save_local_domain") ) &
-      call f_conf%get_or_die("save_local_domain", isave)
-  if ( isave == 1 ) self%save_local_domain = .true.
+  if ( .not. f_conf%get("save_local_domain", self%save_local_domain) ) &
+     self%save_local_domain = .false.
+
 
 end subroutine geom_init
 

--- a/src/soca/Geometry/soca_geom_mod.F90
+++ b/src/soca/Geometry/soca_geom_mod.F90
@@ -106,8 +106,8 @@ subroutine geom_init(self, f_conf, f_comm)
   ! Allocate geometry arrays
   call geom_allocate(self)
 
-  if ( f_conf%has("read_soca_grid") ) &
-      call geom_read(self)
+  ! Read the geometry (created by gridgen)
+  call geom_read(self)
 
   ! Fill halo
   call mpp_update_domains(self%lon, self%Domain%mpp_domain)
@@ -387,7 +387,7 @@ subroutine geom_write(self)
      geom_output_pe='geom_output_'//trim(strpe)//'.nc'
 
      ns = (self%iec - self%isc + 1) * (self%jec - self%jsc + 1 )
-     call write2pe(reshape(self%mask2d,(/ns/)),'mask',geom_output_pe,.true.)
+     call write2pe(reshape(self%mask2d,(/ns/)),'mask',geom_output_pe,.false.)
      call write2pe(reshape(self%lon,(/ns/)),'lon',geom_output_pe,.true.)
      call write2pe(reshape(self%lat,(/ns/)),'lat',geom_output_pe,.true.)
   end if

--- a/test/testinput/3dhyb.yml
+++ b/test/testinput/3dhyb.yml
@@ -2,7 +2,6 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 model:
   name: SOCA
@@ -11,7 +10,7 @@ model:
   variables: &soca_vars [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
 
 _bkg_date: &bkg_date 2018-04-15T00:00:00Z
-  
+
 _file: &_file
   read_from_file: 1
   date: *bkg_date
@@ -34,12 +33,12 @@ cost_function:
         sfc_filename: sfc.res.nc
         date: *bkg_date
         seaice_model: cice
-        
+
     Covariance:
      covariance: hybrid
      static_weight: 0.5
      ensemble_weight: 0.5
-     static: 
+     static:
       covariance: SocaError
       prefix: soca
       datadir: ./bump
@@ -114,7 +113,7 @@ cost_function:
 
       - <<: *_file
         ocn_filename: ocn.pert.ens.3.2018-04-15T00:00:00Z.PT0S.nc
-        ice_filename: ice.pert.ens.3.2018-04-15T00:00:00Z.PT0S.nc        
+        ice_filename: ice.pert.ens.3.2018-04-15T00:00:00Z.PT0S.nc
 
       - <<: *_file
         ocn_filename: ocn.pert.ens.4.2018-04-15T00:00:00Z.PT0S.nc
@@ -153,7 +152,6 @@ variational:
       num_ice_cat: 5
       num_ice_lev: 4
       num_sno_lev: 1
-      read_soca_grid: grid      
     linearmodel:
       varchange: Identity
       version: IdTLM

--- a/test/testinput/3dhybfgat.yml
+++ b/test/testinput/3dhybfgat.yml
@@ -2,7 +2,6 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 model:
   name: SOCA
@@ -11,13 +10,13 @@ model:
   variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
 
 _date_begin: &date_begin 2018-04-15T00:00:00Z
-  
+
 _file: &_file
   read_from_file: 1
   date: *date_begin
   basename: ./Data/
   remap_filename: ./INPUT/MOM.res.nc
-    
+
 cost_function:
   cost_type: 4D-Var
   window_begin: *date_begin
@@ -38,7 +37,7 @@ cost_function:
      covariance: hybrid
      static_weight: 0.5
      ensemble_weight: 0.5
-     static: 
+     static:
       covariance: SocaError
       prefix: soca
       datadir: ./bump
@@ -113,7 +112,7 @@ cost_function:
 
       - <<: *_file
         ocn_filename: ocn.pert.ens.3.2018-04-15T00:00:00Z.PT0S.nc
-        ice_filename: ice.pert.ens.3.2018-04-15T00:00:00Z.PT0S.nc        
+        ice_filename: ice.pert.ens.3.2018-04-15T00:00:00Z.PT0S.nc
 
       - <<: *_file
         ocn_filename: ocn.pert.ens.4.2018-04-15T00:00:00Z.PT0S.nc
@@ -152,7 +151,6 @@ variational:
       num_ice_cat: 5
       num_ice_lev: 4
       num_sno_lev: 1
-      read_soca_grid: grid
     linearmodel:
       varchange: Identity
       version: IdTLM

--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -15,7 +15,6 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 model:
   name: SOCA
@@ -213,7 +212,6 @@ variational:
       num_ice_cat: 5
       num_ice_lev: 4
       num_sno_lev: 1
-      read_soca_grid: grid
     linearmodel:
       varchange: Identity
       version: IdTLM

--- a/test/testinput/3dvar_soca.yml
+++ b/test/testinput/3dvar_soca.yml
@@ -15,7 +15,6 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 model:
   name: SOCA
@@ -225,7 +224,6 @@ variational:
       num_ice_cat: 5
       num_ice_lev: 4
       num_sno_lev: 1
-      read_soca_grid: grid
     linearmodel:
       varchange: Identity
       version: IdTLM

--- a/test/testinput/3dvarfgat.yml
+++ b/test/testinput/3dvarfgat.yml
@@ -15,7 +15,6 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 model:
   name: SOCA
@@ -213,7 +212,6 @@ variational:
       num_ice_cat: 5
       num_ice_lev: 4
       num_sno_lev: 1
-      read_soca_grid: grid
     linearmodel:
       varchange: Identity
       version: IdTLM

--- a/test/testinput/addincrement.yml
+++ b/test/testinput/addincrement.yml
@@ -2,13 +2,11 @@ stateResol:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 incrementResol:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 state:
   read_from_file: 1

--- a/test/testinput/checkpointmodel.yml
+++ b/test/testinput/checkpointmodel.yml
@@ -2,7 +2,6 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 model:
   name: SOCA

--- a/test/testinput/convertstate.yml
+++ b/test/testinput/convertstate.yml
@@ -4,12 +4,12 @@ inputresolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
+  geom_grid_file: soca_gridspec.nc
 outputresolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
+  geom_grid_file: soca_gridspec.nc
 varchange: Ana2Model
 rotate:
   u: [uocn]

--- a/test/testinput/dirac_bump_cov.yml
+++ b/test/testinput/dirac_bump_cov.yml
@@ -42,5 +42,4 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 variables: *soca_vars

--- a/test/testinput/dirac_horizfilt.yml
+++ b/test/testinput/dirac_horizfilt.yml
@@ -2,7 +2,6 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 initial:
   read_from_file: 1

--- a/test/testinput/dirac_soca_cov.yml
+++ b/test/testinput/dirac_soca_cov.yml
@@ -2,7 +2,6 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 initial:
   read_from_file: 1

--- a/test/testinput/dirac_socahyb_cov.yml
+++ b/test/testinput/dirac_socahyb_cov.yml
@@ -2,7 +2,6 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 initial:
   read_from_file: 1
@@ -16,14 +15,14 @@ _file: &_file
   date: *date
   basename: ./Data/
   remap_filename: ./INPUT/MOM.res.nc
-  
+
 variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn]
 
 Covariance:
   covariance: hybrid
   static_weight: 0.5
   ensemble_weight: 0.5
-  static: 
+  static:
    covariance: SocaError
    prefix: soca
    datadir: ./bump

--- a/test/testinput/enshofx.yml
+++ b/test/testinput/enshofx.yml
@@ -5,7 +5,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 Model:
   name: SOCA

--- a/test/testinput/enspert.yml
+++ b/test/testinput/enspert.yml
@@ -2,7 +2,6 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 model:
   name: SOCA

--- a/test/testinput/ensrecenter.yml
+++ b/test/testinput/ensrecenter.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 _file: &_file
   read_from_file: 1

--- a/test/testinput/ensvariance.yml
+++ b/test/testinput/ensvariance.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 Variables:
   variables:  &soca_vars [cicen, hicen, socn, tocn, ssh, hocn]

--- a/test/testinput/forecast_identity.yml
+++ b/test/testinput/forecast_identity.yml
@@ -2,7 +2,6 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid 
 model:
   name: SOCA
   tstep: PT1H

--- a/test/testinput/forecast_identity_cice.yml
+++ b/test/testinput/forecast_identity_cice.yml
@@ -2,7 +2,6 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 model:
   name: SOCA
@@ -27,4 +26,4 @@ output:
   exp: Id
   date: 2018-04-15T00:00:00Z
   type: fc
-  seaice_model: cice  
+  seaice_model: cice

--- a/test/testinput/forecast_mom6.yml
+++ b/test/testinput/forecast_mom6.yml
@@ -2,7 +2,6 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 model:
   name: SOCA

--- a/test/testinput/geometry.yml
+++ b/test/testinput/geometry.yml
@@ -2,4 +2,3 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid

--- a/test/testinput/geometry_iterator.yml
+++ b/test/testinput/geometry_iterator.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 Variables:
   variables: [cicen, hicen, socn, tocn, ssh, hocn]

--- a/test/testinput/geometryatm.yml
+++ b/test/testinput/geometryatm.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
   atm_state:
     init: true
     date_begin: 2018-04-14T00:00:00Z

--- a/test/testinput/getvalues.yml
+++ b/test/testinput/getvalues.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: soca_gridspec.nc
 
 GetValuesTest:
   interp_tolerance: 1.0e-2

--- a/test/testinput/gridgen.yml
+++ b/test/testinput/gridgen.yml
@@ -3,6 +3,7 @@ geometry:
   num_ice_lev: 4
   num_sno_lev: 1
   geom_grid_file: soca_gridspec.nc
+  save_local_domain: 1
 
 gridgen:
   name: SOCA

--- a/test/testinput/gridgen.yml
+++ b/test/testinput/gridgen.yml
@@ -3,8 +3,8 @@ geometry:
   num_ice_lev: 4
   num_sno_lev: 1
   geom_grid_file: soca_gridspec.nc
-  save_local_domain: 1
-  full_init: 1
+  save_local_domain: true
+  full_init: true
 gridgen:
   name: SOCA
   tstep: PT6H

--- a/test/testinput/gridgen.yml
+++ b/test/testinput/gridgen.yml
@@ -4,7 +4,7 @@ geometry:
   num_sno_lev: 1
   geom_grid_file: soca_gridspec.nc
   save_local_domain: 1
-
+  full_init: 1
 gridgen:
   name: SOCA
   tstep: PT6H

--- a/test/testinput/hofx_3d.yml
+++ b/test/testinput/hofx_3d.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 Forecasts:
   variables: [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]

--- a/test/testinput/hofx_3dcrtm.yml
+++ b/test/testinput/hofx_3dcrtm.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
   notocean:
     init: true
     date_begin: 2018-04-14T00:00:00Z

--- a/test/testinput/hofx_4d.yml
+++ b/test/testinput/hofx_4d.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 Model:
   name: SOCA

--- a/test/testinput/increment.yml
+++ b/test/testinput/increment.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 Variables:
   variables: [cicen, hicen, socn, tocn, ssh, hocn, sw, lw, lhf, shf, us]

--- a/test/testinput/letkf.yml
+++ b/test/testinput/letkf.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 Assimilation Window:
   window_begin: &date 2018-04-14T00:00:00Z
@@ -71,4 +70,3 @@ output:
   date: *date
   exp: letkf
   type: ens
-

--- a/test/testinput/lineargetvalues.yml
+++ b/test/testinput/lineargetvalues.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: soca_gridspec.nc
 
 LinearGetValuesTest:
   toleranceLinearity: 1.0e-11

--- a/test/testinput/linearmodel.yml
+++ b/test/testinput/linearmodel.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 Variables:
   variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]

--- a/test/testinput/makeobs.yml
+++ b/test/testinput/makeobs.yml
@@ -6,7 +6,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 Model:
   name: SOCA

--- a/test/testinput/model.yml
+++ b/test/testinput/model.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 ModelBias:
 
@@ -23,7 +22,7 @@ State:
   basename: "./INPUT/"
   ocn_filename: MOM.res.nc
   ice_filename: ice_model.res.nc
-  sfc_filename: sfc.res.nc  
+  sfc_filename: sfc.res.nc
   variables: *soca_vars
 
 forecast_length: PT3H

--- a/test/testinput/parameters_bump_cov_lct.yml
+++ b/test/testinput/parameters_bump_cov_lct.yml
@@ -2,7 +2,6 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn]
 

--- a/test/testinput/parameters_bump_cov_nicas.yml
+++ b/test/testinput/parameters_bump_cov_nicas.yml
@@ -2,7 +2,6 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 variables: &soca_vars  [cicen, hicen, socn, tocn, ssh, hocn]
 

--- a/test/testinput/parameters_bump_loc.yml
+++ b/test/testinput/parameters_bump_loc.yml
@@ -2,7 +2,6 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 variables: &soca_vars [cicen, hicen, hsnon, socn, tocn, ssh, hocn]
 

--- a/test/testinput/state.yml
+++ b/test/testinput/state.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 StateTest:
   StateFile:

--- a/test/testinput/static_socaerror_init.yml
+++ b/test/testinput/static_socaerror_init.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 Variables:
   variables: &soca_vars [cicen, hicen, hocn, socn, tocn, ssh]

--- a/test/testinput/static_socaerror_test.yml
+++ b/test/testinput/static_socaerror_test.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 Variables:
   variables: &soca_vars [cicen, hicen, hocn, socn, tocn, ssh]
@@ -30,5 +29,3 @@ Covariance:
 CovarianceTest:
   tolerance: 1e-10
   testinverse: false
-
-

--- a/test/testinput/varchange_ana2model.yml
+++ b/test/testinput/varchange_ana2model.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 VariableChangeTests:
 - varchange: Ana2Model

--- a/test/testinput/varchange_balance.yml
+++ b/test/testinput/varchange_balance.yml
@@ -4,7 +4,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 State:
   read_from_file: 1

--- a/test/testinput/varchange_balance_TSSSH.yml
+++ b/test/testinput/varchange_balance_TSSSH.yml
@@ -4,7 +4,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 State:
   read_from_file: 1

--- a/test/testinput/varchange_bkgerrfilt.yml
+++ b/test/testinput/varchange_bkgerrfilt.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 State:
   read_from_file: 1
@@ -23,4 +22,3 @@ LinearVariableChangeTests:
     variables: *soca_vars
   outputVariables:
     variables: *soca_vars
-

--- a/test/testinput/varchange_bkgerrgodas.yml
+++ b/test/testinput/varchange_bkgerrgodas.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 State:
   read_from_file: 1

--- a/test/testinput/varchange_bkgerrsoca.yml
+++ b/test/testinput/varchange_bkgerrsoca.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 State:
   read_from_file: 1

--- a/test/testinput/varchange_horizfilt.yml
+++ b/test/testinput/varchange_horizfilt.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 State:
   read_from_file: 1

--- a/test/testinput/varchange_vertconv.yml
+++ b/test/testinput/varchange_vertconv.yml
@@ -2,7 +2,6 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  read_soca_grid: grid
 
 State:
   read_from_file: 1


### PR DESCRIPTION
## Description
Cleanup of poor logic and removal of unused variables in the geometry setup and yaml files. While a lot of files have been touched, code changes are confined to `soca_geom_mod.F90`. 

**Provide a detailed description of what this PR does.**  
- Removed [Unused logic/variable](https://github.com/JCSDA/soca/blob/4462283365ed9904a7fbe0d698abd8519a72b678/src/soca/Geometry/soca_geom_mod.F90#L109)
- Revived writing of local geometry, useful for debugging and making nostalgic disco plots:

![fms-domains](https://user-images.githubusercontent.com/14031856/81181109-f441f700-8f79-11ea-96f2-ffff982351e3.png)

**What bug does it fix, or what feature does it add?**
local geometry writing was broken, it is now fixed.

**Is a change of answers expected from this PR?**
**NO**

### Issue(s) addressed
- closes #346 
- closes #308 

## Testing

How were these changes tested? **ctest only on(in?) containers**
What compilers / HPCs was it tested with? **gcc7.4**
Are the changes covered by ctests? **Yes, local writing of geometry has been added to the gridgen test**

## Dependencies
**NONE**


