### PR TITLE
Broken letkf test

### DIFF
--- a/test/testref/letkf.test
+++ b/test/testref/letkf.test
@@ -49,15 +49,15 @@ Test     : SeaSurfaceTemp nobs= 201 Min=-0.990177, Max=30.561830, RMS=24.133756
 Test     : background y - H(x): 
 Test     : SeaSurfaceTemp nobs= 201 Min=-5.036848, Max=4.298109, RMS=1.331321
 Test     : H(x) for member 1:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.989932, Max=30.376682, RMS=24.035634
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.989930, Max=30.376757, RMS=24.035661
 Test     : H(x) for member 2:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.990169, Max=30.326795, RMS=24.043538
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.990169, Max=30.326781, RMS=24.043526
 Test     : H(x) for member 3:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.990297, Max=30.453053, RMS=24.039635
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.990298, Max=30.453068, RMS=24.039618
 Test     : H(x) for member 4:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.990282, Max=30.344695, RMS=24.052510
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.990283, Max=30.344670, RMS=24.052517
 Test     : H(x) for member 5:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.990185, Max=30.532182, RMS=24.046659
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.990185, Max=30.532216, RMS=24.046655
 Test     : H(x) ensemble analysis mean: 
 Test     : SeaSurfaceTemp nobs= 201 Min=-0.990173, Max=30.389153, RMS=24.043481
 Test     : analysis y - H(x): 


### PR DESCRIPTION
## Description
The letkf test keeps failing (randomly?) in the compare test, for some reason the script isn't using the prescribed tolerance.  I'm not sure why ...
This bugfix isn't addressing the root cause of the problem, but it should fix the sometimes broken test. 


