### PR TITLE
More flexible obs space in cycling scripts

### DIFF
--- a/scripts/workflow/apps/cycle.sh
+++ b/scripts/workflow/apps/cycle.sh
@@ -159,9 +159,7 @@ while true; do
         export MOM_CONFIG=$MODEL_CONFIG/model
         export MOM_DATA=$MODEL_DATA/model
         export OBS_IODA
-        export OBS_ADT
-        export OBS_INSITU
-        export OBS_SST
+        export OBS_LIST
         export RESTART_DIR=$SCRATCH_DIR_CYCLE/fcst.run/RESTART
         export SOCA_BIN_DIR
         export SOCA_CONFIG=$MODEL_CONFIG/soca

--- a/scripts/workflow/apps/exp.config.geos
+++ b/scripts/workflow/apps/exp.config.geos
@@ -3,7 +3,7 @@ EXP_DIR=$(readlink -f .)
 WORKLOAD_MANAGER=slurm  # none or slurm
 MACHINE=discover        # default or discover (default is a Linux workstation, no modules loaded)
                         # TODO(Guillaume) add Hera and Orion
-MPIRUN=mpirun           # TODO could probably get the info from somewhere else
+MPIRUN=mpirun           #TODO could probably get the info from somewhere else
 
 # parameters used by SLURM
 JOB_NAME=exp13
@@ -22,9 +22,9 @@ SOCA_BUNDLE_DIR=/path/to/soca-bundle/
 SOCA_BIN_DIR=${SOCA_BUNDLE_DIR}/build-gnu/bin/
 
 # model/soca configuration to be used
-MODEL=mom6                         # options: mom6 or geos
+MODEL=geos                         # options: mom6 or geos
                                    # TODO add EMC's MOM6-CICE
-MOM_EXE=${SOCA_BIN_DIR}/mom6.x     # only used when model is mom6
+MOM_EXE=NA                         # only used when model is mom6
 model_res=1deg                     # other options for now are 05deg and 025deg
 MODEL_CONFIG=${EXP_DIR}/soca-config/jcsda/mom6sis2_global/${model_res}
 MODEL_DATA=/discover/nobackup/tsluka/jedi/soca.data/mom6sis2_global/${model_res}
@@ -33,10 +33,16 @@ MODEL_DATA=/discover/nobackup/tsluka/jedi/soca.data/mom6sis2_global/${model_res}
 # TODO 1 year spin-up so we can start doing science!
 MOM_IC=/path/to/initial/restart/MOM.res.nc
 
+# geos specific configuration
+# TODO move somewhere else
+GEOS_RC=/path/to/geos/rc           # resource files for geos
+GEOS_GCMRUN=/path/to/gcm_run.j     # geos run script
+GEOS_IC=/path/to/non-mom6/initial/restart/rst_atm_20151201_120000.tar
+
 # forcing (unused when model is geos)
-FORC_ATM="cfsr"
-FORC_MEAN_FILE=/discover/nobackup/tsluka/DATA/fluxes/cfsr/%Y/%Y%m%d/cfsr.%Y%m%d.'#var#'.nc
-FORC_VAR=DLWRF.sfc,DSWRF.sfc,PRATE,SLP,TMP.2m,SPFH.2m,UGRD.10m,VGRD.10m
+FORC_ATM=NA
+FORC_MEAN_FILE=NA
+FORC_VAR=NA
 
 # observations
 OBS_IODA=/path/to/obs_ioda
@@ -44,9 +50,3 @@ OBS_LIST="adt sst sss insitu" # TODO split per instrument, point to EMC's ObsTyp
                               # Elements $o of the list is used to:
                               #   1. Locate ioda file $OBS_IODA/${ymd}/$o/$o.$ymd.nc
                               #   2. Add ObsSpace $o.yml to the ObsTypes in 3dvar.yml
-
-# Set unused variables to dummy values
-# TODO(Guillaume) GEOS_* are currently needed in cycle.sh. Move the model needed variable to a dedicated script.
-GEOS_RC=NA
-GEOS_GCMRUN=NA
-GEOS_IC=NA

--- a/scripts/workflow/apps/exp.config.mom6solo
+++ b/scripts/workflow/apps/exp.config.mom6solo
@@ -2,8 +2,8 @@ EXP_DIR=$(readlink -f .)
 
 WORKLOAD_MANAGER=slurm  # none or slurm
 MACHINE=discover        # default or discover (default is a Linux workstation, no modules loaded)
