### PR TITLE
use crtm_COEFFICIENT_DIR to link crtm coeff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
     - BUILD_OPT_mom6="-DENABLE_OCEAN_BGC=ON"
     - BUILD_OPT_oops="-DENABLE_QG_MODEL=OFF -DENABLE_LORENZ95_MODEL=OFF"
     - BUILD_OPT_ufo="-DLOCAL_PATH_TESTFILES_IODA=NONE"
-    - BUILD_OPT_soca="-DSOCA_TESTS_FORC_DEFAULT_TOL=ON -DCRTM_FIX_DIR=../../repo.src/crtm/fix -DENABLE_OCEAN_BGC=ON"
+    - BUILD_OPT_soca="-DSOCA_TESTS_FORC_DEFAULT_TOL=ON -DENABLE_OCEAN_BGC=ON"
     - MATCH_REPOS="saber oops ioda ioda-converters ufo mom6 soca soca-config"
     - LFS_REPOS="crtm"
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -197,17 +197,6 @@ endforeach(FILENAME)
 # Link CRTM coeff
 if( ${CRTM_FOUND} )
 
-  # determine where to look for coefficients
-  set( CRTM_FIX_DIR_DOCSTRING
-      "Path to the CRTM fix directory, needs to be set if CRTM was not built as part of this bundle.")
-  set( CRTM_FIX_DIR NOTFOUND CACHE PATH ${CRTM_FIX_DIR_DOCSTRING})
-  if( NOT CRTM_FIX_DIR AND EXISTS ${crtm_SOURCE_DIR}/fix)
-    set( CRTM_FIX_DIR ${crtm_SOURCE_DIR}/fix CACHE PATH ${CRTM_FIX_DIR_DOCSTRING} FORCE)
-  elseif( NOT CRTM_FIX_DIR )
-    message(FATAL_ERROR
-      "CRTM was not built as part of the bundle, CRTM_FIX_DIR must be set")
-  endif()
-
   # the coefficient files needed
   list( APPEND crtm_coef
     SpcCoeff/Little_Endian/gmi_gpm.SpcCoeff.bin
@@ -221,7 +210,7 @@ if( ${CRTM_FOUND} )
   foreach(FILENAME ${crtm_coef})
        get_filename_component(filename ${FILENAME} NAME )
        execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
-             ${CRTM_FIX_DIR}/${FILENAME}
+             ${crtm_COEFFICIENT_DIR}/${FILENAME}
              ${CMAKE_CURRENT_BINARY_DIR}/Data/${filename} )
   endforeach(FILENAME)
 endif()


### PR DESCRIPTION
## Description

`crtm_COEFFICIENT_DIR` can now be used to link crtm coefficients for testing. This has been used in UFO and tested when building inside and outside of the bundle. 

## Testing
I tested this branch using soca-bundle and everything passed on Cheyenne with gnu/openmpi. 

There are failures in the clang container when I used the bundle, Travis-CI method, and jedi-build-package for building. These issues are not caused by the changes in this PR. I will issue a separate PR for that. 