### PR TITLE
Add valgrind tests

### DIFF
--- a/.github/travisci/build.sh
+++ b/.github/travisci/build.sh
@@ -72,8 +72,16 @@ cd $build_dir
 build_opt_var=BUILD_OPT_${MAIN_REPO/-/_}
 build_opt=${!build_opt_var}
 
+# valgrind and gprof are mutually exclusive
+if [[ "$ENABLE_VALGRIND" == "ON"]]; then
+    $build_opt="$build_opt -DSOCA_TESTS_VALGRIND=ON"
+else
+    $build_opt="$build_opt -DENABLE_GPROF=ON"
+fi
+
+
 time ecbuild $src_dir -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-       -DCMAKE_BUILD_TYPE=${MAIN_BUILD_TYPE} -DENABLE_GPROF=ON $build_opt
+       -DCMAKE_BUILD_TYPE=${MAIN_BUILD_TYPE} $build_opt
 time make -j4
 
 

--- a/.github/travisci/build.sh
+++ b/.github/travisci/build.sh
@@ -73,7 +73,7 @@ build_opt_var=BUILD_OPT_${MAIN_REPO/-/_}
 build_opt=${!build_opt_var}
 
 # valgrind and gprof are mutually exclusive
-if [[ "$ENABLE_VALGRIND" == "ON"]]; then
+if [[ "$ENABLE_VALGRIND" == "ON" ]]; then
     $build_opt="$build_opt -DSOCA_TESTS_VALGRIND=ON"
 else
     $build_opt="$build_opt -DENABLE_GPROF=ON"

--- a/.github/travisci/build.sh
+++ b/.github/travisci/build.sh
@@ -74,9 +74,9 @@ build_opt=${!build_opt_var}
 
 # valgrind and gprof are mutually exclusive
 if [[ "$ENABLE_VALGRIND" == "ON" ]]; then
-    $build_opt="$build_opt -DSOCA_TESTS_VALGRIND=ON"
+    build_opt="$build_opt -DSOCA_TESTS_VALGRIND=ON"
 else
-    $build_opt="$build_opt -DENABLE_GPROF=ON"
+    build_opt="$build_opt -DENABLE_GPROF=ON"
 fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ env:
     - BUILD_OPT_soca="-DSOCA_TESTS_FORC_DEFAULT_TOL=ON -DENABLE_OCEAN_BGC=ON"
     - MATCH_REPOS="saber oops ioda ioda-converters ufo mom6 soca soca-config"
     - LFS_REPOS="crtm"
+    # ENABLE_VALGRIND="ON"
 
     # secure token used to push changes to GitHub (user: travissluka)
     - secure: phYDV8BnMVQMhKbuyfpA0cUvelL3Jn9GrMunbAQAa4Hw6OInALu0BSoPAm5xd+lPAsVkhy3BwHlRvjqGYmhDr3NFuxUbZ/l1CcSOJZmV5Rp+5CY5nk0scQ9asuRSzt6jHBIaj9ncOyTWc7B3H6Vp88z6dBDgzeXWMaLy5A7u3fkTVI3dYAmvPAEd9wRp4nI6ij2lnTELIziTYZ07nrdIzYfAc6sqvPXhLkZfxYMkfDAbHHWZt+kGoJGPFfsjX1K7cgj32Ro+lm3Vl0u732QRCw3nUefhZrz3PkkGeX1U+GjQsz8liEgBqKng4ZxocepPsv5gwZj/frMCCtcXj59Pia5pmHy6vzdq4XCp/WpYwbbMEF9y9qVL35s9On9JnU20DEOV4r5c9rmJd8gbpsfK1reT8KOD5zJe9YBHRRXajweq23TFJPRyHVHlnSF8OtybOVG6OMLba9vvPTveQuaDIyc3kur5QtbM0HVv3uplef14m1frQYqji9I99h/pI5WcueRpcxARwagL1tnl3cfK4LyI3QWXidetDduE3MJQNfsKADlKKBVw9W2JyzNFCNj0J7x8r5SwObRX7Kj9YZfIPJGVt5rDc0OZm9wCt/BEZclTLyf4qbFibX/0glPiFoqhuYP/ZXAbQdYWI+si68gxcql33+PMkmbuhehA8qNZicE=
@@ -69,7 +70,8 @@ before_install:
     export BRANCH=$( [[ "$TRAVIS_PULL_REQUEST" == "false" ]] && \
                      echo $TRAVIS_BRANCH || echo $TRAVIS_PULL_REQUEST_BRANCH )
     export_vars="-e REPO_CACHE=/repo.cache -e LIB_REPOS -e LIB_BUILD_TYPE
