### PR TITLE
remove unneeded model/linmodel in 3dvars

### DIFF
--- a/test/testinput/3dhyb.yml
+++ b/test/testinput/3dhyb.yml
@@ -10,12 +10,6 @@ cost function:
     num_sno_lev: 1
     mom6_input_nml: ./inputnml/input.nml
 
-  model:
-    name: SOCA
-    tstep: PT1H
-    advance_mom6: 0
-    model variables: *soca_vars
-
   background:
     read_from_file: 1
     basename: ./INPUT/
@@ -151,11 +145,6 @@ variational:
       num_ice_lev: 4
       num_sno_lev: 1
       mom6_input_nml: ./inputnml/input.nml
-    linear model:
-      variable change: Identity
-      name: IdTLM
-      tstep: PT1H
-      lm variables: *soca_vars
     ninner: 1
     gradient norm reduction: 1e-15
     test: on

--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -20,12 +20,6 @@ cost function:
     u: [uocn]
     v: [vocn]
 
-  model:
-    name: SOCA
-    tstep: PT1H
-    advance_mom6: 0
-    model variables: *soca_vars
-
   background:
     read_from_file: 1
     basename: ./INPUT/
@@ -195,11 +189,6 @@ variational:
       num_ice_lev: 4
       num_sno_lev: 1
       mom6_input_nml: ./inputnml/input.nml
-    linear model:
-      variable change: Identity
-      name: IdTLM
-      tstep: PT1H
-      lm variables: *soca_vars
     ninner: 5
     gradient norm reduction: 1e-15
     test: on

--- a/test/testinput/3dvar_soca.yml
+++ b/test/testinput/3dvar_soca.yml
@@ -16,12 +16,6 @@ cost function:
     num_sno_lev: 1
     mom6_input_nml: ./inputnml/input.nml
 
-  model:
-    name: SOCA
-    tstep: PT1H
-    advance_mom6: 0
-    model variables: *soca_vars
-
   background:
     read_from_file: 1
     basename: ./INPUT/
@@ -206,11 +200,6 @@ variational:
       num_ice_lev: 4
       num_sno_lev: 1
       mom6_input_nml: ./inputnml/input.nml
-    linear model:
-      variable change: Identity
-      name: IdTLM
-      tstep: PT1H
-      lm variables: *soca_vars
     ninner: 5
     gradient norm reduction: 1e-15
     test: on


### PR DESCRIPTION
## Description

A past oops PR removed the requirement for the Model and LinearModel specification if using 3dvar mode. This removes those sections of the yaml for the 3dvar (non-fgat) tests

### Issue(s) addressed

- closes https://github.com/JCSDA/soca/issues/419

