### PR TITLE
travis-ci failing in new container with gcc 9.3

### DIFF
--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -1040,7 +1040,7 @@ subroutine soca_fields_write_rst(fld, f_conf, vdate)
       idr = register_restart_field( ice_restart, ice_filename, "vsnon", &
         vsnon, domain=fld%geom%Domain%mpp_domain)
 
-    else if (field%io_file /= "") then
+    else if (len(field%io_file) /= 0) then
       ! which file are we writing to
       select case(field%io_file)
       case ('ocn')

--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -1040,7 +1040,7 @@ subroutine soca_fields_write_rst(fld, f_conf, vdate)
       idr = register_restart_field( ice_restart, ice_filename, "vsnon", &
         vsnon, domain=fld%geom%Domain%mpp_domain)
 
-    else if (len(field%io_file) /= 0) then
+    else if (len_trim(field%io_file) /= 0) then
       ! which file are we writing to
       select case(field%io_file)
       case ('ocn')


### PR DESCRIPTION
## Description
Multiple ctests are failing when using the newly updated container. Note that the failure only happens in debug mode and is caused by a weird behavior in testing the "emptiness" of an allocatable character array. The test was simply replaced by checking the length instead. 
   
closes #362 