-                 -e MAIN_REPO -e MAIN_BUILD_TYPE -e CCACHE_DIR=/ccache -e BUILD_OPT"
+                 -e MAIN_REPO -e MAIN_BUILD_TYPE -e CCACHE_DIR=/ccache -e BUILD_OPT
+                 -e ENABLE_VALGRIND"
     for v in $(env | grep BUILD_OPT_ | cut -d'=' -f 1); do
       export_vars="$export_vars -e $v"
     done

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -246,6 +246,12 @@ set( SOCA_TESTS_FORC_TRAPFPE OFF CACHE BOOL
 set( SOCA_TESTS_VALGRIND OFF CACHE BOOL
   "If true, some tests are run under valgrind")
 
+
+if ( SOCA_TESTS_VALGRIND )
+  find_file(VALGRIND_OPENMPI_SUP openmpi-valgrind.supp HINTS $ENV{MPI_ROOT}/share/openmpi/)
+endif()
+
+
 #-------------------------------------------------------------------------------
 # The following is a wrapper to simplify the generation of tests.
 # There are two types of tests:
@@ -356,6 +362,7 @@ function(soca_add_test)
                       MPI ${MPI}
                       COMMAND valgrind
                       ARGS -q --error-exitcode=42
+                           --suppressions=${VALGRIND_OPENMPI_SUP}
                            --suppressions=${CMAKE_CURRENT_SOURCE_DIR}/valgrind.sup
                            --gen-suppressions=all
                            ${EXE} ${CONFIG_FILE}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -247,11 +247,6 @@ set( SOCA_TESTS_VALGRIND OFF CACHE BOOL
   "If true, some tests are run under valgrind")
 
 
-if ( SOCA_TESTS_VALGRIND )
-  find_file(VALGRIND_OPENMPI_SUP openmpi-valgrind.supp HINTS $ENV{MPI_ROOT}/share/openmpi/)
-endif()
-
-
 #-------------------------------------------------------------------------------
 # The following is a wrapper to simplify the generation of tests.
 # There are two types of tests:
@@ -362,7 +357,6 @@ function(soca_add_test)
                       MPI ${MPI}
                       COMMAND valgrind
                       ARGS -q --error-exitcode=42
-                           --suppressions=${VALGRIND_OPENMPI_SUP}
                            --suppressions=${CMAKE_CURRENT_SOURCE_DIR}/valgrind.sup
                            --gen-suppressions=all
                            ${EXE} ${CONFIG_FILE}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -243,6 +243,8 @@ set( SOCA_TESTS_FORC_TRAPFPE OFF CACHE BOOL
   "If true, the specified per-test trapping on/off flag is ignored\
   and is forced to ON for all tests" )
 
+set( SOCA_TESTS_VALGRIND OFF CACHE BOOL
+  "If true, some tests are run under valgrind")
 
 #-------------------------------------------------------------------------------
 # The following is a wrapper to simplify the generation of tests.
@@ -271,7 +273,7 @@ set( SOCA_TESTS_FORC_TRAPFPE OFF CACHE BOOL
 function(soca_add_test)
   # parse the passed arguments
   set(prefix     ARG)
-  set(novals     NOCOMPARE NOTRAPFPE)
+  set(novals     NOCOMPARE NOTRAPFPE NOVALGRIND)
   set(singlevals NAME EXE SRC CFG MPI)
   set(multivals  TEST_DEPENDS TOL)
   cmake_parse_arguments(${prefix}
@@ -288,6 +290,10 @@ function(soca_add_test)
     set ( TRAPFPE_ENV "OOPS_TRAPFPE=0")
   else()
     set ( TRAPFPE_ENV "OOPS_TRAPFPE=1")
+  endif()
+
+  if ( NOT SOCA_TESTS_VALGRIND )
+    set ( ARG_NOVALGRIND TRUE)
   endif()
 
   # determine the default config file name
@@ -313,7 +319,7 @@ function(soca_add_test)
                       MPI     ${MPI}
                       ENVIRONMENT ${TRAPFPE_ENV}
                       TEST_DEPENDS ${ARG_TEST_DEPENDS})
-    set ( ARG_NOCOMPARE TRUE)
+    set( EXE ./test_soca_${ARG_NAME})
 
   else()
     LIST(GET ARG_TOL 0 TOL_F)
@@ -340,6 +346,21 @@ function(soca_add_test)
                               SKIP_COMPARE=${ARG_NOCOMPARE}
                       DEPENDS ${ARG_EXE}
                       TEST_DEPENDS ${ARG_TEST_DEPENDS})
+    set( EXE ${CMAKE_BINARY_DIR}/bin/${ARG_EXE})
+
+  endif()
+
+  # optional valgrind tests
+  if ( NOT ARG_NOVALGRIND )
+    ecbuild_add_test( TARGET test_soca_${ARG_NAME}_valgrind
+                      MPI ${MPI}
+                      COMMAND valgrind
+                      ARGS -q --error-exitcode=42
+                           --suppressions=${CMAKE_CURRENT_SOURCE_DIR}/valgrind.sup
+                           --gen-suppressions=all
+                           ${EXE} ${CONFIG_FILE}
+                      TEST_DEPENDS test_soca_${ARG_NAME}
+                    )
   endif()
 endfunction()
 

--- a/test/valgrind.sup
+++ b/test/valgrind.sup
@@ -73,11 +73,10 @@
 # Netcdf /hdf5
 ################################################################################
 {
-   netcdf
+   H5
    Memcheck:Cond
    ...
-   fun:H5Fclose
-   fun:nc4_close_netcdf4_file
+   fun:H5*
 }
 {
    netcdf
@@ -87,24 +86,12 @@
    fun:write_attlist
    fun:nc4_rec_write_metadata
 }
-
 {
    H5
    Memcheck:Param
    pwrite64(buf)
-   fun:__libc_pwrite64
-   fun:pwrite
-   fun:H5FD_sec2_write
-   fun:H5FD_write
-   fun:H5F__accum_write
-   fun:H5PB_write
-   fun:H5F_block_write
-   fun:H5D__flush_sieve_buf
-   fun:H5D__contig_flush
-   fun:H5D__flush_real
-   fun:H5D__flush_all_cb
-   fun:H5I__iterate_cb
-   fun:H5SL_iterate
+   ...
+   fun:H5*
 }
 
 
@@ -188,42 +175,6 @@
 }
 
 ############################
