### PR TITLE
fix return of test/executables

### DIFF
--- a/test/executables/TestGetValues.cc
+++ b/test/executables/TestGetValues.cc
@@ -13,6 +13,5 @@
 int main(int argc,  char ** argv) {
   oops::Run run(argc, argv);
   test::GetValues<soca::Traits, ufo::ObsTraits> tests;
-  run.execute(tests);
-  return 0;
+  return run.execute(tests);
 }

--- a/test/executables/TestLinearGetValues.cc
+++ b/test/executables/TestLinearGetValues.cc
@@ -13,6 +13,5 @@
 int main(int argc,  char ** argv) {
   oops::Run run(argc, argv);
   test::LinearGetValues<soca::Traits, ufo::ObsTraits> tests;
-  run.execute(tests);
-  return 0;
+  return run.execute(tests);
 }


### PR DESCRIPTION
## Description

two of the test executables were returning 0 instead of the correct return code from `run.execute()`... oops. This fixes that.
