### PR TITLE
working with ENABLE_OCEAN_BGC=OFF

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,11 +92,12 @@ list( APPEND soca_model_param
 list( APPEND soca_model_param_copy
   Data/72x35x25/MOM_input
   Data/72x35x25/MOM_input_small
-  Data/72x35x25/MOM_override
+  Data/72x35x25/MOM_override_bgc
 )
 
 list( APPEND soca_model_namelist
   Data/72x35x25/input.nml
+  Data/72x35x25/input_bgc.nml
   Data/72x35x25/input_small.nml
 )
 

--- a/test/Data/72x35x25/MOM_override
+++ b/test/Data/72x35x25/MOM_override
@@ -1,4 +1,0 @@
-! Blank file in which we can put "overrides" for parameters
-USE_generic_tracer = True
-!----------------------------------
-

--- a/test/Data/72x35x25/MOM_override_bgc
+++ b/test/Data/72x35x25/MOM_override_bgc
@@ -1,0 +1,5 @@
+! Blank file in which we can put "overrides" for parameters specific to
+! the biogeochemistry runs
+USE_generic_tracer = True
+!----------------------------------
+

--- a/test/Data/72x35x25/input_bgc.nml
+++ b/test/Data/72x35x25/input_bgc.nml
@@ -3,7 +3,8 @@
         input_filename = 'r'
         restart_input_dir = 'INPUT/',
         restart_output_dir = 'RESTART/',
-        parameter_filename = 'MOM_input' /
+        parameter_filename = 'MOM_input'
+                             'MOM_override_bgc' /
 
  &diag_manager_nml
  /
@@ -26,3 +27,18 @@
        clock_grain='MODULE'
        domains_stack_size = 2000000
        clock_flags='SYNC' /
+
+ &generic_tracer_nml
+       do_generic_tracer=.true.
+       do_generic_age=.false.
+       do_generic_COBALT=.false.
+       do_generic_BLING=.true.
+       do_generic_miniBLING=.false.
+       do_generic_TOPAZ=.false.
+       force_update_fluxes=.true. /
+
+ &generic_bling_nml
+      do_carbon=.false.
+      bury_caco3=.false.
+      bury_pop=.false.
+      co2_calc='mocsy' /

--- a/test/testinput/forecast_mom6_bgc.yml
+++ b/test/testinput/forecast_mom6_bgc.yml
@@ -2,7 +2,7 @@ resolution:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  mom6_input_nml: ./inputnml/input.nml
+  mom6_input_nml: ./inputnml/input_bgc.nml
 
 model:
   name: SOCA


### PR DESCRIPTION
## Description

"@guillaumevernieres > Couldn't we just append what's needed to `input.nml` and remove that file?" https://github.com/JCSDA/soca/pull/395#discussion_r446143729
Nope, turns out that was wrong.


SOCA is unable to run the tests if `ENABLE_OCEAN_BGC=OFF` because the mom6 config files assume generic tracers were turned on when compiling MOM6. This PR reverts to changes that @liuxiao37k had originally done in https://github.com/JCSDA/soca/pull/395.

- revert to separate `input_bgc.nml`
- rename `MOM_override` to `MOM_override_bgc`, in case we have other types of overrides in the future

## Testing

- tested on personal machine in intel19 & gcc, with `ENABLE_OCEAN_BGC` both on and off
- since TravisCI uses `ENABLE_OCEAN_BGC=ON` you'll have to test on your own machine. 