-# bugs within prints
-{
-   oops_print
-   Memcheck:Cond
-   ...
-   fun:operator<<
-   fun:_ZN4oops13DualMinimizerIN4soca6TraitsEN3ufo9ObsTraitsEE10doMinimizeERKN5eckit13ConfigurationE
-   fun:minimize
-}
-{
-   oops_print
-   Memcheck:Param
-   write(buf)
-   ...
-   fun:operator<<
-   fun:_ZN4oops13DualMinimizerIN4soca6TraitsEN3ufo9ObsTraitsEE10doMinimizeERKN5eckit13ConfigurationE
-   fun:minimize
-}
-{
-   oops_print
-   Memcheck:Value8
-   ...
-   fun:operator<<
-   fun:_ZN4oops13DualMinimizerIN4soca6TraitsEN3ufo9ObsTraitsEE10doMinimizeERKN5eckit13ConfigurationE
-   fun:minimize
-}
-{
-   oops_print
-   Memcheck:Param
-   write(buf)
-   fun:write
-   ...
-   fun:operator<<
-   fun:_ZN4oops13DualMinimizerIN4soca6TraitsEN3ufo9ObsTraitsEE10doMinimizeERKN5eckit13ConfigurationE
-   fun:minimize
-}
 {
    oops_print
    Memcheck:Cond
@@ -238,6 +189,7 @@
    fun:operator<<
    fun:_ZN4oops12CostFunctionIN4soca6TraitsEN3ufo9ObsTraitsEE8evaluateERKNS_15ControlVariableIS2_S4_EERKN5eckit13ConfigurationENS_13PostProcessorINS_5StateIS2_EEEE
 }
+
 {
    oops_print
    Memcheck:Cond
@@ -252,6 +204,7 @@
    fun:operator<<
    fun:_ZNK4oops9ObsVectorIN3ufo9ObsTraitsEE5printERSo
 }
+
 {
    oops_print
    Memcheck:Cond
@@ -266,15 +219,7 @@
    fun:operator<<
    fun:_ZNK4oops6CostJoIN4soca6TraitsEN3ufo9ObsTraitsEE7printJoERKNS_10DeparturesIS4_EES9_
 }
-{
-   oops_print
-   Memcheck:Value8
-   ...
-   fun:operator<<
-   ...
-   fun:_ZN4oops6GMRESRINS_9IncrementIN4soca6TraitsEEENS_16HybridCovarianceIS3_EENS_14IdentityMatrixIS4_EEEEdRT_RKS9_RKT0_RKT1_id
-   fun:_ZNK4oops16HybridCovarianceIN4soca6TraitsEE17doInverseMultiplyERKNS_9IncrementIS2_EERS5_
-}
+
 
 
 ############################
@@ -332,6 +277,7 @@
    ...
    fun:_Destroy<std::shared_ptr<oops::ObsSpace<ufo::ObsTraits> > >
 }
+
 {
    <insert_a_suppression_name_here>
    Memcheck:Param
@@ -341,33 +287,53 @@
    fun:~unique_ptr
    fun:_ZN4ioda7ObsData10SaveToFileERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEm
 }
+
+# hybridcov inverse multiply
 {
    <insert_a_suppression_name_here>
    Memcheck:Cond
    ...
-   fun:_ZN4oops6GMRESRINS_9IncrementIN4soca6TraitsEEENS_16HybridCovarianceIS3_EENS_14IdentityMatrixIS4_EEEEdRT_RKS9_RKT0_RKT1_id
    fun:_ZNK4oops16HybridCovarianceIN4soca6TraitsEE17doInverseMultiplyERKNS_9IncrementIS2_EERS5_
 }
 {
+   oops
+   Memcheck:Value8
+   ...
+   fun:_ZNK4oops16HybridCovarianceIN4soca6TraitsEE17doInverseMultiplyERKNS_9IncrementIS2_EERS5_
+}
+
+# eckit Configuration
+{
    <insert_a_suppression_name_here>
    Memcheck:Cond
    ...
-   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
-   fun:_ZNSo9_M_insertIdEERSoT_
    fun:_ZN4oops13DualMinimizerIN4soca6TraitsEN3ufo9ObsTraitsEE10doMinimizeERKN5eckit13ConfigurationE
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Value8
    ...
-   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
-   fun:_ZNSo9_M_insertIdEERSoT_
    fun:_ZN4oops13DualMinimizerIN4soca6TraitsEN3ufo9ObsTraitsEE10doMinimizeERKN5eckit13ConfigurationE
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Param
+   write(buf)
+   ...
+   fun:_ZN4oops13DualMinimizerIN4soca6TraitsEN3ufo9ObsTraitsEE10doMinimizeERKN5eckit13ConfigurationE
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   ...
+   fun:_ZNK4oops11VariationalIN4soca6TraitsEN3ufo9ObsTraitsEE7executeERKN5eckit13ConfigurationE
 }
 
 ################################################################################
 # SOCA things that definitely should be fixed
 ################################################################################
