### PR TITLE
fix release branch update

### DIFF
--- a/.github/travisci/stable_commit.sh
+++ b/.github/travisci/stable_commit.sh
@@ -18,7 +18,7 @@ RELEASE_BRANCH=${RELEASE_BRANCH:-release/stable-nightly}
 
 cwd=$(pwd)
 cd repo.src/${MAIN_REPO}/bundle
-cp CMakeLists.txt CMakeLists.txt.new
+mv CMakeLists.txt CMakeLists.txt.new
 
 # get the git commit hash for the relevant involved branches 
 ref_develop=$(git rev-parse HEAD)


### PR DESCRIPTION
## Description
The nightly stable branch was not being updated on TravisCI due to a bug. This fixes that.
closes #343 

## Testing

I manually ran the command on my machine to make sure release branch gets updated.