### PR TITLE
remove cvmix, geokdtree and mom6_da_hooks from soca/bundle

### DIFF
--- a/.github/travisci/prep.sh
+++ b/.github/travisci/prep.sh
@@ -104,7 +104,7 @@ for repo in $LIB_REPOS $MAIN_REPO; do
     if [[ $rebuild == 1 || $skip_lfs == 0 ]]; then
         repo_src_dir=repo.src/$repo
         rm -rf $repo_src_dir
-        GIT_LFS_SKIP_SMUDGE=$skip_lfs git clone -b $repo_branch $repo_url $repo_src_dir
+        GIT_LFS_SKIP_SMUDGE=$skip_lfs git clone --recursive -b $repo_branch $repo_url $repo_src_dir
     fi
 
 done

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@
 env:
   global:
     - MAIN_REPO=soca
-    - LIB_REPOS="fms gsw crtm
+    - LIB_REPOS="fms gsw mom6 crtm
                  fckit atlas oops saber ioda ufo ioda-converters soca-config"
     - BUILD_OPT=""
     - BUILD_OPT_CRTM="-DBUILD_CRTM=ON"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@
 env:
   global:
     - MAIN_REPO=soca
-    - LIB_REPOS="fms cvmix geokdtree mom6_da_hooks gsw mom6 crtm
+    - LIB_REPOS="fms gsw mom6 crtm
                  fckit atlas oops saber ioda ufo ioda-converters soca-config"
     - BUILD_OPT=""
     - BUILD_OPT_CRTM="-DBUILD_CRTM=ON"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,14 @@
 env:
   global:
     - MAIN_REPO=soca
-    - LIB_REPOS="fms gsw mom6 crtm
+    - LIB_REPOS="fms gsw crtm
                  fckit atlas oops saber ioda ufo ioda-converters soca-config"
     - BUILD_OPT=""
     - BUILD_OPT_CRTM="-DBUILD_CRTM=ON"
     - BUILD_OPT_OOPS="-DENABLE_OOPS_TOYMODELS=OFF"
     - BUILD_OPT_UFO="-DLOCAL_PATH_TESTFILES_IODA=NONE"
     - BUILD_OPT_SOCA="-DSOCA_TESTS_FORC_DEFAULT_TOL=ON -DCRTM_FIX_DIR=../../repo.src/crtm/fix"
-    - MATCH_REPOS="saber oops ioda ioda-converters ufo soca soca-config"
+    - MATCH_REPOS="saber oops ioda ioda-converters ufo mom6 soca soca-config"
     - LFS_REPOS="crtm"
 
     # secure token used to push changes to GitHub (user: travissluka)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,10 @@ link_libraries( ${ECKIT_LIBRARIES} )
 ecbuild_use_package( PROJECT fckit VERSION 0.4.1 REQUIRED )
 include_directories( ${FCKIT_INCLUDE_DIRS} )
 
