### PR TITLE
Update to the  ensemble variance test

### DIFF
--- a/test/testinput/ensvariance.yml
+++ b/test/testinput/ensvariance.yml
@@ -45,3 +45,13 @@ Ensemble:
   - <<: *_file
     ocn_filename: ocn.pert.ens.5.2018-04-15T00:00:00Z.PT6H.nc
     ice_filename: ice.pert.ens.5.2018-04-15T00:00:00Z.PT6H.nc
+  variable_changes:
+  - varchange: BalanceSOCA
+    dsdtmax: 1.0
+    dsdzmin: 3.0e-3
+    dtdzmin: 1.0e-3
+    nlayers: 10
+    inputVariables:
+      variables: *soca_vars
+    outputVariables:
+      variables: *soca_vars

--- a/test/testref/ensvariance.test
+++ b/test/testref/ensvariance.test
@@ -1,8 +1,8 @@
 Test     : Variance: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    0.001611   mean=    0.000008
+Test     :   cicen   min=    0.000000   max=    0.001458   mean=    0.000009
 Test     :   hicen   min=    0.000000   max=    0.000002   mean=    0.000000
-Test     :    socn   min=    0.000000   max=    2.705720   mean=    0.075802
+Test     :    socn   min=    0.000000   max=    2.705720   mean=    0.075754
 Test     :    tocn   min=    0.000000   max=    6.200128   mean=    0.027768
-Test     :     ssh   min=    0.000000   max=    0.094411   mean=    0.001235
+Test     :     ssh   min=    0.000000   max=    0.302273   mean=    0.005567
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000


### PR DESCRIPTION
## Description
I just noticed that one of the yaml file I use to compute the the variance with the inverse of the balance operator was in fact not applying the variable change ... Not a huge deal since I'm probably the only one playing with that stuff now, but, since the yaml file in the tests are used as a base to build from, adding an example of change of variable is probably a good idea. 


### Issue(s) addressed
closes #408 


## Testing

How were these changes tested? **added to the ensemble variance test**
What compilers / HPCs was it tested with? **gnu**
Are the changes covered by ctests? **yes**



## Dependencies
None
