### PR TITLE
Update ctest reference outputs due to BUMP bugfix

### DIFF
--- a/src/soca/Transforms/HorizFilt/soca_horizfilt_mod.F90
+++ b/src/soca/Transforms/HorizFilt/soca_horizfilt_mod.F90
@@ -5,7 +5,6 @@
 
 
 module soca_horizfilt_mod
-  use config_mod
   use fckit_configuration_module, only: fckit_configuration
   use fckit_geometry_module, only: sphere_distance
   use iso_c_binding

--- a/test/testref/3dhyb.test
+++ b/test/testref/3dhyb.test
@@ -1,21 +1,21 @@
 Test     : CostJb   : Nonlinear Jb = 0
 Test     : CostJo   : Nonlinear Jo(ADT) = 224.622, nobs = 100, Jo/n = 2.24622, err = 0.1
 Test     : CostFunction: Nonlinear J = 224.622
-Test     : RPCGMinimizer: reduction in residual norm = 0.634306
+Test     : RPCGMinimizer: reduction in residual norm = 0.63425
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023969
 Test     :   hicen   min=   -0.000769   max=    2.923064   mean=    0.115988
 Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.573471
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.011806
-Test     :     ssh   min=   -2.375281   max=    0.925786   mean=   -0.289318
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.574256
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.011836
+Test     :     ssh   min=   -2.375283   max=    0.925792   mean=   -0.289317
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min= -225.097763   max=   -0.033703   mean= -110.032311
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   64.434146
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    9.318225
 Test     :      lw   min=    0.000000   max=   88.036087   mean=   48.153824
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.009356
-Test     : CostJb   : Nonlinear Jb = 6.890110
-Test     : CostJo   : Nonlinear Jo(ADT) = 137.806799, nobs = 100, Jo/n = 1.378068, err = 0.100000
-Test     : CostFunction: Nonlinear J = 144.696909
+Test     : CostJb   : Nonlinear Jb = 7.231785
+Test     : CostJo   : Nonlinear Jo(ADT) = 137.800465, nobs = 100, Jo/n = 1.378005, err = 0.100000
+Test     : CostFunction: Nonlinear J = 145.032250

--- a/test/testref/3dhybfgat.test
+++ b/test/testref/3dhybfgat.test
@@ -1,20 +1,20 @@
 Test     : CostJb   : Nonlinear Jb = 0
 Test     : CostJo   : Nonlinear Jo(ADT) = 88.4792, nobs = 31, Jo/n = 2.85417, err = 0.1
 Test     : CostFunction: Nonlinear J = 88.4792
-Test     : RPCGMinimizer: reduction in residual norm = 0.381229
+Test     : RPCGMinimizer: reduction in residual norm = 0.381217
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023946
 Test     :   hicen   min=   -0.000659   max=    2.923064   mean=    0.115987
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.559138
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.014629
-Test     :     ssh   min=   -1.924402   max=    0.921287   mean=   -0.284616
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.559586
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.014665
+Test     :     ssh   min=   -1.924402   max=    0.921295   mean=   -0.284615
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     : CostJb   : Nonlinear Jb = 3.868591
-Test     : CostJo   : Nonlinear Jo(ADT) = 70.243651, nobs = 31, Jo/n = 2.265924, err = 0.100000
-Test     : CostFunction: Nonlinear J = 74.112243
+Test     : CostJb   : Nonlinear Jb = 4.078589
+Test     : CostJo   : Nonlinear Jo(ADT) = 69.874906, nobs = 31, Jo/n = 2.254029, err = 0.100000
+Test     : CostFunction: Nonlinear J = 73.953495

--- a/test/testref/dirac_socahyb_cov.test
+++ b/test/testref/dirac_socahyb_cov.test
@@ -2,15 +2,15 @@ Test     : Increment:
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=   -0.024201   max=    0.000006   mean=   -0.000189
 Test     :   hicen   min=   -0.000102   max=   50.000000   mean=    0.063618
-Test     :    socn   min=   -0.010718   max=    0.059062   mean=    0.000116
-Test     :    tocn   min=   -0.003391   max=    2.670638   mean=    0.008224
-Test     :     ssh   min=   -0.006884   max=    0.019012   mean=    0.000216
+Test     :    socn   min=   -0.010722   max=    0.059720   mean=    0.000121
+Test     :    tocn   min=   -0.005248   max=    2.671357   mean=    0.008225
+Test     :     ssh   min=   -0.006880   max=    0.019012   mean=    0.000215
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : Increment: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.054614
-Test     :   hicen   min=    0.000000   max=    1.000000   mean=    0.054614
-Test     :    socn   min=    0.000000   max=    1.000000   mean=    0.034520
-Test     :    tocn   min=    0.000000   max=    1.000000   mean=    0.034520
-Test     :     ssh   min=    0.000000   max=    1.000000   mean=    0.054614
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.054687
+Test     :   hicen   min=    0.000000   max=    1.000000   mean=    0.054687
+Test     :    socn   min=    0.000000   max=    1.000000   mean=    0.054680
+Test     :    tocn   min=    0.000000   max=    1.000000   mean=    0.054680
+Test     :     ssh   min=    0.000000   max=    1.000000   mean=    0.054687
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000


### PR DESCRIPTION
Issue https://github.com/JCSDA/saber/pull/66 has been fixed with PR https://github.com/JCSDA/saber/pull/116. NICAS-related tests results are affected, but differences in the cost function for SOCA are below 1%.