+# atlas
+ecbuild_use_package( PROJECT atlas VERSION 0.18.1 REQUIRED )
+include_directories( ${ATLAS_INCLUDE_DIRS} )
+
 # oops
 ecbuild_use_package( PROJECT oops VERSION 0.1.0 REQUIRED )
 include_directories( ${OOPS_INCLUDE_DIRS} )

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ make -j 4
 3. If building the same way travis-ci builds the MOM6 SOCA bundle:
 ```
 export MAIN_REPO=soca
-export LIB_REPOS="fms cvmix geokdtree mom6_da_hooks gsw mom6 crtm fckit atlas oops saber ioda ufo ioda-converters soca-config"
+export LIB_REPOS="fms gsw mom6 crtm fckit atlas oops saber ioda ufo ioda-converters soca-config"
 export BUILD_OPT=""
 export BUILD_OPT_CRTM="-DBUILD_CRTM=ON"
 export BUILD_OPT_OOPS="-DENABLE_OOPS_TOYMODELS=OFF"

--- a/bundle/.gitignore
+++ b/bundle/.gitignore
@@ -1,15 +1,12 @@
 atlas/
 crtm/
-cvmix/
 eckit/
 fckit/
 fms/
-geokdtree/
 gsw/
 ioda-converters/
 ioda/
 mom6/
-mom6_da_hooks/
 oops/
 saber/
 soca

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -49,10 +49,7 @@ ecbuild_bundle( PROJECT ioda-converters GIT "https://github.com/JCSDA/ioda-conve
 ecbuild_bundle( PROJECT gsw             GIT "https://github.com/JCSDA/GSW-Fortran.git"     UPDATE BRANCH develop )
 ecbuild_bundle( PROJECT ufo             GIT "https://github.com/JCSDA/ufo.git"             UPDATE BRANCH develop )
 ecbuild_bundle( PROJECT fms             GIT "https://github.com/JCSDA/FMS.git"             UPDATE BRANCH dev/master-ecbuild )
-ecbuild_bundle( PROJECT cvmix           GIT "https://github.com/JCSDA/CVMix-src.git"       UPDATE BRANCH feature/ecbuild )
-ecbuild_bundle( PROJECT geokdtree       GIT "https://github.com/JCSDA/geoKdTree.git"       UPDATE BRANCH feature/ecbuild )
-ecbuild_bundle( PROJECT mom6_da_hooks   GIT "https://github.com/JCSDA/MOM6_DA_hooks.git"   UPDATE BRANCH feature/ecbuild )
-ecbuild_bundle( PROJECT mom6            GIT "https://github.com/JCSDA/MOM6.git"            UPDATE BRANCH dev/master-ecbuild )
+ecbuild_bundle( PROJECT mom6            GIT "https://github.com/JCSDA/MOM6.git"            UPDATE BRANCH feature/recursemom6 RECURSIVE)
 ecbuild_bundle( PROJECT soca-config     GIT "https://github.com/JCSDA/soca-config.git"     UPDATE BRANCH develop )
 ecbuild_bundle( PROJECT soca            SOURCE "../" )
 

--- a/src/soca/CMakeLists.txt
+++ b/src/soca/CMakeLists.txt
@@ -24,7 +24,7 @@ endfunction()
 ecbuild_add_library( TARGET   soca
                      SOURCES ${soca_src_files}
                      LIBS     ${LAPACK_LIBRARIES} ${NETCDF_LIBRARIES}
-                              eckit eckit_mpi fckit oops saber ioda ufo fms mom6
+                              eckit eckit_mpi fckit atlas atlas_f oops saber ioda ufo fms mom6
                      INSTALL_HEADERS LISTED
                      LINKER_LANGUAGE ${SOCA_LINKER_LANGUAGE}
                     )

--- a/src/soca/Geometry/soca_geom_mod.F90
+++ b/src/soca/Geometry/soca_geom_mod.F90
@@ -12,8 +12,6 @@ use soca_mom6, only: soca_mom6_config, soca_mom6_init, soca_ice_column, &
                      soca_geomdomain_init
 use soca_utils, only: write2pe, soca_remap_idw
 use kinds, only: kind_real
-use fckit_kdtree_module, only: kdtree, kdtree_create, kdtree_destroy, &
-                               kdtree_k_nearest_neighbors
 use fckit_configuration_module, only: fckit_configuration
 use fckit_mpi_module, only: fckit_mpi_comm
 use fms_io_mod, only : fms_io_init, fms_io_exit, &
@@ -24,7 +22,6 @@ use mpp_domains_mod, only : mpp_get_compute_domain, mpp_get_data_domain, &
                             mpp_get_global_domain, mpp_update_domains
 use fms_mod,         only : write_data, read_data
 use fms_io_mod,      only : fms_io_init, fms_io_exit 
-use fckit_geometry_module, only: sphere_distance
 use MOM_diag_remap,  only : diag_remap_ctrl, diag_remap_init, diag_remap_configure_axes, &
                             diag_remap_end, diag_remap_update 
 use MOM_EOS,         only : EOS_type

--- a/src/soca/Transforms/HorizFilt/soca_horizfilt_mod.F90
+++ b/src/soca/Transforms/HorizFilt/soca_horizfilt_mod.F90
@@ -5,8 +5,8 @@
 
 
 module soca_horizfilt_mod
+  use atlas_module, only: atlas_geometry
   use fckit_configuration_module, only: fckit_configuration
-  use fckit_geometry_module, only: sphere_distance
   use iso_c_binding
   use kinds
   use mpp_domains_mod, only : mpp_update_domains, mpp_update_domains_ad
@@ -59,7 +59,7 @@ contains
 
     integer :: i, j, ii, jj
     real(kind=kind_real) :: dist(-1:1,-1:1), sum_w, r_dist, r_flow
-    real :: re = 6.371e6 ! radius of earth (m)
+    type(atlas_geometry) :: ageometry
 
     ! Setup list of variables to apply filtering on
     self%vars = vars
@@ -82,6 +82,9 @@ contains
     ! Allocate and compute filtering weights
     allocate(self%wgh(self%isd:self%ied,self%jsd:self%jed,-1:1,-1:1))
 
+    ! Create UnitSphere geometry
+    ageometry = atlas_geometry("Earth")
+
     ! Compute distance based weights
     self%wgh = 0.0_kind_real
     r_dist = 1.0
@@ -92,7 +95,7 @@ contains
              do jj = -1,1
                 ! Great circle distance
                 if(self%scale_dist > 0) then
-                  r_dist = sphere_distance(geom%lon(i,j), geom%lat(i,j), geom%lon(i+ii,j+jj), geom%lat(i+ii,j+jj) ) * re
+                  r_dist = ageometry%distance(geom%lon(i,j), geom%lat(i,j), geom%lon(i+ii,j+jj), geom%lat(i+ii,j+jj) )
                   r_dist = exp(-0.5 * (r_dist/self%scale_dist) ** 2)
                 end if
 

--- a/test/testref/3dvar_godas.test
+++ b/test/testref/3dvar_godas.test
@@ -3,11 +3,11 @@ Test     : CostJo   : Nonlinear Jo(CoolSkin) = 17276.6, nobs = 201, Jo/n = 85.95
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 1625.53, nobs = 173, Jo/n = 9.39612, err = 0.363227
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.0095, nobs = 51, Jo/n = 0.96097, err = 1
 Test     : CostJo   : Nonlinear Jo(ADT) = 212.909, nobs = 95, Jo/n = 2.24115, err = 0.1
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.787, nobs = 206, Jo/n = 1.69314, err = 0.897281
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 355.419, nobs = 218, Jo/n = 1.63036, err = 0.608197
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 343.523, nobs = 206, Jo/n = 1.66759, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 350.504, nobs = 218, Jo/n = 1.60782, err = 0.608197
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 370.055, nobs = 89, Jo/n = 4.15792, err = 0.1
-Test     : CostFunction: Nonlinear J = 20238.3
-Test     : RPCGMinimizer: reduction in residual norm = 0.130931
+Test     : CostFunction: Nonlinear J = 20228.2
+Test     : RPCGMinimizer: reduction in residual norm = 0.130927
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023945
@@ -24,12 +24,12 @@ Test     :      lw   min=    0.000000   max=   88.036091   mean=   48.153833
 Test     :      us   min=    0.004396   max=    0.019667   mean=    0.009419
 Test     :    uocn   min=   -0.858170   max=    0.700095   mean=   -0.000241
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002019
-Test     : CostJb   : Nonlinear Jb = 0.529601
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 16677.089536, nobs = 201, Jo/n = 82.970595, err = 0.364832
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 1520.591713, nobs = 158, Jo/n = 9.623998, err = 0.366233
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.012166, nobs = 51, Jo/n = 0.961023, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 212.792300, nobs = 95, Jo/n = 2.239919, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 347.120950, nobs = 206, Jo/n = 1.685053, err = 0.897281
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 353.860018, nobs = 218, Jo/n = 1.623211, err = 0.608197
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 368.708954, nobs = 89, Jo/n = 4.142797, err = 0.100000
-Test     : CostFunction: Nonlinear J = 19529.705238
+Test     : CostJb   : Nonlinear Jb = 0.529476
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 16677.044891, nobs = 201, Jo/n = 82.970373, err = 0.364832
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 1520.629195, nobs = 158, Jo/n = 9.624235, err = 0.366233
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.012159, nobs = 51, Jo/n = 0.961023, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 212.792269, nobs = 95, Jo/n = 2.239919, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 341.917551, nobs = 206, Jo/n = 1.659794, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 348.946816, nobs = 218, Jo/n = 1.600673, err = 0.608197
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 368.708965, nobs = 89, Jo/n = 4.142797, err = 0.100000
+Test     : CostFunction: Nonlinear J = 19519.581322

--- a/test/testref/3dvar_soca.test
+++ b/test/testref/3dvar_soca.test
@@ -3,10 +3,10 @@ Test     : CostJo   : Nonlinear Jo(CoolSkin) = 14473.8, nobs = 173, Jo/n = 83.66
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 791.222, nobs = 145, Jo/n = 5.4567, err = 0.363828
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.0095, nobs = 51, Jo/n = 0.96097, err = 1
 Test     : CostJo   : Nonlinear Jo(ADT) = 159.451, nobs = 92, Jo/n = 1.73316, err = 0.1
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.787, nobs = 206, Jo/n = 1.69314, err = 0.897281
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 355.419, nobs = 218, Jo/n = 1.63036, err = 0.608197
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 343.523, nobs = 206, Jo/n = 1.66759, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 350.504, nobs = 218, Jo/n = 1.60782, err = 0.608197
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 679.22, nobs = 89, Jo/n = 7.63169, err = 0.1
-Test     : CostFunction: Nonlinear J = 16856.9
+Test     : CostFunction: Nonlinear J = 16846.8
 Test     : RPCGMinimizer: reduction in residual norm = 0.166933
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
@@ -21,12 +21,12 @@ Test     :     lhf   min=  -38.137479   max=  256.595650   mean=   64.433590
 Test     :     shf   min=  -58.949308   max=  201.374193   mean=    9.318212
 Test     :      lw   min=    0.000000   max=   88.036092   mean=   48.153833
 Test     :      us   min=    0.004396   max=    0.019672   mean=    0.009424
-Test     : CostJb   : Nonlinear Jb = 5.410568
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 12929.164967, nobs = 160, Jo/n = 80.807281, err = 0.362894
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 640.723734, nobs = 123, Jo/n = 5.209136, err = 0.360954
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.012417, nobs = 51, Jo/n = 0.961028, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 159.415810, nobs = 92, Jo/n = 1.732781, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.703990, nobs = 206, Jo/n = 1.692738, err = 0.897281
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 353.763431, nobs = 218, Jo/n = 1.622768, err = 0.608197
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 672.101228, nobs = 89, Jo/n = 7.551699, err = 0.100000
-Test     : CostFunction: Nonlinear J = 15158.296147
+Test     : CostJb   : Nonlinear Jb = 5.410564
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 12929.165687, nobs = 160, Jo/n = 80.807286, err = 0.362894
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 640.723678, nobs = 123, Jo/n = 5.209136, err = 0.360954
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.012402, nobs = 51, Jo/n = 0.961027, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 159.415792, nobs = 92, Jo/n = 1.732780, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 343.441326, nobs = 206, Jo/n = 1.667191, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 348.850318, nobs = 218, Jo/n = 1.600231, err = 0.608197
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 672.101231, nobs = 89, Jo/n = 7.551699, err = 0.100000
+Test     : CostFunction: Nonlinear J = 15148.120998

--- a/test/testref/checkpointmodel.test
+++ b/test/testref/checkpointmodel.test
@@ -32,7 +32,7 @@ Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023945
 Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.115987
 Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
 Test     :    socn   min=   10.721046   max=   38.000000   mean=   34.539802
-Test     :    tocn   min=   -1.800000   max=   31.700465   mean=    6.018384
+Test     :    tocn   min=   -1.800000   max=   31.700465   mean=    6.018383
 Test     :     ssh   min=   -1.924842   max=    0.927291   mean=   -0.276780
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000

--- a/test/testref/dirac_horizfilt.test
+++ b/test/testref/dirac_horizfilt.test
@@ -2,7 +2,7 @@ Test     : Increment:
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=    0.000000   max=    0.070621   mean=    0.000124
 Test     :   hicen   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     :    socn   min=    0.000000   max=    0.061217   mean=    0.000024
-Test     :    tocn   min=    0.000000   max=    0.065040   mean=    0.000024
+Test     :    socn   min=    0.000000   max=    0.061218   mean=    0.000024
+Test     :    tocn   min=    0.000000   max=    0.065041   mean=    0.000024
 Test     :     ssh   min=    0.000000   max=    0.476189   mean=    0.001854
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000

--- a/test/testref/hofx_3d.test
+++ b/test/testref/hofx_3d.test
@@ -29,7 +29,7 @@ Test     : CoolSkin nobs= 201 Min=-4.375751, Max=25.239587, RMS=20.067013
 Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.649473, RMS=24.170310
 Test     : SeaSurfaceSalinity nobs= 100 Min=31.245713, Max=37.087544, RMS=34.753009
 Test     : ADT nobs= 100 Min=-1.250816, Max=1.421506, RMS=0.757217
-Test     : InsituTemperature nobs= 218 Min=7.832734, Max=30.431111, RMS=21.287619
-Test     : InsituSalinity nobs= 218 Min=34.160244, Max=35.992907, RMS=35.036438
+Test     : InsituTemperature nobs= 218 Min=7.832734, Max=30.431111, RMS=21.295562
+Test     : InsituSalinity nobs= 218 Min=34.160244, Max=35.992907, RMS=35.044654
 Test     : SeaIceFraction nobs= 100 Min=0.000000, Max=1.000000, RMS=0.694504
 Test     : End H(x)


### PR DESCRIPTION
Change-Id: I1c50532d2e19a6871e53976632124f9f459ff21b

## Description

Provide a detailed description of what this PR does.  - This PR removes the cloning of CVMix, geoKdTree, and MOM6_da_hooks, and instead recursively clones these as part of MOM6.
What bug does it fix, or what feature does it add? - Removes overhead of maintaining 3rd party dependencies of MOM6 and allows us to be in near-constant sync with upstream development.
Is a change of answers expected from this PR? - Perhaps. We used to maintain separate forks of CVMix, geoKdTree and MOM6_da_hooks and never really updated the forks.  If they changed from the time we made those forks, answers are bound to change.



## Testing

How were these changes tested? - Waiting from Travis CI to tell me I made a mistake
What compilers / HPCs was it tested with? - Irrelevant
Are the changes covered by ctests? (If not, tests should be added first.) - Irrelevant



## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names for the automated TravisCI tests to pass

Do PRs in upstream repositories need to be merged first? - Yes. Got rid of some dependencies, added those implicitly here.
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on JCSDA/mom6/pull/[14](https://github.com/JCSDA/MOM6/pull/14)