### PR TITLE
Multiple geometries

### DIFF
--- a/src/mains/GridGen.h
+++ b/src/mains/GridGen.h
@@ -35,8 +35,7 @@ namespace soca {
       const Geometry geom(geomconfig, this->getComm());
 
       //  Generate model grid
-      const eckit::LocalConfiguration gridgenconfig(fullConfig, "gridgen");
-      geom.gridgen(gridgenconfig);
+      geom.gridgen();
 
       return 0;
     }

--- a/src/soca/Geometry/CMakeLists.txt
+++ b/src/soca/Geometry/CMakeLists.txt
@@ -4,4 +4,6 @@ soca_target_sources(
   GeometryFortran.h
   soca_geom_mod.F90
   soca_geom.interface.F90
+  FmsInput.cc
+  FmsInput.h
 )

--- a/src/soca/Geometry/FmsInput.cc
+++ b/src/soca/Geometry/FmsInput.cc
@@ -1,0 +1,79 @@
+/*
+ * (C) Copyright 2020-2020 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#include "soca/Geometry/FmsInput.h"
+
+// -----------------------------------------------------------------------------
+namespace soca {
+  // -----------------------------------------------------------------------------
+  FmsInput::FmsInput(const eckit::mpi::Comm & comm,
+                     const eckit::Configuration & conf)
+    : comm_(comm), conf_(conf) {
+
+    // Get the file name of the fms namelist
+    inputnml_orig_ = conf_.getString("mom6_input_nml");
+
+    // "input.nml" is protected
+    ASSERT(inputnml_orig_ != "input.nml");
+
+    if ( comm_.rank() == 0 ) {
+      // Get serial # of original file
+      inputnml_sn_ = getFileSN(inputnml_orig_);
+    }
+    comm_.broadcast(inputnml_sn_, 0);
+
+    // Check that inputnml_sn_ is a valid serial #
+    ASSERT(inputnml_sn_ > 0);
+    comm_.barrier();
+  }
+  // -----------------------------------------------------------------------------
+  FmsInput::FmsInput(const FmsInput & other)
+    : comm_(other.comm_),
+      conf_(other.conf_),
+      inputnml_sn_(other.inputnml_sn_) {
+  }
+  // -----------------------------------------------------------------------------
+  FmsInput::~FmsInput() {
+    inputnml_sn_ = -1;
+  }
+
+  // -----------------------------------------------------------------------------
+  void FmsInput::updateNameList() {
+    int testlink = -1;
+    if ( comm_.rank() == 0 ) {
+      // Get serial # of current input.nml
+      int inputnml_current_sn = getFileSN("input.nml");
+
+      // If the file's serial # don't match, update the input.nml link
+      if ( inputnml_sn_ != inputnml_current_sn ) {
+        // Remove input.nml (link or file) if it exist
+        struct stat buffer;
+        int status = stat("input.nml", &buffer);
+        if ( status == 0 ) { remove("input.nml"); }
+
+        // Create new symbolic link
+        char* target = const_cast<char*>(inputnml_orig_.c_str());
+        char linkname[] = "input.nml";
+        testlink = symlink(target, linkname);
+        if ( testlink != 0 ) { comm_.abort(); }
+      }
+    }
+    comm_.barrier();
+  }
+  // -----------------------------------------------------------------------------
+  int FmsInput::getFileSN(const std::string & filename) {
+    // Get serial # of file
+    struct stat buffer;
+    char* filename_char = const_cast<char*>(filename.c_str());
+    int status = stat(filename_char, &buffer);
+    if ( status == 0 ) {
+      return buffer.st_ino;
+    } else {
+      return -1;
+    }
+  }
+}  // namespace soca

--- a/src/soca/Geometry/FmsInput.h
+++ b/src/soca/Geometry/FmsInput.h
@@ -1,0 +1,43 @@
+/*
+ * (C) Copyright 2020-2020 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef SOCA_GEOMETRY_FMSINPUT_H_
+#define SOCA_GEOMETRY_FMSINPUT_H_
+
+#include <sys/stat.h>
+
+#include <unistd.h>
+#include <cstring>
+#include <fstream>
+#include <ostream>
+#include <string>
+
+#include "eckit/config/Configuration.h"
+#include "eckit/exception/Exceptions.h"
+#include "eckit/mpi/Comm.h"
+
+// -----------------------------------------------------------------------------
+
+namespace soca {
+
+  /// FmsInput handles the hard-coded fms input.nml file.
+  struct FmsInput {
+    FmsInput(const eckit::mpi::Comm &, const eckit::Configuration & conf);
+    FmsInput(const FmsInput &);
+    ~FmsInput();
+
+    void updateNameList();
+    int getFileSN(const std::string &);
+
+    const eckit::mpi::Comm & comm_;
+    const eckit::Configuration & conf_;
+    int inputnml_sn_;
+    std::string inputnml_orig_;
+  };
+}  // namespace soca
+
+#endif  // SOCA_GEOMETRY_FMSINPUT_H_

--- a/src/soca/Geometry/Geometry.cc
+++ b/src/soca/Geometry/Geometry.cc
@@ -5,33 +5,27 @@
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-#include <string>
-
 #include "soca/Geometry/Geometry.h"
-#include "soca/Geometry/GeometryFortran.h"
-#include "soca/GeometryIterator/GeometryIterator.h"
-#include "soca/GeometryIterator/GeometryIteratorFortran.h"
-
-#include "eckit/config/Configuration.h"
-
-#include "oops/util/Logger.h"
-
-using oops::Log;
 
 // -----------------------------------------------------------------------------
 namespace soca {
   // -----------------------------------------------------------------------------
   Geometry::Geometry(const eckit::Configuration & conf,
                      const eckit::mpi::Comm & comm)
-    : comm_(comm), atmconf_(conf), initatm_(initAtm(conf)) {
+    : comm_(comm),
+      atmconf_(conf),
+      initatm_(initAtm(conf)),
+      fmsinput_(comm, conf) {
     const eckit::Configuration * configc = &conf;
+    fmsinput_.updateNameList();
     soca_geo_setup_f90(keyGeom_, &configc, &comm);
   }
   // -----------------------------------------------------------------------------
   Geometry::Geometry(const Geometry & other)
     : comm_(other.comm_),
       atmconf_(other.atmconf_),
-      initatm_(initAtm(other.atmconf_)) {
+      initatm_(initAtm(other.atmconf_)),
+      fmsinput_(other.fmsinput_) {
     const int key_geo = other.keyGeom_;
     soca_geo_clone_f90(key_geo, keyGeom_);
   }
@@ -40,9 +34,7 @@ namespace soca {
     soca_geo_delete_f90(keyGeom_);
   }
   // -----------------------------------------------------------------------------
-  void Geometry::gridgen(const eckit::Configuration & config) const {
-    Log::trace() << "Geometry::gridgen: " << keyGeom_ << std::endl;
-    Log::trace() << config << std::endl;
+  void Geometry::gridgen() const {
     soca_geo_gridgen_f90(keyGeom_);
   }
   // -----------------------------------------------------------------------------

--- a/src/soca/Geometry/Geometry.h
+++ b/src/soca/Geometry/Geometry.h
@@ -8,24 +8,23 @@
 #ifndef SOCA_GEOMETRY_GEOMETRY_H_
 #define SOCA_GEOMETRY_GEOMETRY_H_
 
+#include <fstream>
 #include <ostream>
 #include <string>
 #include <vector>
 
-#include "soca/Fortran.h"
-
+#include "eckit/config/Configuration.h"
 #include "eckit/config/LocalConfiguration.h"
 #include "eckit/mpi/Comm.h"
+
+#include "soca/Fortran.h"
+#include "soca/Geometry/FmsInput.h"
+#include "soca/Geometry/GeometryFortran.h"
+#include "soca/GeometryIterator/GeometryIterator.h"
+#include "soca/GeometryIterator/GeometryIteratorFortran.h"
+
 #include "oops/util/ObjectCounter.h"
 #include "oops/util/Printable.h"
-
-// forward declarations
-namespace eckit {
-  class Configuration;
-}
-namespace soca {
-  class GeometryIterator;
-}
 
 // -----------------------------------------------------------------------------
 
@@ -47,7 +46,7 @@ namespace soca {
 
       int& toFortran() {return keyGeom_;}
       const int& toFortran() const {return keyGeom_;}
-      void gridgen(const eckit::Configuration &) const;
+      void gridgen() const;
       const eckit::mpi::Comm & getComm() const {return comm_;}
       eckit::LocalConfiguration  getAtmConf() const {return atmconf_;}
       bool  getAtmInit() const {return initatm_;}
@@ -63,6 +62,7 @@ namespace soca {
       const eckit::mpi::Comm & comm_;
       eckit::LocalConfiguration atmconf_;
       bool initatm_;
+      FmsInput fmsinput_;
   };
   // -----------------------------------------------------------------------------
 

--- a/src/soca/Geometry/soca_geom.interface.F90
+++ b/src/soca/Geometry/soca_geom.interface.F90
@@ -97,8 +97,6 @@ end subroutine c_soca_geo_delete
 !> return begin and end of local geometry
 subroutine c_soca_geo_start_end(c_key_self, ist, iend, jst, jend) bind(c, name='soca_geo_start_end_f90')
 
-  implicit none
-
   integer(c_int), intent( in) :: c_key_self
   integer(c_int), intent(out) :: ist, iend, jst, jend
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ list( APPEND soca_test_input
   testinput/geometryatm.yml
   testinput/getvalues.yml
   testinput/gridgen.yml
+  testinput/gridgen_small.yml
   testinput/hofx_3d.yml
   testinput/hofx_3dcrtm.yml
   testinput/hofx_4d.yml
@@ -81,11 +82,19 @@ list( APPEND soca_model_param
   Data/72x35x25/diag_table
   Data/72x35x25/field_table
   Data/72x35x25/ice.bkgerror.nc
-  Data/72x35x25/input.nml
-  Data/72x35x25/MOM_input
   Data/72x35x25/ocn.bkgerror.nc
   Data/godas_sst_bgerr.nc
   Data/rossrad.dat
+)
+
+list( APPEND soca_model_param_copy
+  Data/72x35x25/MOM_input
+  Data/72x35x25/MOM_input_small
+)
+
+list( APPEND soca_model_namelist
+  Data/72x35x25/input.nml
+  Data/72x35x25/input_small.nml
 )
 
 list( APPEND soca_model_restarts
@@ -138,6 +147,21 @@ foreach(FILENAME ${soca_model_param})
            ${CMAKE_CURRENT_BINARY_DIR}/${filename} )
 endforeach(FILENAME)
 
+# MOM's resource files that may be overwritten during the testing
+foreach(FILENAME ${soca_model_param_copy})
+     get_filename_component(filename ${FILENAME} NAME )
+     execute_process( COMMAND ${CMAKE_COMMAND} -E copy
+           ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}
+           ${CMAKE_CURRENT_BINARY_DIR}/${filename} )
+endforeach(FILENAME)
+
+# FMS input.nml that may be overwritten during the testing
+foreach(FILENAME ${soca_model_namelist})
+     get_filename_component(filename ${FILENAME} NAME )
+     execute_process( COMMAND ${CMAKE_COMMAND} -E copy
+           ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}
+           ${CMAKE_CURRENT_BINARY_DIR}/inputnml/${filename} )
+endforeach(FILENAME)
 
 # MOM's output directory
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/RESTART)
@@ -324,7 +348,18 @@ endfunction()
 # Tests that create data other tests will use
 #-------------------------------------------------------------------------------
 
-# Test of grid generation
+# Create subsampled netcdf files
+add_test ( test_soca_subsample_netcdf
+           bash
+           ${CMAKE_CURRENT_SOURCE_DIR}/Data/subsample_mom6files.sh )
+
+# Test of grid generation and create subsampled grid
+soca_add_test( NAME gridgen_small
+               EXE  soca_gridgen.x
+               NOCOMPARE
+               TEST_DEPENDS test_soca_subsample_netcdf )
+
+# Test of grid generation and create regular grid
 soca_add_test( NAME gridgen
                EXE  soca_gridgen.x
                NOCOMPARE )

--- a/test/Data/72x35x25/MOM_input_small
+++ b/test/Data/72x35x25/MOM_input_small
@@ -1,0 +1,592 @@
+! This file was written by the model and records the non-default parameters used at run-time.
+
+! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
+USE_REGRIDDING = True           !   [Boolean] default = False
+                                ! If True, use the ALE algorithm (regridding/remapping).
+                                ! If False, use the layered isopycnal algorithm.
+THICKNESSDIFFUSE = True         !   [Boolean] default = False
+                                ! If true, interface heights are diffused with a
+                                ! coefficient of KHTH.
+THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
+                                ! If true, do thickness diffusion before dynamics.
+                                ! This is only used if THICKNESSDIFFUSE is true.
+DT = 3600                       !   [s]
+                                ! The (baroclinic) dynamics time step.  The time-step that
+                                ! is actually used will be an integer fraction of the
+                                ! forcing time-step (DT_FORCING in ocean-only mode or the
+                                ! coupling timestep in coupled mode.)
+DT_THERM = 3600.0               !   [s] default = 3600.0
+                                ! The thermodynamic and tracer advection time step.
+                                ! Ideally DT_THERM should be an integer multiple of DT
+                                ! and less than the forcing or coupling time-step, unless
+                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
+                                ! can be an integer multiple of the coupling timestep.  By
+                                ! default DT_THERM is set to DT.
+THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
+                                ! If true, the MOM will take thermodynamic and tracer
+                                ! timesteps that can be longer than the coupling timestep.
+                                ! The actual thermodynamic timestep that is used in this
+                                ! case is the largest integer multiple of the coupling
+                                ! timestep that is less than or equal to DT_THERM.
+FRAZIL = True                   !   [Boolean] default = False
+                                ! If true, water freezes if it gets too cold, and the
+                                ! the accumulated heat deficit is returned in the
+                                ! surface state.  FRAZIL is only used if
+                                ! ENABLE_THERMODYNAMICS is true.
+BOUND_SALINITY = True           !   [Boolean] default = False
+                                ! If true, limit salinity to being positive. (The sea-ice
+                                ! model may ask for more salt than is available and
+                                ! drive the salinity negative otherwise.)
+
+! === module MOM_domains ===
+TRIPOLAR_N = True               !   [Boolean] default = False
+                                ! Use tripolar connectivity at the northern edge of the
+                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+NIGLOBAL = 36                   !
+                                ! The total number of thickness grid points in the
+                                ! x-direction in the physical domain. With STATIC_MEMORY_
+                                ! this is set in MOM_memory.h at compile time.
+NJGLOBAL = 35                   !
+                                ! The total number of thickness grid points in the
+                                ! y-direction in the physical domain. With STATIC_MEMORY_
+                                ! this is set in MOM_memory.h at compile time.
+
+! === module MOM_hor_index ===
+! Sets the horizontal array index types.
+
+! === module MOM_verticalGrid ===
+! Parameters providing information about the vertical grid.
+NK = 25                         !   [nondim]
+                                ! The number of model layers.
+
+! === module MOM_fixed_initialization ===
+INPUTDIR = "INPUT_small"              ! default = "."
+                                ! The directory in which input files are found.
+
+! === module MOM_grid_init ===
+GRID_CONFIG = "mosaic"          !
+                                ! A character string that determines the method for
+                                ! defining the horizontal grid.  Current options are:
+                                !     mosaic - read the grid from a mosaic (supergrid)
+                                !              file set by GRID_FILE.
+                                !     cartesian - use a (flat) Cartesian grid.
+                                !     spherical - use a simple spherical grid.
+                                !     mercator - use a Mercator spherical grid.
+GRID_FILE = "ocean_hgrid_small.nc"    !
+                                ! Name of the file from which to read horizontal grid data.
+TOPO_CONFIG = "file"            !
+                                ! This specifies how bathymetry is specified:
+                                !     file - read bathymetric information from the file
+                                !       specified by (TOPO_FILE).
+                                !     flat - flat bottom set to MAXIMUM_DEPTH.
+                                !     bowl - an analytically specified bowl-shaped basin
+                                !       ranging between MAXIMUM_DEPTH and MINIMUM_DEPTH.
+                                !     spoon - a similar shape to 'bowl', but with an vertical
+                                !       wall at the southern face.
+                                !     halfpipe - a zonally uniform channel with a half-sine
+                                !       profile in the meridional direction.
+                                !     benchmark - use the benchmark test case topography.
+                                !     Neverland - use the Neverland test case topography.
+                                !     DOME - use a slope and channel configuration for the
+                                !       DOME sill-overflow test case.
+                                !     ISOMIP - use a slope and channel configuration for the
+                                !       ISOMIP test case.
+                                !     DOME2D - use a shelf and slope configuration for the
+                                !       DOME2D gravity current/overflow test case.
+                                !     Kelvin - flat but with rotated land mask.
+                                !     seamount - Gaussian bump for spontaneous motion test case.
+                                !     dumbbell - Sloshing channel with reservoirs on both ends.
+                                !     shelfwave - exponential slope for shelfwave test case.
+                                !     Phillips - ACC-like idealized topography used in the Phillips config.
+                                !     dense - Denmark Strait-like dense water formation and overflow.
+                                !     USER - call a user modified routine.
+TOPO_FILE = "ocean_topog_small.nc"    ! default = "topog.nc"
+                                ! The file from which the bathymetry is read.
+!MAXIMUM_DEPTH = 5801.341919389728 !   [m]
+                                ! The (diagnosed) maximum depth of the ocean.
+MINIMUM_DEPTH = 10.0            !   [m] default = 0.0
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than
+                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
+                                ! If MASKING_DEPTH is specified, then all depths shallower than
+                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+USE_TRIPOLAR_GEOLONB_BUG = False
+GRID_ROTATION_ANGLE_BUGS = False
+
+! === module MOM_open_boundary ===
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+MASKING_DEPTH = 0.0             !   [m] default = -9999.0
+                                ! The depth below which to mask points as land points, for which all
+                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+
+! === module MOM_tracer_registry ===
+
+! === module MOM_EOS ===
+DTFREEZE_DP = -7.75E-08         !   [deg C Pa-1] default = 0.0
+                                ! When TFREEZE_FORM=LINEAR,
+                                ! this is the derivative of the freezing potential
+                                ! temperature with pressure.
+
+! === module MOM_restart ===
+!RESTARTFILE = "MOM.res.small.nc"
+!RESTARTFILE = "./INPUT/MOM.res.nc"
+RESTART_CHECKSUMS_REQUIRED = .false.
+! === module MOM_tracer_flow_control ===
+
+! === module MOM_coord_initialization ===
+COORD_CONFIG = "file"           !
+                                ! This specifies how layers are to be defined:
+                                !     ALE or none - used to avoid defining layers in ALE mode
+                                !     file - read coordinate information from the file
+                                !       specified by (COORD_FILE).
+                                !     BFB - Custom coords for buoyancy-forced basin case
+                                !       based on SST_S, T_BOT and DRHO_DT.
+                                !     linear - linear based on interfaces not layers
+                                !     layer_ref - linear based on layer densities
+                                !     ts_ref - use reference temperature and salinity
+                                !     ts_range - use range of temperature and salinity
+                                !       (T_REF and S_REF) to determine surface density
+                                !       and GINT calculate internal densities.
+                                !     gprime - use reference density (RHO_0) for surface
+                                !       density and GINT calculate internal densities.
+                                !     ts_profile - use temperature and salinity profiles
+                                !       (read from COORD_FILE) to set layer densities.
+                                !     USER - call a user modified routine.
+COORD_FILE = "layer_coord25.nc" !
+                                ! The file from which the coordinate densities are read.
+REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
+                                ! Coordinate mode for vertical regridding.
+                                ! Choose among the following possibilities:
+                                !  LAYER - Isopycnal or stacked shallow water layers
+                                !  ZSTAR, Z* - stetched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  SIGMA - terrain following coordinates
+                                !  RHO   - continuous isopycnal
+                                !  HYCOM1 - HyCOM-like hybrid coordinate
+                                !  SLIGHT - stretched coordinates above continuous isopycnal
+                                !  ADAPTIVE - optimize for smooth neutral density surfaces
+BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
+                                ! When defined, a proper high-order reconstruction
+                                ! scheme is used within boundary cells rather
+                                ! than PCM. E.g., if PPM is used for remapping, a
+                                ! PPM reconstruction will also be used within
+                                ! boundary cells.
+ALE_COORDINATE_CONFIG = "HYBRID:hycom1_25.nc,sigma2,FNC1:5,4000,4.5,.01" ! default = "UNIFORM"
+                                ! Determines how to specify the coordinate
+                                ! resolution. Valid options are:
+                                !  PARAM       - use the vector-parameter ALE_RESOLUTION
+                                !  UNIFORM[:N] - uniformly distributed
+                                !  FILE:string - read from a file. The string specifies
+                                !                the filename and variable name, separated
+                                !                by a comma or space, e.g. FILE:lev.nc,dz
+                                !                or FILE:lev.nc,interfaces=zw
+                                !  WOA09[:N]   - the WOA09 vertical grid (approximately)
+                                !  FNC1:string - FNC1:dz_min,H_total,power,precision
+                                !  HYBRID:string - read from a file. The string specifies
+                                !                the filename and two variable names, separated
+                                !                by a comma or space, for sigma-2 and dz. e.g.
+                                !                HYBRID:vgrid.nc,sigma2,dz
+!ALE_RESOLUTION = 2*5.0, 5.01, 5.07, 5.25, 5.68, 6.55, 8.1, 10.66, 14.620000000000001, 20.450000000000003, 28.73, 40.1, 55.32, 75.23, 100.8, 133.09, 173.26, 222.62, 282.56, 354.62, 440.47, 541.87, 660.76, 799.1800000000001 !   [m]
+                                ! The distribution of vertical resolution for the target
+                                ! grid used for Eulerian-like coordinates. For example,
+                                ! in z-coordinate mode, the parameter is a list of level
+                                ! thicknesses (in m). In sigma-coordinate mode, the list
+                                ! is of non-dimensional fractions of the water column.
+!TARGET_DENSITIES = 1010.0, 1020.843017578125, 1027.0274658203125, 1029.279541015625, 1030.862548828125, 1032.1572265625, 1033.27978515625, 1034.251953125, 1034.850830078125, 1035.28857421875, 1035.651123046875, 1035.967529296875, 1036.2410888671875, 1036.473876953125, 1036.6800537109375, 1036.8525390625, 1036.9417724609375, 1037.0052490234375, 1037.057373046875, 1037.1065673828125, 1037.15576171875, 1037.2060546875, 1037.26416015625, 1037.3388671875, 1037.4749755859375, 1038.0 !   [m]
+                                ! HYBRID target densities for itnerfaces
+REGRID_COMPRESSIBILITY_FRACTION = 0.01 !   [not defined] default = 0.0
+                                ! When interpolating potential density profiles we can add
+                                ! some artificial compressibility solely to make homogenous
+                                ! regions appear stratified.
+MAXIMUM_INT_DEPTH_CONFIG = "FNC1:5,8000.0,1.0,.125" ! default = "NONE"
+                                ! Determines how to specify the maximum interface depths.
+                                ! Valid options are:
+                                !  NONE        - there are no maximum interface depths
+                                !  PARAM       - use the vector-parameter MAXIMUM_INTERFACE_DEPTHS
+                                !  FILE:string - read from a file. The string specifies
+                                !                the filename and variable name, separated
+                                !                by a comma or space, e.g. FILE:lev.nc,Z
+                                !  FNC1:string - FNC1:dz_min,H_total,power,precision
+!MAXIMUM_INT_DEPTHS = 0.0, 5.0, 36.25, 93.75, 177.5, 287.5, 423.75, 586.25, 775.0, 990.0, 1231.25, 1498.75, 1792.5, 2112.5, 2458.75, 2831.25, 3230.0, 3655.0, 4106.25, 4583.75, 5087.5, 5617.5, 6173.75, 6756.25, 7365.0, 8000.0 !   [m]
+                                ! The list of maximum depths for each interface.
+MAX_LAYER_THICKNESS_CONFIG = "FNC1:400,31000.0,0.1,.01" ! default = "NONE"
+                                ! Determines how to specify the maximum layer thicknesses.
+                                ! Valid options are:
+                                !  NONE        - there are no maximum layer thicknesses
+                                !  PARAM       - use the vector-parameter MAX_LAYER_THICKNESS
+                                !  FILE:string - read from a file. The string specifies
+                                !                the filename and variable name, separated
+                                !                by a comma or space, e.g. FILE:lev.nc,Z
+                                !  FNC1:string - FNC1:dz_min,H_total,power,precision
+!MAX_LAYER_THICKNESS = 400.0, 1094.2, 1144.02, 1174.81, 1197.42, 1215.4099999999999, 1230.42, 1243.3200000000002, 1254.65, 1264.78, 1273.94, 1282.31, 1290.02, 1297.17, 1303.85, 1310.1, 1316.0, 1321.5700000000002, 1326.85, 1331.87, 1336.67, 1341.25, 1345.6399999999999, 1349.85, 1353.88 !   [m]
+                                ! The list of maximum thickness for each layer.
+REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
+                                ! This sets the reconstruction scheme used
+                                ! for vertical remapping for all variables.
+                                ! It can be one of the following schemes:
+                                ! PCM         (1st-order accurate)
+                                ! PLM         (2nd-order accurate)
+                                ! PPM_H4      (3rd-order accurate)
+                                ! PPM_IH4     (3rd-order accurate)
+                                ! PQM_IH4IH3  (4th-order accurate)
+                                ! PQM_IH6IH5  (5th-order accurate)
+
+! === module MOM_grid ===
+! Parameters providing information about the lateral grid.
+
+! === module MOM_state_initialization ===
+INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
+                                ! If true, intialize the layer thicknesses, temperatures,
+                                ! and salnities from a Z-space file on a latitude-
+                                ! longitude grid.
+
+! === module MOM_initialize_layers_from_Z ===
+TEMP_SALT_Z_INIT_FILE = ""      ! default = "temp_salt_z.nc"
+                                ! The name of the z-space input file used to initialize
+                                ! temperatures (T) and salinities (S). If T and S are not
+                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
+                                ! must be set.
+TEMP_Z_INIT_FILE = "woa13_decav_ptemp_monthly_fulldepth_01.nc" ! default = ""
+                                ! The name of the z-space input file used to initialize
+                                ! temperatures, only.
+SALT_Z_INIT_FILE = "woa13_decav_s_monthly_fulldepth_01.nc" ! default = ""
+                                ! The name of the z-space input file used to initialize
+                                ! temperatures, only.
+Z_INIT_FILE_PTEMP_VAR = "ptemp_an" ! default = "ptemp"
+                                ! The name of the potential temperature variable in
+                                ! TEMP_Z_INIT_FILE.
+Z_INIT_FILE_SALT_VAR = "s_an"   ! default = "salt"
+                                ! The name of the salinity variable in
+                                ! SALT_Z_INIT_FILE.
+Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
+                                ! If True, then remap straight to model coordinate from file.
+
+! === module MOM_diag_mediator ===
+
+! === module MOM_MEKE ===
+USE_MEKE = True                 !   [Boolean] default = False
+                                ! If true, turns on the MEKE scheme which calculates
+                                ! a sub-grid mesoscale eddy kinetic energy budget.
+
+! === module MOM_lateral_mixing_coeffs ===
+USE_VARIABLE_MIXING = True      !   [Boolean] default = False
+                                ! If true, the variable mixing code will be called.  This
+                                ! allows diagnostics to be created even if the scheme is
+                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
+                                ! this is set to true regardless of what is in the
+                                ! parameter file.
+
+! === module MOM_set_visc ===
+CHANNEL_DRAG = True             !   [Boolean] default = False
+                                ! If true, the bottom drag is exerted directly on each
+                                ! layer proportional to the fraction of the bottom it
+                                ! overlies.
+HBBL = 10.0                     !   [m]
+                                ! The thickness of a bottom boundary layer with a
+                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
+                                ! the thickness over which near-bottom velocities are
+                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
+                                ! but LINEAR_DRAG is not.
+KV = 1.0E-04                    !   [m2 s-1]
+                                ! The background kinematic viscosity in the interior.
+                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+
+! === module MOM_continuity ===
+
+! === module MOM_continuity_PPM ===
+
+! === module MOM_CoriolisAdv ===
+CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
+                                ! CORIOLIS_SCHEME selects the discretization for the
+                                ! Coriolis terms. Valid values are:
+                                !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
+                                !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
+                                !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
+                                !    ARAKAWA_LAMB81    - Arakawa & Lamb, 1981; En. + Enst.
+                                !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
+                                !                         Arakawa & Hsu and Sadourny energy
+BOUND_CORIOLIS = True           !   [Boolean] default = False
+                                ! If true, the Coriolis terms at u-points are bounded by
+                                ! the four estimates of (f+rv)v from the four neighboring
+                                ! v-points, and similarly at v-points.  This option would
+                                ! have no effect on the SADOURNY Coriolis scheme if it
+                                ! were possible to use centered difference thickness fluxes.
+
+! === module MOM_PressureForce ===
+
+! === module MOM_PressureForce_AFV ===
+MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
+                                ! If true, use mass weighting when interpolating T/S for
+                                ! integrals near the bathymetry in AFV pressure gradient
+                                ! calculations.
+
+! === module MOM_hor_visc ===
+LAPLACIAN = True                !   [Boolean] default = False
+                                ! If true, use a Laplacian horizontal viscosity.
+KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
+                                ! The velocity scale which is multiplied by the grid
+                                ! spacing to calculate the Laplacian viscosity.
+                                ! The final viscosity is the largest of this scaled
+                                ! viscosity, the Smagorinsky and Leith viscosities, and KH.
+KH_SIN_LAT = 2000.0             !   [m2 s-1] default = 0.0
+                                ! The amplitude of a latidutinally-dependent background
+                                ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
+SMAGORINSKY_KH = True           !   [Boolean] default = False
+                                ! If true, use a Smagorinsky nonlinear eddy viscosity.
+SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
+                                ! The nondimensional Laplacian Smagorinsky constant,
+                                ! often 0.15.
+AH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
+                                ! The velocity scale which is multiplied by the cube of
+                                ! the grid spacing to calculate the biharmonic viscosity.
+                                ! The final viscosity is the largest of this scaled
+                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+SMAGORINSKY_AH = True           !   [Boolean] default = False
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
+                                ! viscosity.
+SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
+                                ! The nondimensional biharmonic Smagorinsky constant,
+                                ! typically 0.015 - 0.06.
+USE_LAND_MASK_FOR_HVISC = True  !   [Boolean] default = False
+                                ! If true, use Use the land mask for the computation of thicknesses
+                                ! at velocity locations. This eliminates the dependence on arbitrary
+                                ! values over land or outside of the domain. Default is False in order to
+                                ! maintain answers with legacy experiments but should be changed to True
+                                ! for new experiments.
+
+! === module MOM_vert_friction ===
+HMIX_FIXED = 0.5                !   [m]
+                                ! The prescribed depth over which the near-surface
+                                ! viscosity and diffusivity are elevated when the bulk
+                                ! mixed layer is not used.
+MAXVEL = 5.0                    !   [m s-1] default = 3.0E+08
+                                ! The maximum velocity allowed before the velocity
+                                ! components are truncated.
+
+! === module MOM_barotropic ===
+BOUND_BT_CORRECTION = True      !   [Boolean] default = False
+                                ! If true, the corrective pseudo mass-fluxes into the
+                                ! barotropic solver are limited to values that require
+                                ! less than maxCFL_BT_cont to be accommodated.
+BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
+                                ! If true, step the barotropic velocity first and project
+                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! transport.  The default (false) is to use a predictor
+                                ! continuity step to find the pressure field, and then
+                                ! to do a corrector continuity step using a weighted
+                                ! average of the old and new velocities, with weights
+                                ! of (1-BEBT) and BEBT.
+DYNAMIC_SURFACE_PRESSURE = True !   [Boolean] default = False
+                                ! If true, add a dynamic pressure due to a viscous ice
+                                ! shelf, for instance.
+BEBT = 0.2                      !   [nondim] default = 0.1
+                                ! BEBT determines whether the barotropic time stepping
+                                ! uses the forward-backward time-stepping scheme or a
+                                ! backward Euler scheme. BEBT is valid in the range from
+                                ! 0 (for a forward-backward treatment of nonrotating
+                                ! gravity waves) to 1 (for a backward Euler treatment).
+                                ! In practice, BEBT must be greater than about 0.05.
+DTBT = -0.9                     !   [s or nondim] default = -0.98
+                                ! The barotropic time step, in s. DTBT is only used with
+                                ! the split explicit time stepping. To set the time step
+                                ! automatically based the maximum stable value use 0, or
+                                ! a negative value gives the fraction of the stable value.
+                                ! Setting DTBT to 0 is the same as setting it to -0.98.
+                                ! The value of DTBT that will actually be used is an
+                                ! integer fraction of DT, rounding down.
+
+! === module MOM_thickness_diffuse ===
+
+! === module MOM_mixed_layer_restrat ===
+MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
+                                ! If true, a density-gradient dependent re-stratifying
+                                ! flow is imposed in the mixed layer. Can be used in ALE mode
+                                ! without restriction but in layer mode can only be used if
+                                ! BULKMIXEDLAYER is true.
+FOX_KEMPER_ML_RESTRAT_COEF = 1.0 !   [nondim] default = 0.0
+                                ! A nondimensional coefficient that is proportional to
+                                ! the ratio of the deformation radius to the dominant
+                                ! lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the
+                                ! mesoscale eddy kinetic energy to the large-scale
+                                ! geostrophic kinetic energy or 1 plus the square of the
+                                ! grid spacing over the deformation radius, as detailed
+                                ! by Fox-Kemper et al. (2010)
+MLE_FRONT_LENGTH = 200.0        !   [m] default = 0.0
+                                ! If non-zero, is the frontal-length scale used to calculate the
+                                ! upscaling of buoyancy gradients that is otherwise represented
+                                ! by the parameter FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is
+                                ! non-zero, it is recommended to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
+MLE_USE_PBL_MLD = True          !   [Boolean] default = False
+                                ! If true, the MLE parameterization will use the mixed-layer
+                                ! depth provided by the active PBL parameterization. If false,
+                                ! MLE will estimate a MLD based on a density difference with the
+                                ! surface using the parameter MLE_DENSITY_DIFF.
+MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
+                                ! The time-scale for a running-mean filter applied to the mixed-layer
+                                ! depth used in the MLE restratification parameterization. When
+                                ! the MLD deepens below the current running-mean the running-mean
+                                ! is instantaneously set to the current MLD.
+
+! === module MOM_diag_to_Z ===
+
+! === module MOM_diabatic_driver ===
+! The following parameters are used for diabatic processes.
+ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
+                                ! If true, use an implied energetics planetary boundary
+                                ! layer scheme to determine the diffusivity and viscosity
+                                ! in the surface boundary layer.
+
+! === module MOM_CVMix_KPP ===
+! This is the MOM wrapper to CVMix:KPP
+! See http://cvmix.github.io/
+
+! === module MOM_tidal_mixing ===
+! Vertical Tidal Mixing Parameterization
+
+! === module MOM_CVMix_conv ===
+! Parameterization of enhanced mixing due to convection via CVMix
+
+! === module MOM_entrain_diffusive ===
+
+! === module MOM_set_diffusivity ===
+
+! === module MOM_bkgnd_mixing ===
+! Adding static vertical background mixing coefficients
+KD = 1.5E-05                    !   [m2 s-1]
+                                ! The background diapycnal diffusivity of density in the
+                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
+                                ! may be used.
+KD_MIN = 2.0E-06                !   [m2 s-1] default = 1.5E-07
+                                ! The minimum diapycnal diffusivity.
+HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
+                                ! If true, use a latitude-dependent scaling for the near
+                                ! surface background diffusivity, as described in
+                                ! Harrison & Hallberg, JPO 2008.
+
+! === module MOM_kappa_shear ===
+! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
+USE_JACKSON_PARAM = True        !   [Boolean] default = False
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
+                                ! shear mixing parameterization.
+MAX_RINO_IT = 205               !   [nondim] default = 50
+                                ! The maximum number of iterations that may be used to
+                                ! estimate the Richardson number driven mixing.
+
+! === module MOM_CVMix_shear ===
+! Parameterization of shear-driven turbulence via CVMix (various options)
+
+! === module MOM_CVMix_ddiff ===
+! Parameterization of mixing due to double diffusion processes via CVMix
+
+! === module MOM_diabatic_aux ===
+! The following parameters are used for auxiliary diabatic processes.
+
+! === module MOM_energetic_PBL ===
+EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
+                                ! The (tiny) minimum friction velocity used within the
+                                ! ePBL code, derived from OMEGA and ANGSTROM.
+
+! === module MOM_regularize_layers ===
+
+! === module MOM_opacity ===
+
+! === module MOM_tracer_advect ===
+TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
+                                ! The horizontal transport scheme for tracers:
+                                !   PLM    - Piecewise Linear Method
+                                !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+                                !   PPM    - Piecewise Parabolic Method (Colella-Woodward)
+
+! === module MOM_tracer_hor_diff ===
+KHTR = 50.0                     !   [m2 s-1] default = 0.0
+                                ! The background along-isopycnal tracer diffusivity.
+CHECK_DIFFUSIVE_CFL = True      !   [Boolean] default = False
+                                ! If true, use enough iterations the diffusion to ensure
+                                ! that the diffusive equivalent of the CFL limit is not
+                                ! violated.  If false, always use the greater of 1 or
+                                ! MAX_TR_DIFFUSION_CFL iteration.
+MAX_TR_DIFFUSION_CFL = 2.0      !   [nondim] default = -1.0
+                                ! If positive, locally limit the along-isopycnal tracer
+                                ! diffusivity to keep the diffusive CFL locally at or
+                                ! below this value.  The number of diffusive iterations
+                                ! is often this value or the next greater integer.
+
+! === module MOM_neutral_diffusion ===
+! This module implements neutral diffusion of tracers
+USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
+                                ! If true, enables the neutral diffusion module.
+
+! === module MOM_sum_output ===
+MAXTRUNC = 1000                 !   [truncations save_interval-1] default = 0
+                                ! The run will be stopped, and the day set to a very
+                                ! large value if the velocity is truncated more than
+                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! to stop if there is any truncation of velocities.
+
+! === module ocean_model_init ===
+
+! === module MOM_surface_forcing ===
+BUOY_CONFIG = "file"            !
+                                ! The character string that indicates how buoyancy forcing
+                                ! is specified. Valid options include (file), (zero),
+                                ! (linear), (USER), (BFB) and (NONE).
+ARCHAIC_OMIP_FORCING_FILE = False !   [Boolean] default = True
+                                ! If true, use the forcing variable decomposition from
+                                ! the old German OMIP prescription that predated CORE. If
+                                ! false, use the variable groupings available from MOM
+                                ! output diagnostics of forcing variables.
+LONGWAVE_FILE = "forcing_daily.nc" !
+                                ! The file with the longwave heat flux, in the variable
+                                ! given by LONGWAVE_FORCING_VAR.
+SHORTWAVE_FILE = "forcing_daily.nc" !
+                                ! The file with the shortwave heat flux, in the variable
+                                ! given by SHORTWAVE_FORCING_VAR.
+EVAPORATION_FILE = "forcing_daily.nc" !
+                                ! The file with the evaporative moisture flux, in the
+                                ! variable given by EVAP_FORCING_VAR.
+LATENTHEAT_FILE = "forcing_daily.nc" !
+                                ! The file with the latent heat flux, in the variable
+                                ! given by LATENT_FORCING_VAR.
+SENSIBLEHEAT_FILE = "forcing_daily.nc" !
+                                ! The file with the sensible heat flux, in the variable
+                                ! given by SENSIBLE_FORCING_VAR.
+RAIN_FILE = "forcing_monthly.nc" !
+                                ! The file with the liquid precipitation flux, in the
+                                ! variable given by RAIN_FORCING_VAR.
+SNOW_FILE = "forcing_monthly.nc" !
+                                ! The file with the frozen precipitation flux, in the
+                                ! variable given by SNOW_FORCING_VAR.
+RUNOFF_FILE = "forcing_monthly.nc" !
+                                ! The file with the fresh and frozen runoff/calving
+                                ! fluxes, in variables given by LIQ_RUNOFF_FORCING_VAR
+                                ! and FROZ_RUNOFF_FORCING_VAR.
+SSTRESTORE_FILE = "forcing_daily.nc" !
+                                ! The file with the SST toward which to restore in the
+                                ! variable given by SST_RESTORE_VAR.
+SALINITYRESTORE_FILE = "forcing_daily.nc" !
+                                ! The file with the surface salinity toward which to
+                                ! restore in the variable given by SSS_RESTORE_VAR.
+WIND_CONFIG = "file"            !
+                                ! The character string that indicates how wind forcing
+                                ! is specified. Valid options include (file), (2gyre),
+                                ! (1gyre), (gyres), (zero), and (USER).
+WIND_FILE = "forcing_daily.nc" !
+                                ! The file in which the wind stresses are found in
+                                ! variables STRESS_X and STRESS_Y.
+WINDSTRESS_X_VAR = "taux"       ! default = "STRESS_X"
+                                ! The name of the x-wind stress variable in WIND_FILE.
+WINDSTRESS_Y_VAR = "tauy"       ! default = "STRESS_Y"
+                                ! The name of the y-wind stress variable in WIND_FILE.
+WINDSTRESS_STAGGER = "C"        ! default = "A"
+                                ! A character indicating how the wind stress components
+                                ! are staggered in WIND_FILE.  This may be A or C for now.
+FLUXCONST = 0.5                 !   [m day-1]
+                                ! The constant that relates the restoring surface fluxes
+                                ! to the relative surface anomalies (akin to a piston
+                                ! velocity).  Note the non-MKS units.
+! === module MOM_restart ===
+
+! === module MOM_file_parser ===

--- a/test/Data/72x35x25/input_small.nml
+++ b/test/Data/72x35x25/input_small.nml
@@ -1,0 +1,28 @@
+ &MOM_input_nml
+        output_directory = './',
+        input_filename = 'r'
+        restart_input_dir = 'INPUT_small/',
+        restart_output_dir = 'RESTART/',
+        parameter_filename = 'MOM_input_small' /
+
+ &diag_manager_nml
+ /
+
+ &ocean_solo_nml
+            months = 0
+            days   = 1
+            date_init = 2018,4,15,0,0,0,
+            hours = 0
+            minutes = 0
+            seconds = 0
+            calendar = 'NOLEAP' /
+
+ &fms_io_nml
+      max_files_w=100
+      checksum_required=.false.
+/
+
+ &fms_nml
+       clock_grain='MODULE'
+       domains_stack_size = 2000000
+       clock_flags='SYNC' /

--- a/test/Data/subsample_mom6files.sh
+++ b/test/Data/subsample_mom6files.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+mkdir -p ./INPUT_small/
+cp ./INPUT/hycom1_25.nc ./INPUT_small/
+cp ./INPUT/layer_coord25.nc ./INPUT_small/
+ncks -O -d nxp,0,144,2 -d nx,0,143,2 ./INPUT/ocean_hgrid.nc ./INPUT_small/ocean_hgrid_small.nc
+ncks -O -d nx,0,71,2 ./INPUT/ocean_topog.nc ./INPUT_small/ocean_topog_small.nc
+ncks -O -d lonh,0,71,2 -d lonq,0,71,2 ./INPUT/MOM.res.nc ./INPUT_small/MOM.res.nc

--- a/test/testinput/3dhyb.yml
+++ b/test/testinput/3dhyb.yml
@@ -2,6 +2,7 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 model:
   name: SOCA
@@ -152,6 +153,7 @@ variational:
       num_ice_cat: 5
       num_ice_lev: 4
       num_sno_lev: 1
+      mom6_input_nml: ./inputnml/input.nml
     linearmodel:
       varchange: Identity
       version: IdTLM

--- a/test/testinput/3dhybfgat.yml
+++ b/test/testinput/3dhybfgat.yml
@@ -2,6 +2,7 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 model:
   name: SOCA
@@ -151,6 +152,7 @@ variational:
       num_ice_cat: 5
       num_ice_lev: 4
       num_sno_lev: 1
+      mom6_input_nml: ./inputnml/input.nml
     linearmodel:
       varchange: Identity
       version: IdTLM

--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -15,6 +15,7 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 model:
   name: SOCA
@@ -212,6 +213,7 @@ variational:
       num_ice_cat: 5
       num_ice_lev: 4
       num_sno_lev: 1
+      mom6_input_nml: ./inputnml/input.nml
     linearmodel:
       varchange: Identity
       version: IdTLM

--- a/test/testinput/3dvar_soca.yml
+++ b/test/testinput/3dvar_soca.yml
@@ -15,6 +15,7 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 model:
   name: SOCA
@@ -224,6 +225,7 @@ variational:
       num_ice_cat: 5
       num_ice_lev: 4
       num_sno_lev: 1
+      mom6_input_nml: ./inputnml/input.nml
     linearmodel:
       varchange: Identity
       version: IdTLM

--- a/test/testinput/3dvarfgat.yml
+++ b/test/testinput/3dvarfgat.yml
@@ -15,6 +15,7 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 model:
   name: SOCA
@@ -212,6 +213,7 @@ variational:
       num_ice_cat: 5
       num_ice_lev: 4
       num_sno_lev: 1
+      mom6_input_nml: ./inputnml/input.nml
     linearmodel:
       varchange: Identity
       version: IdTLM

--- a/test/testinput/addincrement.yml
+++ b/test/testinput/addincrement.yml
@@ -2,11 +2,13 @@ stateResol:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 incrementResol:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 state:
   read_from_file: 1

--- a/test/testinput/checkpointmodel.yml
+++ b/test/testinput/checkpointmodel.yml
@@ -2,6 +2,7 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 model:
   name: SOCA

--- a/test/testinput/convertstate.yml
+++ b/test/testinput/convertstate.yml
@@ -5,11 +5,13 @@ inputresolution:
   num_ice_lev: 4
   num_sno_lev: 1
   geom_grid_file: soca_gridspec.nc
+  mom6_input_nml: ./inputnml/input.nml
 outputresolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
   geom_grid_file: soca_gridspec.nc
+  mom6_input_nml: ./inputnml/input.nml
 varchange: Ana2Model
 rotate:
   u: [uocn]

--- a/test/testinput/dirac_bump_cov.yml
+++ b/test/testinput/dirac_bump_cov.yml
@@ -42,4 +42,5 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 variables: *soca_vars

--- a/test/testinput/dirac_horizfilt.yml
+++ b/test/testinput/dirac_horizfilt.yml
@@ -2,6 +2,7 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 initial:
   read_from_file: 1

--- a/test/testinput/dirac_soca_cov.yml
+++ b/test/testinput/dirac_soca_cov.yml
@@ -2,6 +2,7 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 initial:
   read_from_file: 1

--- a/test/testinput/dirac_socahyb_cov.yml
+++ b/test/testinput/dirac_socahyb_cov.yml
@@ -2,6 +2,7 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 initial:
   read_from_file: 1

--- a/test/testinput/enshofx.yml
+++ b/test/testinput/enshofx.yml
@@ -5,6 +5,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 Model:
   name: SOCA

--- a/test/testinput/enspert.yml
+++ b/test/testinput/enspert.yml
@@ -2,6 +2,7 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 model:
   name: SOCA

--- a/test/testinput/ensrecenter.yml
+++ b/test/testinput/ensrecenter.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 _file: &_file
   read_from_file: 1

--- a/test/testinput/ensvariance.yml
+++ b/test/testinput/ensvariance.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 Variables:
   variables:  &soca_vars [cicen, hicen, socn, tocn, ssh, hocn]

--- a/test/testinput/forecast_identity.yml
+++ b/test/testinput/forecast_identity.yml
@@ -2,6 +2,8 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
+
 model:
   name: SOCA
   tstep: PT1H

--- a/test/testinput/forecast_identity_cice.yml
+++ b/test/testinput/forecast_identity_cice.yml
@@ -2,6 +2,7 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 model:
   name: SOCA

--- a/test/testinput/forecast_mom6.yml
+++ b/test/testinput/forecast_mom6.yml
@@ -2,6 +2,7 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 model:
   name: SOCA

--- a/test/testinput/geometry.yml
+++ b/test/testinput/geometry.yml
@@ -2,3 +2,4 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml

--- a/test/testinput/geometry_iterator.yml
+++ b/test/testinput/geometry_iterator.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 Variables:
   variables: [cicen, hicen, socn, tocn, ssh, hocn]

--- a/test/testinput/geometryatm.yml
+++ b/test/testinput/geometryatm.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
   atm_state:
     init: true
     date_begin: 2018-04-14T00:00:00Z

--- a/test/testinput/getvalues.yml
+++ b/test/testinput/getvalues.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 GetValuesTest:
   interp_tolerance: 1.0e-2

--- a/test/testinput/gridgen_small.yml
+++ b/test/testinput/gridgen_small.yml
@@ -2,7 +2,7 @@ geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  geom_grid_file: soca_gridspec.nc
+  geom_grid_file: soca_gridspec.small.nc
   save_local_domain: true
   full_init: true
-  mom6_input_nml: ./inputnml/input.nml
+  mom6_input_nml: ./inputnml/input_small.nml

--- a/test/testinput/hofx_3d.yml
+++ b/test/testinput/hofx_3d.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 Forecasts:
   variables: [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]

--- a/test/testinput/hofx_3dcrtm.yml
+++ b/test/testinput/hofx_3dcrtm.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
   notocean:
     init: true
     date_begin: 2018-04-14T00:00:00Z

--- a/test/testinput/hofx_4d.yml
+++ b/test/testinput/hofx_4d.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 Model:
   name: SOCA

--- a/test/testinput/increment.yml
+++ b/test/testinput/increment.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 Variables:
   variables: [cicen, hicen, socn, tocn, ssh, hocn, sw, lw, lhf, shf, us]

--- a/test/testinput/letkf.yml
+++ b/test/testinput/letkf.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 Assimilation Window:
   window_begin: &date 2018-04-14T00:00:00Z

--- a/test/testinput/lineargetvalues.yml
+++ b/test/testinput/lineargetvalues.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 LinearGetValuesTest:
   toleranceLinearity: 1.0e-11

--- a/test/testinput/linearmodel.yml
+++ b/test/testinput/linearmodel.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 Variables:
   variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]

--- a/test/testinput/makeobs.yml
+++ b/test/testinput/makeobs.yml
@@ -6,6 +6,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 Model:
   name: SOCA

--- a/test/testinput/model.yml
+++ b/test/testinput/model.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 ModelBias:
 

--- a/test/testinput/parameters_bump_cov_lct.yml
+++ b/test/testinput/parameters_bump_cov_lct.yml
@@ -2,6 +2,7 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn]
 

--- a/test/testinput/parameters_bump_cov_nicas.yml
+++ b/test/testinput/parameters_bump_cov_nicas.yml
@@ -2,6 +2,7 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 variables: &soca_vars  [cicen, hicen, socn, tocn, ssh, hocn]
 

--- a/test/testinput/parameters_bump_loc.yml
+++ b/test/testinput/parameters_bump_loc.yml
@@ -2,6 +2,7 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 variables: &soca_vars [cicen, hicen, hsnon, socn, tocn, ssh, hocn]
 

--- a/test/testinput/state.yml
+++ b/test/testinput/state.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 StateTest:
   StateFile:

--- a/test/testinput/static_socaerror_init.yml
+++ b/test/testinput/static_socaerror_init.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 Variables:
   variables: &soca_vars [cicen, hicen, hocn, socn, tocn, ssh]

--- a/test/testinput/static_socaerror_test.yml
+++ b/test/testinput/static_socaerror_test.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 Variables:
   variables: &soca_vars [cicen, hicen, hocn, socn, tocn, ssh]

--- a/test/testinput/varchange_ana2model.yml
+++ b/test/testinput/varchange_ana2model.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 VariableChangeTests:
 - varchange: Ana2Model

--- a/test/testinput/varchange_balance.yml
+++ b/test/testinput/varchange_balance.yml
@@ -4,6 +4,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 State:
   read_from_file: 1

--- a/test/testinput/varchange_balance_TSSSH.yml
+++ b/test/testinput/varchange_balance_TSSSH.yml
@@ -4,6 +4,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 State:
   read_from_file: 1

--- a/test/testinput/varchange_bkgerrfilt.yml
+++ b/test/testinput/varchange_bkgerrfilt.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 State:
   read_from_file: 1

--- a/test/testinput/varchange_bkgerrgodas.yml
+++ b/test/testinput/varchange_bkgerrgodas.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 State:
   read_from_file: 1

--- a/test/testinput/varchange_bkgerrsoca.yml
+++ b/test/testinput/varchange_bkgerrsoca.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 State:
   read_from_file: 1

--- a/test/testinput/varchange_horizfilt.yml
+++ b/test/testinput/varchange_horizfilt.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 State:
   read_from_file: 1

--- a/test/testinput/varchange_vertconv.yml
+++ b/test/testinput/varchange_vertconv.yml
@@ -2,6 +2,7 @@ Geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
 
 State:
   read_from_file: 1


### PR DESCRIPTION
## Description
One step closer to be able to use multiple geometries. Despite the large number of files touched, the new features are confined in the Geometry class. Most of the files were touched to update the geometry configuration in the yaml files.

**New features:**
- Addition of a test to create a coarse geometry by sub-sampling the existing MOM6 netcdf files
- An fms struct to handle the hard-coded `input.nml`
- `input.nml` in the scratch directory is now a **protected name** This is going to break our scripts for GODAS (pinging @flampouris and @jkbk2004 ), the real time SOCA and our simple regular cycling scripts in soca. None of these issues are addressed in this work. 

... and just to be sure the message is received:
**THE LOCATION OF THE `input.nml` NAMELIST IS NOW REQUIRED IN THE GEOMETRY PART OF THE YAML FILES.**

Is a change of answers expected from this PR? **NO**

**Issues to debate:**
- I went against backward compatibility, in the long run we should assume that we will need multiple input.nml, thus having to remove the one in the scratch directory. It is safer to stage it from elsewhere. This is how @danholdaway implemented it for fv3-jedi, and I can't think of a better solution, short of modifying fms. 
- I added a test to sub-sample some of the mom6 files that we use, but it's slow (~4-5 sec on my computer), they could be added to the repo instead. 
- Meaning of life?

### Issue(s) addressed
closes #352 

## Testing

How were these changes tested? **Addition of a test for a coarser grid**
What compilers / HPCs was it tested with? **gcc debug/release**
Are the changes covered by ctests? **yes**

## Dependencies
**NONE**