-                       # TODO(Guillaume) add Hera and Orion
-MPIRUN=mpirun          #TODO could probably get the info from somewhere else
+                        # TODO(Guillaume) add Hera and Orion
+MPIRUN=mpirun           # TODO could probably get the info from somewhere else
 
 # parameters used by SLURM
 JOB_NAME=exp13
@@ -18,7 +18,7 @@ FCST_LEN=24
 
 # various directory locations
 SCRATCH_DIR=${EXP_DIR}/WRK
-SOCA_BUNDLE_DIR=/home/gvernier/nobackup/soca/soca-bundle/
+SOCA_BUNDLE_DIR=/path/to/soca-bundle/
 SOCA_BIN_DIR=${SOCA_BUNDLE_DIR}/build-gnu/bin/
 
 # model/soca configuration to be used
@@ -31,13 +31,7 @@ MODEL_DATA=/discover/nobackup/tsluka/jedi/soca.data/mom6sis2_global/${model_res}
 
 # initial conditions for model
 # TODO 1 year spin-up so we can start doing science!
-MOM_IC=/home/gvernier/nobackup/soca/runs/exp12/rst/2015123112/MOM.res.nc
-
-# geos specific configuration
-# TODO move somewhere else
-GEOS_RC=/home/gvernier/nobackup/geos-santha/geos-scratch
-GEOS_GCMRUN=${GEOS_RC}/gcm_run.j
-GEOS_IC=/home/gvernier/nobackup/geos-santha/soca-cpld/util/rst_atm_20151201_120000.tar
+MOM_IC=/path/to/initial/restart/MOM.res.nc
 
 # forcing (unused when model is geos)
 FORC_ATM="cfsr"
@@ -45,8 +39,14 @@ FORC_MEAN_FILE=/discover/nobackup/tsluka/DATA/fluxes/cfsr/%Y/%Y%m%d/cfsr.%Y%m%d.
 FORC_VAR=DLWRF.sfc,DSWRF.sfc,PRATE,SLP,TMP.2m,SPFH.2m,UGRD.10m,VGRD.10m
 
 # observations
-OBS_IODA=/home/gvernier/nobackup/soca/runs/obs_ioda
+OBS_IODA=/path/to/obs_ioda
 OBS_LIST="adt sst sss insitu" # TODO split per instrument, point to EMC's ObsTypes
-                          # Elements $o of the list is used to:
-                          #   1. Locate ioda file $OBS_IODA/${ymd}/$o/$o.$ymd.nc
-                          #   2. Add ObsSpace $o.yml to the ObsTypes in 3dvar.yml
+                              # Elements $o of the list is used to:
+                              #   1. Locate ioda file $OBS_IODA/${ymd}/$o/$o.$ymd.nc
+                              #   2. Add ObsSpace $o.yml to the ObsTypes in 3dvar.yml
+
+# Set unused variables to dummy values
+# TODO(Guillaume) GEOS_* are currently needed in cycle.sh. Implement differently!
+GEOS_RC=NA
+GEOS_GCMRUN=NA
+GEOS_IC=NA

--- a/scripts/workflow/apps/exp.config.mom6solo
+++ b/scripts/workflow/apps/exp.config.mom6solo
@@ -1,13 +1,13 @@
 EXP_DIR=$(readlink -f .)
 
-WORKLOAD_MANAGER=slurm # none or slurm
-MACHINE=discover       # default or discover (default is a Linux workstation, no modules loaded)
+WORKLOAD_MANAGER=none  # none or slurm
+MACHINE=default        # default or discover (default is a Linux workstation, no modules loaded)
                        # TODO(Guillaume) add Hera and Orion
 MPIRUN=mpirun          #TODO could probably get the info from somewhere else
 
 # parameters used by SLURM
 JOB_NAME=test
-JOB_NPES=360
+JOB_NPES=6
 JOB_TIME=1:00:00
 JOB_ACCT=g0613
 
@@ -18,20 +18,20 @@ FCST_LEN=24
 
 # various directory locations
 SCRATCH_DIR=${EXP_DIR}/WRK
-SOCA_BUNDLE_DIR=/home/gvernier/nobackup/soca/soca-bundle
-SOCA_BIN_DIR=/home/gvernier/nobackup/soca/soca-bundle/build-gnu/bin
+SOCA_BUNDLE_DIR=/home/gvernier/sandboxes/soca/soca-bundle/
+SOCA_BIN_DIR=/home/gvernier/sandboxes/soca/soca-bundle/build/bin/
 
 # model/soca configuration to be used