+
+# soca state
 {
    <insert_a_suppression_name_here>
    Memcheck:Cond
@@ -385,6 +351,22 @@
    <insert_a_suppression_name_here>
    Memcheck:Cond
    ...
+   fun:operator<<
+   fun:_ZNK4soca5State5printERSo
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   ...
+   fun:operator<<
+   fun:_ZNK4soca5State5printERSo
+}
+
+# soca increment
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   ...
    fun:__soca_fields_mod_MOD_soca_fields_gpnorm
    fun:soca_increment_gpnorm_f90
 }
@@ -393,21 +375,13 @@
    Memcheck:Cond
    ...
    fun:operator<<
-   fun:_ZNK4soca5State5printERSo
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Cond
-   ...
-   fun:operator<<
    fun:_ZNK4soca9Increment5printERSo
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Value8
    ...
-   fun:operator<<
-   fun:_ZNK4soca5State5printERSo
+   fun:_ZNK4soca9Increment5printERSo
 }
 {
   <insert_a_suppression_name_here>
@@ -416,6 +390,8 @@
    fun:operator<<
    fun:_ZNK4soca9Increment5printERSo
 }
+
+# soca related UFOs
 {
    <insert_a_suppression_name_here>
    Memcheck:Cond

--- a/test/valgrind.sup
+++ b/test/valgrind.sup
@@ -51,6 +51,22 @@
    fun:PMPI_Wait
    fun:PMPI_WAIT
 }
+{
+   mpi
+   Memcheck:Param
+   writev(vector[...])
+   fun:writev
+   ...
+   fun:PMPI_Isend
+}
+{
+   mpi
+   Memcheck:Param
+   writev(vector[...])
+   fun:writev
+   ...
+   fun:PMPI_Alltoallv
+}
 
 
 ################################################################################
@@ -332,8 +348,22 @@
    fun:_ZN4oops6GMRESRINS_9IncrementIN4soca6TraitsEEENS_16HybridCovarianceIS3_EENS_14IdentityMatrixIS4_EEEEdRT_RKS9_RKT0_RKT1_id
    fun:_ZNK4oops16HybridCovarianceIN4soca6TraitsEE17doInverseMultiplyERKNS_9IncrementIS2_EERS5_
 }
-
-
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   ...
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:_ZN4oops13DualMinimizerIN4soca6TraitsEN3ufo9ObsTraitsEE10doMinimizeERKN5eckit13ConfigurationE
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   ...
+   fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE15_M_insert_floatIdEES3_S3_RSt8ios_baseccT_
+   fun:_ZNSo9_M_insertIdEERSoT_
+   fun:_ZN4oops13DualMinimizerIN4soca6TraitsEN3ufo9ObsTraitsEE10doMinimizeERKN5eckit13ConfigurationE
+}
 
 ################################################################################
 # SOCA things that definitely should be fixed

--- a/test/valgrind.sup
+++ b/test/valgrind.sup
@@ -72,6 +72,25 @@
    fun:nc4_rec_write_metadata
 }
 
+{
+   H5
+   Memcheck:Param
+   pwrite64(buf)
+   fun:__libc_pwrite64
+   fun:pwrite
+   fun:H5FD_sec2_write
+   fun:H5FD_write
+   fun:H5F__accum_write
+   fun:H5PB_write
+   fun:H5F_block_write
+   fun:H5D__flush_sieve_buf
+   fun:H5D__contig_flush
+   fun:H5D__flush_real
+   fun:H5D__flush_all_cb
+   fun:H5I__iterate_cb
+   fun:H5SL_iterate
+}
+
 
 ################################################################################
 # fms
@@ -99,11 +118,16 @@
    fms_io_exit
    Memcheck:Param
    write(buf)
-   fun:write
    ...
    fun:__fms_io_mod_MOD_fms_io_exit
 }
-
+{
+   fms
+   Memcheck:Param
+   write(buf)
+   ...
+   fun:__mpp_io_mod_MOD_write_record_default
+}
 
 ################################################################################
 # mom
