### PR TITLE
removed assertion for valid file sn

### DIFF
--- a/src/soca/Geometry/FmsInput.cc
+++ b/src/soca/Geometry/FmsInput.cc
@@ -25,10 +25,6 @@ namespace soca {
       inputnml_sn_ = getFileSN(inputnml_orig_);
     }
     comm_.broadcast(inputnml_sn_, 0);
-
-    // Check that inputnml_sn_ is a valid serial #
-    ASSERT(inputnml_sn_ > 0);
-    comm_.barrier();
   }
   // -----------------------------------------------------------------------------
   FmsInput::FmsInput(const FmsInput & other)


### PR DESCRIPTION
## Description

Assertion for valid file serial number randomly fails on Hera and Orion.

## Testing

How were these changes tested? ctests 
What compilers / HPCs was it tested with? I could not reproduce the issue, but @jkbk2004 tested the bugfix on Hera 
Are the changes covered by ctests? yes

## Dependencies

None

## Issues addressed

closes [358](https://github.com/JCSDA/soca/issues/358)