### PR TITLE
speedup kdtree creation used by godas bgerr

### DIFF
--- a/src/soca/Utils/soca_utils.F90
+++ b/src/soca/Utils/soca_utils.F90
@@ -187,6 +187,7 @@ subroutine soca_remap_idw(lon_src, lat_src, data_src, lon_dst, lat_dst, data_dst
   n_src = size(lon_src)
   ageometry = atlas_geometry("UnitSphere")
   kd = atlas_indexkdtree(ageometry)
+  call kd%reserve(n_src)
   call kd%build(n_src, lon_src, lat_src)
 
   ! remap


### PR DESCRIPTION
## Description

when the kdtree used by soca was switched to the atlas one, any test that used the godas bgerr went a lot slower (though we didn't notice it at the time)

Looking back over the TravisCI logs:
Before switch to atlas:
```
28/48 Test #28: test_soca_varchange_bkgerrgodas .....   Passed    4.00 sec
````

and after:
```
32/55 Test #32: test_soca_varchange_bkgerrgodas .....   Passed   39.02 sec
```

This speeds up the kdtree build by reserving the correct amount of space beforehand