@@ -152,6 +176,15 @@
 {
    oops_print
    Memcheck:Cond
+   ...
+   fun:operator<<
+   fun:_ZN4oops13DualMinimizerIN4soca6TraitsEN3ufo9ObsTraitsEE10doMinimizeERKN5eckit13ConfigurationE
+   fun:minimize
+}
+{
+   oops_print
+   Memcheck:Param
+   write(buf)
    ...
    fun:operator<<
    fun:_ZN4oops13DualMinimizerIN4soca6TraitsEN3ufo9ObsTraitsEE10doMinimizeERKN5eckit13ConfigurationE
@@ -322,8 +355,22 @@
    <insert_a_suppression_name_here>
    Memcheck:Cond
    ...
+   fun:__soca_fields_mod_MOD_soca_fields_gpnorm
+   fun:soca_increment_gpnorm_f90
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   ...
    fun:operator<<
    fun:_ZNK4soca5State5printERSo
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   ...
+   fun:operator<<
+   fun:_ZNK4soca9Increment5printERSo
 }
 {
    <insert_a_suppression_name_here>

--- a/test/valgrind.sup
+++ b/test/valgrind.sup
@@ -40,32 +40,7 @@
    Memcheck:Param
    writev(vector[...])
    fun:writev
-   fun:mca_btl_tcp_frag_send
-   fun:mca_btl_tcp_endpoint_send_handler
-   fun:event_persist_closure
-   fun:event_process_active_single_queue
-   fun:event_process_active
-   fun:opal_libevent2022_event_base_loop
-   fun:opal_progress
-   fun:ompi_request_default_wait
-   fun:PMPI_Wait
-   fun:PMPI_WAIT
-}
-{
-   mpi
-   Memcheck:Param
-   writev(vector[...])
-   fun:writev
-   ...
-   fun:PMPI_Isend
-}
-{
-   mpi
-   Memcheck:Param
-   writev(vector[...])
-   fun:writev
-   ...
-   fun:PMPI_Alltoallv
+   fun:PMPI_*
 }
 
 
@@ -73,18 +48,18 @@
 # Netcdf /hdf5
 ################################################################################
 {
-   H5
-   Memcheck:Cond
-   ...
-   fun:H5*
-}
-{
    netcdf
    Memcheck:Cond
    ...
    fun:put_att_grpa
    fun:write_attlist
    fun:nc4_rec_write_metadata
+}
+{
+   H5
+   Memcheck:Cond
+   ...
+   fun:H5*
 }
 {
    H5
@@ -182,14 +157,6 @@
    fun:operator<<
    fun:_ZNK4oops11CostJbTotalIN4soca6TraitsEN3ufo9ObsTraitsEE8evaluateERKNS_16ControlIncrementIS2_S4_EE
 }
-{
-   oops_print
-   Memcheck:Cond
-   ...
-   fun:operator<<
-   fun:_ZN4oops12CostFunctionIN4soca6TraitsEN3ufo9ObsTraitsEE8evaluateERKNS_15ControlVariableIS2_S4_EERKN5eckit13ConfigurationENS_13PostProcessorINS_5StateIS2_EEEE
-}
-
 {
    oops_print
    Memcheck:Cond
@@ -307,26 +274,20 @@
    <insert_a_suppression_name_here>
    Memcheck:Cond
    ...
-   fun:_ZN4oops13DualMinimizerIN4soca6TraitsEN3ufo9ObsTraitsEE10doMinimizeERKN5eckit13ConfigurationE
+   fun:*oops*eckit13Configuration*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Value8
    ...
-   fun:_ZN4oops13DualMinimizerIN4soca6TraitsEN3ufo9ObsTraitsEE10doMinimizeERKN5eckit13ConfigurationE
+   fun:*oops*eckit13Configuration*
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Param
    write(buf)
    ...
-   fun:_ZN4oops13DualMinimizerIN4soca6TraitsEN3ufo9ObsTraitsEE10doMinimizeERKN5eckit13ConfigurationE
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Cond
-   ...
-   fun:_ZNK4oops11VariationalIN4soca6TraitsEN3ufo9ObsTraitsEE7executeERKN5eckit13ConfigurationE
+   fun:*oops*eckit13Configuration*
 }
 
 ################################################################################

--- a/test/valgrind.sup
+++ b/test/valgrind.sup
@@ -1,3 +1,6 @@
+################################################################################
+# mpi
+################################################################################
 {
    mpi
    Memcheck:Param
@@ -11,21 +14,52 @@
    fun:start_thread
    fun:clone
 }
+{
+   mpi
+   Memcheck:Param
+   socketcall.sendto(msg)
+   fun:send
+   fun:mca_btl_tcp_send_blocking
+   ...
+   fun:opal_progress
+}
+{
+   mpi
+   Memcheck:Param
+   write(buf)
+   fun:write
+   fun:sem_open
+   fun:mca_sharedfp_sm_file_open
+   fun:mca_common_ompio_file_open
+   fun:mca_io_ompio_file_open
+   fun:mca_io_base_file_select
+   fun:ompi_file_open
+}
+{
+   mpi
+   Memcheck:Param
+   writev(vector[...])
+   fun:writev
+   fun:mca_btl_tcp_frag_send
+   fun:mca_btl_tcp_endpoint_send_handler
+   fun:event_persist_closure
+   fun:event_process_active_single_queue
+   fun:event_process_active
+   fun:opal_libevent2022_event_base_loop
+   fun:opal_progress
+   fun:ompi_request_default_wait
+   fun:PMPI_Wait
+   fun:PMPI_WAIT
+}
 
 
+################################################################################
+# Netcdf /hdf5
+################################################################################
 {
    netcdf
    Memcheck:Cond
-   fun:H5C__flush_single_entry
-   fun:H5C__flush_invalidate_cache
-   fun:H5C_dest
-   fun:H5AC_dest
-   fun:H5F__dest
-   fun:H5F_try_close
-   fun:H5F__close_cb
-   fun:H5I_dec_ref
-   fun:H5I_dec_app_ref
-   fun:H5F__close
+   ...
    fun:H5Fclose
    fun:nc4_close_netcdf4_file
 }
