### PR TITLE
change oops/parallel/mpi/mpi.h

### DIFF
--- a/src/mains/CheckpointModel.h
+++ b/src/mains/CheckpointModel.h
@@ -18,7 +18,7 @@
 
 #include "eckit/config/LocalConfiguration.h"
 #include "oops/base/PostProcessor.h"
-#include "oops/parallel/mpi/mpi.h"
+#include "oops/mpi/mpi.h"
 #include "oops/runs/Application.h"
 #include "oops/util/DateTime.h"
 #include "oops/util/Duration.h"
@@ -28,7 +28,7 @@ namespace soca {
 
   class CheckpointModel : public oops::Application {
    public:
-    explicit CheckpointModel(const eckit::mpi::Comm & comm = oops::mpi::comm())
+    explicit CheckpointModel(const eckit::mpi::Comm & comm = oops::mpi::world())
       : Application(comm) {}
     static const std::string classname() {return "soca::CheckpointModel";}
 

--- a/src/mains/GridGen.h
+++ b/src/mains/GridGen.h
@@ -18,14 +18,14 @@
 #include "eckit/config/LocalConfiguration.h"
 #include "eckit/mpi/Comm.h"
 #include "oops/base/PostProcessor.h"
-#include "oops/parallel/mpi/mpi.h"
+#include "oops/mpi/mpi.h"
 #include "oops/runs/Application.h"
 
 namespace soca {
 
   class GridGen : public oops::Application {
    public:
-    explicit GridGen(const eckit::mpi::Comm & comm = oops::mpi::comm())
+    explicit GridGen(const eckit::mpi::Comm & comm = oops::mpi::world())
       : Application(comm) {}
     static const std::string classname() {return "soca::GridGen";}
 


### PR DESCRIPTION
## Description
 keeping up to date with https://github.com/JCSDA/oops/pull/830
Small change to mpi.h path effecting checkpoint and gridgen executables.

## Dependencies
testing requires oops/ufo/ioda/saber branches of the same name

- waiting on https://github.com/JCSDA/oops/pull/830


