### PR TITLE
Compiler cache build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See the [soca ReadTheDocs](https://jointcenterforsatellitedataassimilation-soca.
 
 1. If building as part of the larger SOCA coupled system, see the [soca-bundle](https://github.com/JCSDA/soca-bundle)
 
-2. Otherwise, for just the MOM6 SOCA component: unlike other JEDI projects, this project contains its own bundle, it can be built as follows
+2. If building the MOM6 SOCA component: unlike other JEDI projects, this project contains its own bundle, it can be built as follows
 ```
 git clone https://github.com/JCSDA/soca.git
 mkdir -p soca_build
@@ -22,6 +22,29 @@ cd soca_build
 ecbuild ../soca/bundle
 cd soca
 make -j 4
+```
+
+3. If building the same way travis-ci builds the MOM6 SOCA bundle:
+```
+export MAIN_REPO=soca
+export LIB_REPOS="fms cvmix geokdtree mom6_da_hooks gsw mom6 crtm fckit atlas oops saber ioda ufo ioda-converters soca-config"
+export BUILD_OPT=""
+export BUILD_OPT_CRTM="-DBUILD_CRTM=ON"
+export BUILD_OPT_OOPS="-DENABLE_OOPS_TOYMODELS=OFF"
+export BUILD_OPT_UFO="-DLOCAL_PATH_TESTFILES_IODA=NONE"
+export BUILD_OPT_SOCA="-DSOCA_TESTS_FORC_DEFAULT_TOL=ON -DCRTM_FIX_DIR=../../repo.src/crtm/fix"
+export MATCH_REPOS="atlas oops saber ioda ioda-converters ufo soca soca-config"
+export LFS_REPOS="crtm"
+export REPO_CACHE="/path/to/somewhere/repo.cache"
+mkdir -p repo.src
+cd repo.src
+git clone https://github.com/JCSDA/soca.git
+cd ..
+./repo.src/soca/.github/travisci/prep.sh
+```
+Note that ccache needs to be installed or loaded. If testing within singularity, swap ccache with ccache-swig in `./github/travisci/build.sh`.
+```
+ ./repo.src/soca/.github/travisci/build.sh
 ```
 
 See the [JEDI Documentation](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/) for additional details on how to setup, build, and test JEDI projects.


### PR DESCRIPTION
## Description

In my current attempt at figuring out why travis-ci is currently failing, while the tests are fine on most hpc and containers, I built soca the same way travis-ci does. This is mainly a note to self for future reference, because I WILL forget. It might be of use to somebody else.

### Issue(s) addressed

related to #370 but unfortunately does not fix it.


## Testing

Tested within singularity.  I unfortunately cannot replicate the current travis-ci failure, soca builds and tests fine, and the ecmwf repos are pointing to the correct stable branches.