@@ -39,21 +73,41 @@
 }
 
 
+################################################################################
+# fms
+################################################################################
 {
-   fms
+   fms_save_restart
    Memcheck:Cond
-   fun:__mpp_io_mod_MOD_mpp_open
-   fun:__fms_io_mod_MOD_save_default_restart.constprop.0
+   ...
    fun:__fms_io_mod_MOD_save_restart
 }
 {
-   fms
+   fms_save_restart
+   Memcheck:Param
+   write(buf)
+   ...
+   fun:__fms_io_mod_MOD_save_restart
+}
+{
+   fms_io_exit
    Memcheck:Cond
-   fun:__mpp_io_mod_MOD_mpp_open
+   ...
+   fun:__fms_io_mod_MOD_fms_io_exit
+}
+{
+   fms_io_exit
+   Memcheck:Param
+   write(buf)
+   fun:write
+   ...
    fun:__fms_io_mod_MOD_fms_io_exit
 }
 
 
+################################################################################
+# mom
+################################################################################
 {
    mom
    Memcheck:Cond
@@ -68,12 +122,246 @@
 {
    mom
    Memcheck:Cond
-   fun:__generic_bling_MOD_generic_bling_update_from_source
-   fun:__generic_tracer_MOD_generic_tracer_source
-   fun:__mom_generic_tracer_MOD_mom_generic_tracer_column_physics
-   fun:__mom_tracer_flow_control_MOD_call_tracer_column_fns
-   fun:__mom_diabatic_driver_MOD_diabatic
-   fun:__mom_MOD_step_mom_thermo
+   ...
    fun:__mom_MOD_step_mom
    fun:__soca_model_mod_MOD_soca_propagate
+}
+{
+   mom
+   Memcheck:Value8
+   ...
+   fun:__mom_MOD_step_mom
+   fun:__soca_model_mod_MOD_soca_propagate
+}
+
+################################################################################
+# JEDI (these should probably be fixed!)
+################################################################################
+{
+   ioda
+   Memcheck:Cond
+   fun:__string_f_c_mod_MOD_c_f_string
+   fun:__obsspace_mod_MOD_obsspace_get_comm
+   fun:__ufo_adt_mod_MOD_ufo_adt_simobs
+   fun:__ufo_basis_mod_MOD_opr_simobs_
+   fun:ufo_adt_simobs_f90
+}
+
+############################
+# bugs within prints
+{
+   oops_print
+   Memcheck:Cond
+   ...
+   fun:operator<<
+   fun:_ZN4oops13DualMinimizerIN4soca6TraitsEN3ufo9ObsTraitsEE10doMinimizeERKN5eckit13ConfigurationE
+   fun:minimize
+}
+{
+   oops_print
+   Memcheck:Value8
+   ...
+   fun:operator<<
+   fun:_ZN4oops13DualMinimizerIN4soca6TraitsEN3ufo9ObsTraitsEE10doMinimizeERKN5eckit13ConfigurationE
+   fun:minimize
+}
+{
+   oops_print
+   Memcheck:Param
+   write(buf)
+   fun:write
+   ...
+   fun:operator<<
+   fun:_ZN4oops13DualMinimizerIN4soca6TraitsEN3ufo9ObsTraitsEE10doMinimizeERKN5eckit13ConfigurationE
+   fun:minimize
+}
+{
+   oops_print
+   Memcheck:Cond
+   ...
+   fun:operator<<
+   fun:_ZNK4oops11CostJbTotalIN4soca6TraitsEN3ufo9ObsTraitsEE8evaluateERKNS_16ControlIncrementIS2_S4_EE
+}
+{
+   oops_print
+   Memcheck:Cond
+   ...
+   fun:operator<<
+   fun:_ZN4oops12CostFunctionIN4soca6TraitsEN3ufo9ObsTraitsEE8evaluateERKNS_15ControlVariableIS2_S4_EERKN5eckit13ConfigurationENS_13PostProcessorINS_5StateIS2_EEEE
+}
+{
+   oops_print
+   Memcheck:Cond
+   ...
+   fun:operator<<
+   fun:_ZNK4oops9ObsVectorIN3ufo9ObsTraitsEE5printERSo
+}
+{
+   oops_print
+   Memcheck:Value8
+   ...
+   fun:operator<<
+   fun:_ZNK4oops9ObsVectorIN3ufo9ObsTraitsEE5printERSo
+}
+{
+   oops_print
+   Memcheck:Cond
+    ...
+   fun:operator<<
+   fun:_ZNK4oops6CostJoIN4soca6TraitsEN3ufo9ObsTraitsEE7printJoERKNS_10DeparturesIS4_EES9_
+}
+{
+   oops_print
+   Memcheck:Value8
+    ...
+   fun:operator<<
+   fun:_ZNK4oops6CostJoIN4soca6TraitsEN3ufo9ObsTraitsEE7printJoERKNS_10DeparturesIS4_EES9_
+}
+{
+   oops_print
+   Memcheck:Value8
+   ...
+   fun:operator<<
+   ...
+   fun:_ZN4oops6GMRESRINS_9IncrementIN4soca6TraitsEEENS_16HybridCovarianceIS3_EENS_14IdentityMatrixIS4_EEEEdRT_RKS9_RKT0_RKT1_id
+   fun:_ZNK4oops16HybridCovarianceIN4soca6TraitsEE17doInverseMultiplyERKNS_9IncrementIS2_EERS5_
+}
+
+
+############################
+# other stuff
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   ...
+   fun:_ZNK3ufo10FilterBase8doFilterEv
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:_ZNK3ufo9QCmanager10postFilterERKN4ioda9ObsVectorERKNS_14ObsDiagnosticsE
+   fun:_ZNK4oops9ObsFilterIN3ufo9ObsTraitsENS1_9QCmanagerEE10postFilterERKNS_9ObsVectorIS2_EERKNS_14ObsDiagnosticsIS2_EE
+   fun:postFilter
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:_ZNK4oops11CostJbTotalIN4soca6TraitsEN3ufo9ObsTraitsEE8evaluateERKNS_16ControlIncrementIS2_S4_EE
+   fun:_ZNK4oops11CostJbTotalIN4soca6TraitsEN3ufo9ObsTraitsEE8finalizeEPNS_6JqTermIS2_EE
+}
+
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:_ZN4ioda14ConvertVarTypeIdfEEvRKSt6vectorIT_SaIS2_EERS1_IT0_SaIS7_EE
+   fun:_ZN4ioda7ObsData6put_dbERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES8_RKSt6vectorIdSaIdEE
+   fun:_ZNK4ioda9ObsVector4saveERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+   fun:_ZNK4oops9ObsVectorIN3ufo9ObsTraitsEE4saveERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:_ZN4ioda9ObsVector*
+   fun:_ZN4oops9ObsVectorIN3ufo9ObsTraitsEE*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:_ZNK4ioda9ObsVector16dot_product_withERKS0_
+   fun:_ZNK4oops9ObsVectorIN3ufo9ObsTraitsEE16dot_product_withERKS3_
+   fun:dot_product<oops::ObsVector<ufo::ObsTraits> >
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:_ZNK4ioda9ObsVector4nobsEv
+   fun:nobs
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   ...
+   fun:_Destroy<std::shared_ptr<oops::ObsSpace<ufo::ObsTraits> > >
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Param
+   pwrite64(buf)
+   fun:pwrite
+   ...
+   fun:~unique_ptr
+   fun:_ZN4ioda7ObsData10SaveToFileERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEm
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   ...
+   fun:_ZN4oops6GMRESRINS_9IncrementIN4soca6TraitsEEENS_16HybridCovarianceIS3_EENS_14IdentityMatrixIS4_EEEEdRT_RKS9_RKT0_RKT1_id
+   fun:_ZNK4oops16HybridCovarianceIN4soca6TraitsEE17doInverseMultiplyERKNS_9IncrementIS2_EERS5_
+}
+
+
+
+################################################################################
+# SOCA things that definitely should be fixed
+################################################################################
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:__soca_state_mod_MOD_soca_state_add_incr
+   fun:soca_state_add_incr_f90
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:__soca_fieldsutils_mod_MOD_fldinfo3d
+   fun:__soca_fields_mod_MOD_soca_fields_gpnorm
+   fun:soca_state_gpnorm_f90
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   ...
+   fun:operator<<
+   fun:_ZNK4soca5State5printERSo
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   ...
+   fun:operator<<
+   fun:_ZNK4soca5State5printERSo
+}
+{
+  <insert_a_suppression_name_here>
+   Memcheck:Value8
+   ...
+   fun:operator<<
+   fun:_ZNK4soca9Increment5printERSo
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   ...
+   fun:__ufo_coolskin_mod_MOD_ufo_coolskin_simobs
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   ...
+   fun:__ufo_coolskin_mod_MOD_ufo_coolskin_simobs
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   ...
+   fun:__ufo_insitutemperature_mod_MOD_ufo_insitutemperature_simobs
+   fun:__ufo_basis_mod_MOD_opr_simobs_
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   ...
+   fun:__ufo_marinevertinterp_mod_MOD_ufo_marinevertinterp_simobs
+   fun:ufo_marinevertinterp_simobs_f90
 }