-MODEL=geos                         # options: mom6 or geos
+MODEL=mom6                         # options: mom6 or geos
                                    # TODO add EMC's MOM6-CICE
 MOM_EXE=${SOCA_BIN_DIR}/mom6.x     # only used when model is mom6
 model_res=1deg                     # other options for now are 05deg and 025deg
-MODEL_CONFIG=/discover/nobackup/gvernier/soca/runs/test/soca-config/jcsda/mom6-geos/${model_res}
-MODEL_DATA=/discover/nobackup/tsluka/jedi/soca.data/mom6sis2_global/${model_res}
+MODEL_CONFIG=/home/gvernier/sandboxes/soca/soca-bundle/soca-config/jcsda/mom6sis2_global/${model_res}
+MODEL_DATA=/home/gvernier/sandboxes/soca/runs/mom6sis2_global/${model_res}
 
 # initial conditions for model
 # TODO 1 year spin-up so we can start doing science!
-MOM_IC=/discover/nobackup/tsluka/DATA/ic/soda_3.3.1_20151130.nc
+MOM_IC=/home/gvernier/sandboxes/soca/runs/DATA/ic/soda_3.3.1_20151130.nc
 
 # geos specific configuration
 # TODO move somewhere else
@@ -41,11 +41,11 @@ GEOS_IC=/home/gvernier/nobackup/geos-santha/soca-cpld/util/rst_atm_20151201_1200
 
 # forcing (unused when model is geos)
 FORC_ATM="cfsr"
-FORC_MEAN_FILE=/discover/nobackup/tsluka/DATA/fluxes/cfsr/%Y/%Y%m%d/cfsr.%Y%m%d.'#var#'.nc
+FORC_MEAN_FILE=/home/gvernier/sandboxes/soca/runs/DATA/fluxes/cfsr/%Y/%Y%m%d/cfsr.%Y%m%d.'#var#'.nc
 FORC_VAR=DLWRF.sfc,DSWRF.sfc,PRATE,SLP,TMP.2m,SPFH.2m,UGRD.10m,VGRD.10m
 
 # observations
-OBS_IODA=/discover/nobackup/tsluka/DATA/obs.ioda
+OBS_IODA=/home/gvernier/sandboxes/soca/runs/Data/obs_ioda
 OBS_LIST="adt sst sss insitu" # TODO split per instrument, point to EMC's ObsTypes
                               # Elements $o of the list is used to:
                               #   1. Locate ioda file $OBS_IODA/${ymd}/$o/$o.$ymd.nc

--- a/scripts/workflow/apps/exp.config.mom6solo
+++ b/scripts/workflow/apps/exp.config.mom6solo
@@ -1,37 +1,37 @@
 EXP_DIR=$(readlink -f .)
 
-WORKLOAD_MANAGER=none  # none or slurm
-MACHINE=default        # default or discover (default is a Linux workstation, no modules loaded)
+WORKLOAD_MANAGER=slurm  # none or slurm
+MACHINE=discover        # default or discover (default is a Linux workstation, no modules loaded)
                        # TODO(Guillaume) add Hera and Orion
 MPIRUN=mpirun          #TODO could probably get the info from somewhere else
 
 # parameters used by SLURM
-JOB_NAME=test
-JOB_NPES=6
+JOB_NAME=exp13
+JOB_NPES=100
 JOB_TIME=1:00:00
 JOB_ACCT=g0613
 
 # experiment start/stop times
-EXP_START_TIME=20151201Z12
-EXP_END_TIME=20151231Z12
+EXP_START_TIME=20160101Z12
+EXP_END_TIME=20160102Z12
 FCST_LEN=24
 
 # various directory locations
 SCRATCH_DIR=${EXP_DIR}/WRK
-SOCA_BUNDLE_DIR=/home/gvernier/sandboxes/soca/soca-bundle/
-SOCA_BIN_DIR=/home/gvernier/sandboxes/soca/soca-bundle/build/bin/
+SOCA_BUNDLE_DIR=/home/gvernier/nobackup/soca/soca-bundle/
+SOCA_BIN_DIR=${SOCA_BUNDLE_DIR}/build-gnu/bin/
 
 # model/soca configuration to be used
 MODEL=mom6                         # options: mom6 or geos
                                    # TODO add EMC's MOM6-CICE
 MOM_EXE=${SOCA_BIN_DIR}/mom6.x     # only used when model is mom6
 model_res=1deg                     # other options for now are 05deg and 025deg
