### PR TITLE
Fix release/stable-nightly generation 

### DIFF
--- a/.github/travisci/stable_commit.sh
+++ b/.github/travisci/stable_commit.sh
@@ -20,7 +20,12 @@ cwd=$(pwd)
 cd repo.src/${MAIN_REPO}/bundle
 mv CMakeLists.txt CMakeLists.txt.new
 
-# get the git commit hash for the relevant involved branches 
+# by default TravisCI only fetches the single branch that is going to be tested,
+# this makes sure the release branch is retrieved as well
+git remote set-branches --add origin $RELEASE_BRANCH
+git fetch --all
+
+# get the git commit hash for the relevant involved branches
 ref_develop=$(git rev-parse HEAD)
 git checkout $RELEASE_BRANCH || git checkout -b $RELEASE_BRANCH
 ref_stable=$(git rev-parse HEAD)
@@ -30,7 +35,7 @@ ref_common=$(git merge-base $ref_develop $ref_stable)
 # (needs to be done when develop has been updated since the last release tag)
 amend=""
 if [[ "$ref_common" != "$ref_develop" ]]; then
-    git merge -s ours develop -m "temporary branch"
+    git merge -s ours $BRANCH -m "temporary branch"
     amend="--amend"
 fi
 

--- a/.github/travisci/stable_commit.sh
+++ b/.github/travisci/stable_commit.sh
@@ -31,6 +31,7 @@ url=${url/github.com/"${GH_TOKEN}@github.com"}
 # (otherwise, if we do it here, this script may change!)
 git clone $url $cwd/repo.release
 cd $cwd/repo.release
+git checkout $BRANCH
 git checkout $RELEASE_BRANCH || git checkout -b $RELEASE_BRANCH
 ref_release=$(git rev-parse HEAD)
 

--- a/.github/travisci/stable_commit.sh
+++ b/.github/travisci/stable_commit.sh
@@ -39,7 +39,7 @@ amend=""
 ref_stable=$(git rev-parse HEAD)
 ref_common=$(git merge-base $ref_develop $ref_stable)
 if [[ "$ref_common" != "$ref_develop" ]]; then
-    git merge -s ours $BRANCH -m "temporary branch"
+    git merge -s ours origin/$BRANCH -m "temporary branch"
     amend="--amend"
 fi
 

--- a/.github/travisci/stable_mark.sh
+++ b/.github/travisci/stable_mark.sh
@@ -11,8 +11,6 @@
 #================================================================================
 set -e
 
-RELEASE_BRANCH=${RELEASE_BRANCH:-release/stable-nightly}
-
 cwd=$(pwd)
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
@@ -66,6 +64,6 @@ for r in $bundle_repos; do
     if [[ $hash != "none" ]]; then
         hash=${hash:0:7}
         echo "changing $r to $hash"
-        sed -i "s/\(.* PROJECT $r .*\) \(BRANCH\|TAG\) .*/\1 TAG $hash \)/" $bundle_dir/CMakeLists.txt
+        sed -i "s/\(.*PROJECT \+$r .*\)\(BRANCH\|TAG\) *\([a-zA-Z0-9\/\_\.\-]*\)\(.*\)/\1TAG $hash\4/g" $bundle_dir/CMakeLists.txt
     fi
 done


### PR DESCRIPTION
## Description

The nightly cron script to generate the `release/stable-nightly` branch for soca was not working. I have no idea why I thought the previous version would work, it was all wrong. Same fix will be done for cice after we confirm it works for soca

### Issue(s) addressed

This should fix the problem in https://github.com/JCSDA/soca/issues/374 but I'll wait to close out the issue until the travisci develop cron runs overnight after merging this PR.

Modified the tagging script so that the `RECURSIVE` keyword is not removed for mom6

## Testing

This stuff has been difficult to test, since it really needs to run travisci cron on develop to make sure it's working (which I obviously can't do until it's merged!). I did make a small change in another branch to force travisci to run (https://travis-ci.com/github/JCSDA/soca/builds/173051028), updating the `bugfix/release_travisci_test` branch as if it were the `release/stable-nightly`, and it does appear to be working correctly now https://github.com/JCSDA/soca/compare/bugfix/release_travisci_test