--- a/test/valgrind.sup
+++ b/test/valgrind.sup
@@ -1,0 +1,79 @@
+{
+   mpi
+   Memcheck:Param
+   writev(vector[...])
+   fun:__writev
+   fun:writev
+   fun:OPAL_MCA_PMIX3X_pmix_ptl_base_send_handler
+   obj:/usr/lib/x86_64-linux-gnu/libevent-2.1.so.7.0.0
+   fun:event_base_loop
+   fun:progress_engine
+   fun:start_thread
+   fun:clone
+}
+
+
+{
+   netcdf
+   Memcheck:Cond
+   fun:H5C__flush_single_entry
+   fun:H5C__flush_invalidate_cache
+   fun:H5C_dest
+   fun:H5AC_dest
+   fun:H5F__dest
+   fun:H5F_try_close
+   fun:H5F__close_cb
+   fun:H5I_dec_ref
+   fun:H5I_dec_app_ref
+   fun:H5F__close
+   fun:H5Fclose
+   fun:nc4_close_netcdf4_file
+}
+{
+   netcdf
+   Memcheck:Cond
+   ...
+   fun:put_att_grpa
+   fun:write_attlist
+   fun:nc4_rec_write_metadata
+}
+
+
+{
+   fms
+   Memcheck:Cond
+   fun:__mpp_io_mod_MOD_mpp_open
+   fun:__fms_io_mod_MOD_save_default_restart.constprop.0
+   fun:__fms_io_mod_MOD_save_restart
+}
+{
+   fms
+   Memcheck:Cond
+   fun:__mpp_io_mod_MOD_mpp_open
+   fun:__fms_io_mod_MOD_fms_io_exit
+}
+
+
+{
+   mom
+   Memcheck:Cond
+   fun:_gfortran_string_len_trim
+   fun:_gfortran_string_trim
+   ...
+   fun:__mom_tracer_flow_control_MOD_call_tracer_stocks
+   fun:__mom_sum_output_MOD_write_energy
+   fun:__mom_MOD_finish_mom_initialization
+   fun:__soca_mom6_MOD_soca_mom6_init
+}
+{
+   mom
+   Memcheck:Cond
+   fun:__generic_bling_MOD_generic_bling_update_from_source
+   fun:__generic_tracer_MOD_generic_tracer_source
+   fun:__mom_generic_tracer_MOD_mom_generic_tracer_column_physics
+   fun:__mom_tracer_flow_control_MOD_call_tracer_column_fns
+   fun:__mom_diabatic_driver_MOD_diabatic
+   fun:__mom_MOD_step_mom_thermo
+   fun:__mom_MOD_step_mom
+   fun:__soca_model_mod_MOD_soca_propagate
+}