-MODEL_CONFIG=/home/gvernier/sandboxes/soca/soca-bundle/soca-config/jcsda/mom6sis2_global/${model_res}
-MODEL_DATA=/home/gvernier/sandboxes/soca/runs/mom6sis2_global/${model_res}
+MODEL_CONFIG=${EXP_DIR}/soca-config/jcsda/mom6sis2_global/${model_res}
+MODEL_DATA=/discover/nobackup/tsluka/jedi/soca.data/mom6sis2_global/${model_res}
 
 # initial conditions for model
 # TODO 1 year spin-up so we can start doing science!
-MOM_IC=/home/gvernier/sandboxes/soca/runs/DATA/ic/soda_3.3.1_20151130.nc
+MOM_IC=/home/gvernier/nobackup/soca/runs/exp12/rst/2015123112/MOM.res.nc
 
 # geos specific configuration
 # TODO move somewhere else
@@ -41,12 +41,12 @@ GEOS_IC=/home/gvernier/nobackup/geos-santha/soca-cpld/util/rst_atm_20151201_1200
 
 # forcing (unused when model is geos)
 FORC_ATM="cfsr"
-FORC_MEAN_FILE=/home/gvernier/sandboxes/soca/runs/DATA/fluxes/cfsr/%Y/%Y%m%d/cfsr.%Y%m%d.'#var#'.nc
+FORC_MEAN_FILE=/discover/nobackup/tsluka/DATA/fluxes/cfsr/%Y/%Y%m%d/cfsr.%Y%m%d.'#var#'.nc
 FORC_VAR=DLWRF.sfc,DSWRF.sfc,PRATE,SLP,TMP.2m,SPFH.2m,UGRD.10m,VGRD.10m
 
 # observations
-OBS_IODA=/home/gvernier/sandboxes/soca/runs/Data/obs_ioda
+OBS_IODA=/home/gvernier/nobackup/soca/runs/obs_ioda
 OBS_LIST="adt sst sss insitu" # TODO split per instrument, point to EMC's ObsTypes
-                              # Elements $o of the list is used to:
-                              #   1. Locate ioda file $OBS_IODA/${ymd}/$o/$o.$ymd.nc
-                              #   2. Add ObsSpace $o.yml to the ObsTypes in 3dvar.yml
+                          # Elements $o of the list is used to:
+                          #   1. Locate ioda file $OBS_IODA/${ymd}/$o/$o.$ymd.nc
+                          #   2. Add ObsSpace $o.yml to the ObsTypes in 3dvar.yml

--- a/scripts/workflow/apps/soca.modules.default
+++ b/scripts/workflow/apps/soca.modules.default
@@ -1,0 +1,1 @@
+echo "No loading of modules."

--- a/scripts/workflow/subscripts/da.init.sh
+++ b/scripts/workflow/subscripts/da.init.sh
@@ -63,7 +63,7 @@ cd ..
 # create time dependent momt namelist file
 FCST_RESTART=1
 FCST_RST_OFST=$FCST_LEN
