### PR TITLE
Output sponge file

### DIFF
--- a/src/soca/Model/soca_model.interface.F90
+++ b/src/soca/Model/soca_model.interface.F90
@@ -81,6 +81,10 @@ subroutine c_soca_setup(c_conf, c_key_geom, c_key_model) bind (c,name='soca_setu
     model%socn_minmax=(/-999., -999./)
   endif
 
+  ! Setup sponge output if needed (possibly used when running the checkpoint app)
+  if ( .not. f_conf%get("output_sponge", model%output_sponge) ) model%output_sponge = .false.
+  if ( .not. f_conf%get("sponge_idamp", model%sponge_idamp) ) model%sponge_idamp = 1.0
+
   ! Initialize mom6
   call soca_setup(model, geom)
 

--- a/src/soca/Model/soca_mom6.F90
+++ b/src/soca/Model/soca_mom6.F90
@@ -261,6 +261,7 @@ subroutine soca_mom6_init(mom6_config, partial_init)
                    mom6_config%surface_forcing_CSp)
 
   ! Do more stuff for mom init ...
+  mom6_config%MOM_CSp%write_IC = .true.
   call finish_MOM_initialization(mom6_config%Time,&
                                  mom6_config%dirs,&
                                  mom6_config%MOM_CSp,&

--- a/src/soca/Model/soca_mom6.F90
+++ b/src/soca/Model/soca_mom6.F90
@@ -261,7 +261,6 @@ subroutine soca_mom6_init(mom6_config, partial_init)
                    mom6_config%surface_forcing_CSp)
 
   ! Do more stuff for mom init ...
-  mom6_config%MOM_CSp%write_IC = .true.
   call finish_MOM_initialization(mom6_config%Time,&
                                  mom6_config%dirs,&
                                  mom6_config%MOM_CSp,&

--- a/test/Data/72x35x25/MOM_input
+++ b/test/Data/72x35x25/MOM_input
@@ -1,8 +1,6 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
-SAVE_INITIAL_CONDS = True
-!IC_OUTPUT_FILE = "IC.nc"
 
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.
@@ -591,12 +589,14 @@ FLUXCONST = 0.5                 !   [m day-1]
 
 ! === module MOM_file_parser ===
 
-! === module sponge ===
+! === sponge use example ===
 !SPONGE = True
+!NEW_SPONGES = False
 !SPONGE_CONFIG = file
-!SPONGE_DAMPING_FILE
-!SPONGE_STATE_FILE
-!SPONGE_PTEMP_VAR
-!SPONGE_SALT_VAR
-!SPONGE_ETA_VAR
-!SPONGE_IDAMP_VAR
+!SPONGE_DAMPING_FILE = "sponge.nc"
+!SPONGE_STATE_FILE = "sponge.nc"
+!SPONGE_PTEMP_VAR = "ptemp"
+!SPONGE_SALT_VAR = "Salt"
+!SPONGE_ETA_VAR = "eta"
+!SPONGE_IDAMP_VAR = "Idamp"
+

--- a/test/Data/72x35x25/MOM_input
+++ b/test/Data/72x35x25/MOM_input
@@ -588,3 +588,13 @@ FLUXCONST = 0.5                 !   [m day-1]
 ! === module MOM_restart ===
 
 ! === module MOM_file_parser ===
+
+! === module sponge ===
+!SPONGE = True
+!SPONGE_CONFIG = file
+!SPONGE_DAMPING_FILE
+!SPONGE_STATE_FILE
+!SPONGE_PTEMP_VAR
+!SPONGE_SALT_VAR
+!SPONGE_ETA_VAR
+!SPONGE_IDAMP_VAR

--- a/test/Data/72x35x25/MOM_input
+++ b/test/Data/72x35x25/MOM_input
@@ -1,6 +1,8 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+SAVE_INITIAL_CONDS = True
+!IC_OUTPUT_FILE = "IC.nc"
 
 ! === module MOM_unit_scaling ===
 ! Parameters for doing unit scaling of variables.

--- a/test/testinput/checkpointmodel.yml
+++ b/test/testinput/checkpointmodel.yml
@@ -11,7 +11,7 @@ model:
   variables: [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
   tocn_minmax: [-1.8, 32.0]
   socn_minmax: [0.1, 38.0]
-  output_sponge: True   # output sponge file
+  output_sponge: 1   # output sponge file
   sponge_idamp: 0.1  # [s^-1]
 
 background:

--- a/test/testinput/checkpointmodel.yml
+++ b/test/testinput/checkpointmodel.yml
@@ -11,6 +11,8 @@ model:
   variables: [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
   tocn_minmax: [-1.8, 32.0]
   socn_minmax: [0.1, 38.0]
+  output_sponge: True   # output sponge file
+  sponge_idamp: 0.1  # [s^-1]
 
 background:
   read_from_file: 1


### PR DESCRIPTION
## Description
Add the possibility to dump the tracer analysis in a sponge formatted file. This file can be used as the tracer fields to relax to in a mom6 forecast.

### Issue(s) addressed
closes [#379](https://github.com/JCSDA/soca/issues/379)

## Testing
How were these changes tested? **checkpoint ctest**
What compilers / HPCs was it tested with? **gnu**
Are the changes covered by ctests? **yes**

## Remarks
- The current build of mom6, and resulting executable, segfaults when using sponges, in general (unrelated to the work in this pr)
- The GFDL build of mom6 can read and "do things" with the sponge file generated by this work, but the results are not as expected. 