--- a/test/valgrind.sup
+++ b/test/valgrind.sup
@@ -39,7 +39,7 @@
    mpi
    Memcheck:Param
    writev(vector[...])
-   fun:writev
+   ...
    fun:PMPI_*
 }
 

--- a/test/valgrind.sup
+++ b/test/valgrind.sup
@@ -244,7 +244,12 @@
    ...
    fun:_Destroy<std::shared_ptr<oops::ObsSpace<ufo::ObsTraits> > >
 }
-
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   ...
+   fun:_ZNK4ioda9ObsVector5printERSo
+}
 {
    <insert_a_suppression_name_here>
    Memcheck:Param
@@ -312,14 +317,12 @@
    <insert_a_suppression_name_here>
    Memcheck:Cond
    ...
-   fun:operator<<
    fun:_ZNK4soca5State5printERSo
 }
 {
    <insert_a_suppression_name_here>
    Memcheck:Value8
    ...
-   fun:operator<<
    fun:_ZNK4soca5State5printERSo
 }
 
@@ -335,7 +338,6 @@
    <insert_a_suppression_name_here>
    Memcheck:Cond
    ...
-   fun:operator<<
    fun:_ZNK4soca9Increment5printERSo
 }
 {

--- a/test/valgrind.sup
+++ b/test/valgrind.sup
@@ -259,6 +259,16 @@
    fun:~unique_ptr
    fun:_ZN4ioda7ObsData10SaveToFileERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEm
 }
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   ...
+   fun:_ZN4ioda7ObsData10SaveToFile*
+   ...
+   fun:~shared_ptr
+}
+
+
 
 # hybridcov inverse multiply
 {


### PR DESCRIPTION
## Description

Valgrind tests have been added to soca and can be enabled with `-DSOCA_TESTS_VALGRIND=ON`.
Since these are slow, they are not enabled by default. (Also, valgrind and code coverage cannot be enabled at the same time). After this PR is merged I'll setup a night cron that will run the valgrind tests

In order to get this "passing" there is a long list of suppressions that have been added. Basically everything in the model propagation is expected to fail, and so is ignored, we have no hope of fixing that.

- At the end of the suppression file there is a section of SOCA suppressions that we should probably fix at some point. 
- There is also a list of JEDI suppressions that I might keep ignoring, or bug the JEDI people to fix.


## Testing

The travisCI tests here will NOT test valgrind. Testing of the valgrind has been forced separately in this test: 
https://travis-ci.com/github/JCSDA/soca/jobs/382861723
