### PR TITLE
PseudoModel for forecast, hofx4d and 3dvarfgat

### DIFF
--- a/src/mains/3DVar.cc
+++ b/src/mains/3DVar.cc
@@ -15,10 +15,12 @@
 #include "ufo/instantiateObsFilterFactory.h"
 #include "oops/runs/Run.h"
 #include "oops/runs/Variational.h"
+#include "oops/generic/instantiateModelFactory.h"
 #include "saber/oops/instantiateLocalizationFactory.h"
 
 int main(int argc,  char ** argv) {
   oops::Run run(argc, argv);
+  oops::instantiateModelFactory<soca::Traits>();
   soca::instantiateBalanceOpFactory();
   ufo::instantiateObsFilterFactory<ufo::ObsTraits>();
   saber::instantiateLocalizationFactory<soca::Traits>();

--- a/src/mains/Forecast.cc
+++ b/src/mains/Forecast.cc
@@ -6,11 +6,13 @@
  */
 
 #include "soca/Traits.h"
+#include "oops/generic/instantiateModelFactory.h"
 #include "oops/runs/Forecast.h"
 #include "oops/runs/Run.h"
 
 int main(int argc,  char ** argv) {
   oops::Run run(argc, argv);
+  oops::instantiateModelFactory<soca::Traits>();
   oops::Forecast<soca::Traits> fc;
   return run.execute(fc);
 }

--- a/src/mains/HofX.cc
+++ b/src/mains/HofX.cc
@@ -11,6 +11,7 @@
 
 #include "soca/Traits.h"
 
+#include "oops/generic/instantiateModelFactory.h"
 #include "oops/runs/HofX.h"
 #include "oops/runs/Run.h"
 #include "ufo/instantiateObsFilterFactory.h"
@@ -18,6 +19,7 @@
 
 int main(int argc,  char ** argv) {
   oops::Run run(argc, argv);
+  oops::instantiateModelFactory<soca::Traits>();
   ufo::instantiateObsFilterFactory<ufo::ObsTraits>();
   oops::HofX<soca::Traits, ufo::ObsTraits> hofx;
   return run.execute(hofx);

--- a/src/soca/State/State.h
+++ b/src/soca/State/State.h
@@ -58,6 +58,9 @@ namespace soca {
       virtual ~State();
       State & operator=(const State &);
 
+      /// Needed by PseudoModel
+      void updateTime(const util::Duration & dt) {time_ += dt;}
+
       /// Rotations
       void rotate2north(const oops::Variables &, const oops::Variables &) const;
       void rotate2grid(const oops::Variables &, const oops::Variables &) const;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -401,7 +401,7 @@ endif()
 # Test PseudoModel forecast
 soca_add_test( NAME forecast_pseudo
                EXE  soca_forecast.x
-             TEST_DEPENDS test_soca_forecast_mom6 )
+               TEST_DEPENDS test_soca_forecast_mom6 )
 
 # Initialize static error covariance model defined in soca, used for 3DVAR
 soca_add_test( NAME static_socaerror_init
@@ -633,7 +633,7 @@ soca_add_test( NAME 3dvarfgat
 soca_add_test( NAME 3dvarfgat_pseudo
                EXE  soca_3dvar.x
                TOL  1e-6 0
-               NOTRAPFPE               
+               NOTRAPFPE
                TEST_DEPENDS test_soca_static_socaerror_init )
 
 soca_add_test( NAME 3dhyb

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@ list( APPEND soca_test_input
   testinput/3dvar_godas.yml
   testinput/3dvar_soca.yml
   testinput/3dvarfgat.yml
+  testinput/3dvarfgat_pseudo.yml
   testinput/addincrement.yml
   testinput/checkpointmodel.yml
   testinput/convertstate.yml
@@ -19,6 +20,7 @@ list( APPEND soca_test_input
   testinput/forecast_identity_cice.yml
   testinput/forecast_mom6.yml
   testinput/forecast_mom6_bgc.yml
+  testinput/forecast_pseudo.yml
   testinput/geometry.yml
   testinput/geometry_iterator.yml
   testinput/geometryatm.yml
@@ -28,6 +30,7 @@ list( APPEND soca_test_input
   testinput/hofx_3d.yml
   testinput/hofx_3dcrtm.yml
   testinput/hofx_4d.yml
+  testinput/hofx_4d_pseudo.yml
   testinput/increment.yml
   testinput/letkf.yml
   testinput/lineargetvalues.yml
@@ -57,6 +60,7 @@ list( APPEND soca_test_ref
   testref/3dvar_godas.test
   testref/3dvar_soca.test
   testref/3dvarfgat.test
+  testref/3dvarfgat_pseudo.test
   testref/addincrement.test
   testref/checkpointmodel.test
   testref/convertstate.test
@@ -72,9 +76,11 @@ list( APPEND soca_test_ref
   testref/forecast_identity.test
   testref/forecast_mom6.test
   testref/forecast_mom6_bgc.test
+  testref/forecast_pseudo.test
   testref/hofx_3d.test
   testref/hofx_3dcrtm.test
   testref/hofx_4d.test
+  testref/hofx_4d_pseudo.test
   testref/letkf.test
   testref/makeobs.test
   testref/parameters_bump_cov_lct.test
@@ -390,6 +396,11 @@ soca_add_test( NAME forecast_mom6_bgc
                TEST_DEPENDS test_soca_gridgen )
 endif()
 
+# Test PseudoModel forecast
+soca_add_test( NAME forecast_pseudo
+               EXE  soca_forecast.x
+             TEST_DEPENDS test_soca_forecast_mom6 )
+
 # Initialize static error covariance model defined in soca, used for 3DVAR
 soca_add_test( NAME static_socaerror_init
                EXE  soca_staticbinit.x
@@ -575,6 +586,10 @@ soca_add_test( NAME hofx_4d
                NOTRAPFPE
                TEST_DEPENDS test_soca_gridgen )
 
+soca_add_test( NAME hofx_4d_pseudo
+               EXE  soca_hofx.x
+               TEST_DEPENDS test_soca_forecast_mom6 )
+
 # TODO enshofx currently breaks compare.py
 # Re-enable the comparison once that's fixed
 soca_add_test( NAME enshofx
@@ -607,6 +622,12 @@ soca_add_test( NAME 3dvarfgat
                EXE  soca_3dvar.x
                TOL  1e-6 0
                NOTRAPFPE
+               TEST_DEPENDS test_soca_static_socaerror_init )
+
+soca_add_test( NAME 3dvarfgat_pseudo
+               EXE  soca_3dvar.x
+               TOL  1e-6 0
+               NOTRAPFPE               
                TEST_DEPENDS test_soca_static_socaerror_init )
 
 soca_add_test( NAME 3dhyb

--- a/test/testinput/3dvarfgat_pseudo.yml
+++ b/test/testinput/3dvarfgat_pseudo.yml
@@ -1,0 +1,214 @@
+#
+#                               3DVAR (No FGAT)
+#
+#     <---------------------- window_length (6 hours) ---------------------->
+#
+# ---|-----------|-----------|-----------|-----------|-----------|-----------|
+#    |                                   |                                   |
+# window_begin: 2018-04-14T21:00:00Z     |                           2015-04-15T3:00:00Z
+#                                        |
+#                       bkg/ana/incr: 2018-04-15T00:00:00Z
+#
+#
+
+resolution:
+  num_ice_cat: 5
+  num_ice_lev: 4
+  num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
+
+model:
+  name: PseudoModel
+  tstep: PT1H
+  variables: &soca_vars [socn, tocn, ssh, hocn, uocn, vocn]
+  states:
+  - date: 2018-04-15T01:00:00Z
+    basename: ./Data/
+    ocn_filename: ocn.mom6.fc.2018-04-15T00:00:00Z.PT1H.nc
+    read_from_file: 1
+  - date: 2018-04-15T02:00:00Z
+    basename: ./Data/
+    ocn_filename: ocn.mom6.fc.2018-04-15T00:00:00Z.PT2H.nc
+    read_from_file: 1
+  - date: 2018-04-15T03:00:00Z
+    basename: ./Data/
+    ocn_filename: ocn.mom6.fc.2018-04-15T00:00:00Z.PT3H.nc
+    read_from_file: 1
+  - date: 2018-04-15T04:00:00Z
+    basename: ./Data/
+    ocn_filename: ocn.mom6.fc.2018-04-15T00:00:00Z.PT4H.nc
+    read_from_file: 1
+  - date: 2018-04-15T05:00:00Z
+    basename: ./Data/
+    ocn_filename: ocn.mom6.fc.2018-04-15T00:00:00Z.PT5H.nc
+    read_from_file: 1
+  - date: 2018-04-15T06:00:00Z
+    basename: ./Data/
+    ocn_filename: ocn.mom6.fc.2018-04-15T00:00:00Z.PT6H.nc
+    read_from_file: 1
+
+# common filters used later on
+_: &land_mask
+  Filter: Domain Check
+  where:
+  - variable: {name: sea_area_fraction@GeoVaLs}
+    minvalue: 0.5
+
+cost_function:
+  cost_type: 4D-Var
+  window_begin: &date_begin 2018-04-15T00:00:00Z
+  window_length: PT6H
+  variables: *soca_vars
+  varchange: Identity
+  Jb:
+    Background:
+      state:
+      - read_from_file: 1
+        basename: ./INPUT/
+        ocn_filename: MOM.res.nc
+        date: &bkg_date 2018-04-15T00:00:00Z
+
+    Covariance:
+      covariance: SocaError
+      prefix: soca
+      datadir: ./bump
+      strategy: specific_univariate
+      load_nicas: 1
+      lsqrt: 1
+      mpicom: 2
+      date: *bkg_date
+      variables: *soca_vars
+
+      variable_changes:
+
+      - varchange: BkgErrFILT
+        ocean_depth_min: 1000 # [m]
+        rescale_bkgerr: 1.0
+        efold_z: 2500.0       # [m]
+        inputVariables:
+          variables: *soca_vars
+        outputVariables:
+          variables: *soca_vars
+
+      - varchange: VertConvSOCA
+        Lz_min: 10.0
+        Lz_mld: 1
+        Lz_mld_max: 500
+        scale_layer_thick: 1.5
+        inputVariables:
+          variables: *soca_vars
+        outputVariables:
+          variables: *soca_vars
+
+      - varchange: BalanceSOCA
+        dsdtmax: 0.1
+        dsdzmin: 3.0e-6
+        dtdzmin: 1.0e-6
+        nlayers: 10
+        inputVariables:
+          variables: *soca_vars
+        outputVariables:
+          variables: *soca_vars
+
+  Jo:
+    ObsTypes:
+
+    - ObsSpace:
+        name: SeaSurfaceTemp
+        ObsDataOut: {obsfile: ./Data/sst.out.nc}
+        ObsDataIn:  {obsfile: ./Data/sst.nc}
+        simulate:   {variables: [ sea_surface_temperature ]}
+      ObsOperator:
+        name: Identity
+      Covariance:
+        covariance: diagonal
+      ObsFilters:
+      - *land_mask
+      - Filter: Thinning
+        amount: 0.1
+        random_seed: 0
+
+    - ObsSpace:
+        name: SeaSurfaceSalinity
+        ObsDataOut: {obsfile: ./Data/sss.out.nc}
+        ObsDataIn:  {obsfile: ./Data/sss.nc}
+        simulate:   {variables: [ sea_surface_salinity ]}
+      ObsOperator:
+        name: Identity
+      Covariance:
+        covariance: diagonal
+      ObsFilters:
+      - *land_mask
+      - Filter: Domain Check
+        where:
+        - variable: {name: sea_surface_temperature@GeoVaLs}
+          minvalue: 15
+
+    - ObsSpace:
+        name: ADT
+        ObsDataOut: {obsfile: ./Data/adt.out.nc}
+        ObsDataIn:  {obsfile: ./Data/adt.nc}
+        simulate:   {variables: [ obs_absolute_dynamic_topography ]}
+      ObsOperator:
+        name: ADT
+      Covariance:
+        covariance: diagonal
+      ObsFilters:
+      - *land_mask
+
+    - ObsSpace:
+        name: InsituTemperature
+        ObsDataOut: {obsfile: ./Data/prof.T.out.nc}
+        ObsDataIn:  {obsfile: ./Data/prof.nc}
+        simulate:   {variables: [ sea_water_temperature ]}
+      ObsOperator:
+        name: InsituTemperature
+      Covariance:
+        covariance: diagonal
+      ObsFilters:
+      - *land_mask
+      - Filter: Background Check
+        threshold: 5
+
+    - ObsSpace:
+        name: InsituSalinity
+        ObsDataOut: {obsfile: ./Data/prof.S.out.nc}
+        ObsDataIn:  {obsfile: ./Data/prof.nc}
+        simulate:   {variables: [ sea_water_salinity ]}
+      ObsOperator:
+        name: MarineVertInterp
+      Covariance:
+        covariance: diagonal
+      ObsFilters:
+      - *land_mask
+
+variational:
+  iteration:
+  - resolution:
+      num_ice_cat: 5
+      num_ice_lev: 4
+      num_sno_lev: 1
+      mom6_input_nml: ./inputnml/input.nml
+    linearmodel:
+      varchange: Identity
+      version: IdTLM
+      tstep: PT1H
+      variables: *soca_vars
+    ninner: 1
+    gradient_norm_reduction: 1e-15
+    test: 'on'
+    prints:
+    diagnostics:
+      departures: ombg
+
+minimizer:
+  algorithm: RPCG
+
+output:
+  datadir: Data
+  exp: 3dvarfgat_pseudo
+  type: an
+
+final:
+  diagnostics:
+    departures: oman

--- a/test/testinput/forecast_mom6.yml
+++ b/test/testinput/forecast_mom6.yml
@@ -21,7 +21,7 @@ initial:
 forecast_length: PT6H
 
 output:
-  frequency: PT6H
+  frequency: PT1H
   datadir: Data
   exp: mom6
   date: *date

--- a/test/testinput/forecast_pseudo.yml
+++ b/test/testinput/forecast_pseudo.yml
@@ -1,0 +1,50 @@
+resolution:
+  num_ice_cat: 5
+  num_ice_lev: 4
+  num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
+
+model:
+  name: PseudoModel
+  tstep: PT1H
+  variables: [socn, tocn, ssh, hocn, uocn, vocn]
+  states:
+  - date: 2018-04-15T01:00:00Z
+    basename: ./Data/
+    ocn_filename: ocn.mom6.fc.2018-04-15T00:00:00Z.PT1H.nc
+    read_from_file: 1
+  - date: 2018-04-15T02:00:00Z
+    basename: ./Data/
+    ocn_filename: ocn.mom6.fc.2018-04-15T00:00:00Z.PT2H.nc
+    read_from_file: 1
+  - date: 2018-04-15T03:00:00Z
+    basename: ./Data/
+    ocn_filename: ocn.mom6.fc.2018-04-15T00:00:00Z.PT3H.nc
+    read_from_file: 1
+  - date: 2018-04-15T04:00:00Z
+    basename: ./Data/
+    ocn_filename: ocn.mom6.fc.2018-04-15T00:00:00Z.PT4H.nc
+    read_from_file: 1
+  - date: 2018-04-15T05:00:00Z
+    basename: ./Data/
+    ocn_filename: ocn.mom6.fc.2018-04-15T00:00:00Z.PT5H.nc
+    read_from_file: 1
+  - date: 2018-04-15T06:00:00Z
+    basename: ./Data/
+    ocn_filename: ocn.mom6.fc.2018-04-15T00:00:00Z.PT6H.nc
+    read_from_file: 1
+
+initial:
+  read_from_file: 1
+  date: &date 2018-04-15T00:00:00Z
+  basename: ./INPUT/
+  ocn_filename: MOM.res.nc
+
+forecast_length: PT6H
+
+output:
+  frequency: PT6H
+  datadir: Data
+  exp: pseudomodel
+  date: *date
+  type: fc

--- a/test/testinput/hofx_4d_pseudo.yml
+++ b/test/testinput/hofx_4d_pseudo.yml
@@ -1,0 +1,91 @@
+Geometry:
+  num_ice_cat: 5
+  num_ice_lev: 4
+  num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
+
+Model:
+  name: PseudoModel
+  tstep: PT1H
+  variables: [socn, tocn, ssh, hocn, uocn, vocn]
+  states:
+  - date: 2018-04-15T01:00:00Z
+    basename: ./Data/
+    ocn_filename: ocn.mom6.fc.2018-04-15T00:00:00Z.PT1H.nc
+    read_from_file: 1
+  - date: 2018-04-15T02:00:00Z
+    basename: ./Data/
+    ocn_filename: ocn.mom6.fc.2018-04-15T00:00:00Z.PT2H.nc
+    read_from_file: 1
+  - date: 2018-04-15T03:00:00Z
+    basename: ./Data/
+    ocn_filename: ocn.mom6.fc.2018-04-15T00:00:00Z.PT3H.nc
+    read_from_file: 1
+
+Initial Condition:
+  read_from_file: 1
+  date: 2018-04-15T00:00:00Z
+  basename: ./INPUT/
+  ocn_filename: MOM.res.nc
+
+Assimilation Window:
+  window_begin: 2018-04-15T00:00:00Z
+  window_length: PT3H
+
+Observations:
+  ObsTypes:
+
+  - ObsSpace:
+      name: SeaSurfaceTemp
+      ObsDataOut: {obsfile: ./Data/sst.out.nc}
+      ObsDataIn:  {obsfile: ./Data/sst.nc}
+      simulate:
+        variables: [sea_surface_temperature]
+    ObsOperator:
+      name: Identity
+    Covariance:
+      covariance: diagonal
+
+  - ObsSpace:
+      name: SeaSurfaceSalinity
+      ObsDataOut: {obsfile: ./Data/sss.out.nc}
+      ObsDataIn:  {obsfile: ./Data/sss.nc}
+      simulate:
+        variables: [sea_surface_salinity]
+    ObsOperator:
+      name: Identity
+    Covariance:
+      covariance: diagonal
+
+  - ObsSpace:
+      name: ADT
+      ObsDataOut: {obsfile: ./Data/adt.out.nc}
+      ObsDataIn:  {obsfile: ./Data/adt.nc}
+      simulate:
+        variables: [obs_absolute_dynamic_topography]
+    ObsOperator:
+      name: ADT
+    Covariance:
+      covariance: diagonal
+
+  - ObsSpace:
+      name: InsituTemperature
+      ObsDataOut: {obsfile: ./Data/prof.T.out.nc}
+      ObsDataIn:  {obsfile: ./Data/prof.nc}
+      simulate:
+        variables: [sea_water_temperature]
+    ObsOperator:
+      name: InsituTemperature
+    Covariance:
+      covariance: diagonal
+
+  - ObsSpace:
+      name: InsituSalinity
+      ObsDataOut: {obsfile: ./Data/prof.S.out.nc}
+      ObsDataIn:  {obsfile: ./Data/prof.nc}
+      simulate:
+        variables: [sea_water_salinity]
+    ObsOperator:
+      name: MarineVertInterp
+    Covariance:
+      covariance: diagonal

--- a/test/testref/3dvarfgat_pseudo.test
+++ b/test/testref/3dvarfgat_pseudo.test
@@ -1,0 +1,23 @@
+Test     : CostJb   : Nonlinear Jb = 0
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 306.385, nobs = 43, Jo/n = 7.12523, err = 0.385815
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.48256, nobs = 17, Jo/n = 0.146033, err = 1
+Test     : CostJo   : Nonlinear Jo(ADT) = 86.7406, nobs = 29, Jo/n = 2.99106, err = 0.1
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 41.1264, nobs = 31, Jo/n = 1.32666, err = 0.90894
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.7824, nobs = 33, Jo/n = 0.447953, err = 0.61043
+Test     : CostFunction: Nonlinear J = 451.517
+Test     : RPCGMinimizer: reduction in residual norm = 0.88409
+Test     : CostFunction::addIncrement: Analysis: 
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.553982
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.016058
+Test     :     ssh   min=   -1.999609   max=    0.869096   mean=   -0.300312
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :    uocn   min=   -0.857170   max=    0.700086   mean=   -0.000019
+Test     :    vocn   min=   -0.766110   max=    1.437886   mean=    0.002044
+Test     : CostJb   : Nonlinear Jb = 177.641033
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 303.787825, nobs = 43, Jo/n = 7.064833, err = 0.385815
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.482557, nobs = 17, Jo/n = 0.146033, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 51.705862, nobs = 29, Jo/n = 1.782961, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 41.126443, nobs = 31, Jo/n = 1.326659, err = 0.908940
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.782435, nobs = 33, Jo/n = 0.447953, err = 0.610430
+Test     : CostFunction: Nonlinear J = 591.526155

--- a/test/testref/forecast_pseudo.test
+++ b/test/testref/forecast_pseudo.test
@@ -1,0 +1,16 @@
+Test     : Initial state: 
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000241
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002019
+Test     : Final state: 
+Test     :   Valid time: 2018-04-15T06:00:00Z
+Test     :    socn   min=   10.718537   max=   40.441636   mean=   34.545189
+Test     :    tocn   min=   -1.888294   max=   31.764659   mean=    6.018082
+Test     :     ssh   min=   -1.905847   max=    0.908715   mean=   -0.276541
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628049
+Test     :    uocn   min=   -0.837073   max=    0.678109   mean=    0.000408
+Test     :    vocn   min=   -0.894579   max=    0.944747   mean=    0.000457

--- a/test/testref/hofx_4d_pseudo.test
+++ b/test/testref/hofx_4d_pseudo.test
@@ -1,0 +1,23 @@
+Test     : Initial state: 
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000241
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002019
+Test     : Final state: 
+Test     :   Valid time: 2018-04-15T03:00:00Z
+Test     :    socn   min=   10.719748   max=   40.441647   mean=   34.544471
+Test     :    tocn   min=   -1.888350   max=   31.732789   mean=    6.017631
+Test     :     ssh   min=   -1.908126   max=    0.908462   mean=   -0.276582
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628088
+Test     :    uocn   min=   -0.847397   max=    0.688618   mean=    0.000122
+Test     :    vocn   min=   -0.834614   max=    1.365686   mean=    0.001625
+Test     : H(x): 
+Test     : SeaSurfaceTemp nobs= 21 Min=5.767587, Max=29.793238, RMS=26.104151
+Test     : SeaSurfaceSalinity nobs= 9 Min=33.356994, Max=35.661500, RMS=34.492936
+Test     : ADT nobs= 14 Min=-0.712938, Max=1.495788, RMS=1.001840
+Test     : InsituTemperature nobs= 10 Min=8.008760, Max=30.370147, RMS=23.734703
+Test     : InsituSalinity nobs= 10 Min=34.156561, Max=35.701557, RMS=35.026666
+Test     : End H(x)


### PR DESCRIPTION
## Description
Adds the possibility to use the generic oops PseudoModel for forecast, hofx and var. 

### Issue(s) addressed
closes #404 

## Testing

How were these changes tested? **pseudo model implemented in the forecast, hofx and var applications**
What compilers / HPCs was it tested with? **gnu**
Are the changes covered by ctests? **yes**

Possible remaining issue: Not tested with sea-ice. I couldn't figure out how to read the sea-ice files dumped during a soca forecast, these would not be used with the pseudo model anyways (the sea-ice and ocean restarts from mom6/sis2/cice would instead). I could add a test with sea-ice, advancing the pseudo model but pointing to the same restart, as an illustration ... or not.