-. input.nml.sh > input.nml
+. input.nml.sh > input-mom6.nml
 
 # link soca config files
 ln -s $SOCA_CONFIG/* .

--- a/scripts/workflow/subscripts/da.run.sh
+++ b/scripts/workflow/subscripts/da.run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ev
 cat <<EOF
 
 #================================================================================
@@ -119,8 +119,9 @@ echo "Moving restart files..."
 mkdir -p $CYCLE_RST_DIR
 cp $WORK_DIR/INPUT/*.res* $CYCLE_RST_DIR/
 
-if [[ -f $WORK_DIR/INPUT/*_rst ]]; then
-    cp $WORK_DIR/INPUT/*_rst $CYCLE_RST_DIR/ #TODO cp of geos rst need to go somewhere else
-fi
-#rsync -av --ignore-missing-args $WORK_DIR/INPUT/*_rst $CYCLE_RST_DIR/ #TODO cp of geos rst need to go somewhere else
+#if [[ -f $WORK_DIR/INPUT/*_rst ]]; then
+#    cp $WORK_DIR/INPUT/*_rst $CYCLE_RST_DIR/ #TODO cp of geos rst need to go somewhere else
+#fi
+
+rsync -av --copy-links --ignore-missing-args $WORK_DIR/INPUT/*_rst $CYCLE_RST_DIR/ #TODO cp of geos rst need to go somewhere else
 cp $WORK_DIR/RESTART/* $CYCLE_RST_DIR/

--- a/scripts/workflow/subscripts/da.run.sh
+++ b/scripts/workflow/subscripts/da.run.sh
@@ -20,9 +20,7 @@ envar+=("FCST_START_TIME") # date and time of start of forecast
 envar+=("MOM_CONFIG")      # path to input model configuration files
 envar+=("MOM_DATA")        # path to input model static data
 envar+=("OBS_IODA")        # path to observations already processed into ioda format
-envar+=("OBS_ADT")         # directory name for adt
-envar+=("OBS_INSITU")      # directory name for insitu
-envar+=("OBS_SST")         # directory name for sst
+envar+=("OBS_LIST")        # List of observations ("adt sst sss insitu")
 envar+=("RESTART_DIR")     # path to input restart files for da background
 envar+=("SOCA_BIN_DIR")    # path to soca executables
 envar+=("SOCA_CONFIG")     # path to input soca configuration files
@@ -68,10 +66,10 @@ cd ..
 # create time dependent mom namelist file
 FCST_RESTART=1
 FCST_RST_OFST=$FCST_LEN
-. input.nml.sh > input.nml
+. input.nml.sh > input-mom6.nml
 
-# link soca config files
-ln -s $SOCA_CONFIG/* .
+# copy soca config files
+cp $SOCA_CONFIG/* .
 . 3dvar.yml.sh > 3dvar.yml
 . checkpoint.yml.sh > checkpoint.yml
 ln -s $SOCA_DATA/* .
@@ -88,10 +86,25 @@ cd ..
 # TODO make obs list configurable
 cd obs
 ymd=$(date -u -d "$ANA_TIME" +%Y%m%d)
-ln -s $OBS_IODA/$OBS_ADT/${ymd:0:4}/$ymd.nc adt.nc
-ln -s $OBS_IODA/$OBS_INSITU/${ymd:0:4}/$ymd.nc insitu.nc
-ln -s $OBS_IODA/$OBS_SST/${ymd:0:4}/$ymd.nc sst.nc
+
+obs_list_cycle=""
+for o in $OBS_LIST; do
+  if [[ -f $OBS_IODA/${ymd}/$o/$o.$ymd.nc ]]; then
+    echo "Adding $o observations..."
+    obs_list_cycle="$obs_list_cycle $o"
+    ln -s $OBS_IODA/${ymd}/$o/$o.$ymd.nc $o.nc
+  fi
+done
 cd ..
+
+# Add the ObsSpace's to the 3DVAR Jo cost function
+for o in $obs_list_cycle; do
+  if [[ -f $o.yml ]]; then
+    echo "Adding $o to ObsSpace templated from $o.yml ..."
+    cp $o.yml obs.yml
+    sed -i -e '/# OBS_SPACE/{r obs.yml' -e 'd' -e '}' 3dvar.yml
+  fi
+done
 
 # run the 3dvar
 echo "Starting 3dvar..."
@@ -105,5 +118,9 @@ time $MPIRUN -np $JOB_NPES $SOCA_BIN_DIR/soca_checkpoint_model.x checkpoint.yml
 echo "Moving restart files..."
 mkdir -p $CYCLE_RST_DIR
 cp $WORK_DIR/INPUT/*.res* $CYCLE_RST_DIR/
-rsync -av --ignore-missing-args $WORK_DIR/INPUT/*_rst $CYCLE_RST_DIR/ #TODO cp of geos rst need to go somewhere else
+
+if [[ -f $WORK_DIR/INPUT/*_rst ]]; then
+    cp $WORK_DIR/INPUT/*_rst $CYCLE_RST_DIR/ #TODO cp of geos rst need to go somewhere else
+fi
+#rsync -av --ignore-missing-args $WORK_DIR/INPUT/*_rst $CYCLE_RST_DIR/ #TODO cp of geos rst need to go somewhere else
 cp $WORK_DIR/RESTART/* $CYCLE_RST_DIR/


### PR DESCRIPTION
## Description

Updates to the cycling scripts. 
- Added GEOS forecast model
- Switching the obsspace setup in the 3dvar yaml to do something similar to what we have for EMC
- Updates to how we handle `input.nml`


### Issue(s) addressed

We should be able to re-use what we developed for EMC in terms of the ObsSpace setup, which is done per instrument, as opposed to general obs types (e.g. gmi.sst instead of sst ... etc)



## Testing

Tested on discover and linux workstations. This code is not part of our automated travis-ci tests.
These are very simple and easily portable scripts, I will add the necessary data to allow us to use them on Hera and Orion.


## Dependencies

[soca-config pr#20](https://github.com/JCSDA/soca-config/pull/20)
