### PR TITLE
Remove deprecated use of config_mod

### DIFF
--- a/src/soca/Transforms/HorizFilt/soca_horizfilt_mod.F90
+++ b/src/soca/Transforms/HorizFilt/soca_horizfilt_mod.F90
@@ -5,7 +5,6 @@
 
 
 module soca_horizfilt_mod
-  use config_mod
   use fckit_configuration_module, only: fckit_configuration
   use fckit_geometry_module, only: sphere_distance
   use iso_c_binding


### PR DESCRIPTION
## Description
Removed the now deprecated `use config_mod` in one of the variable change.
