### PR TITLE
Feature/3dbump

### DIFF
--- a/src/mains/3DVar.cc
+++ b/src/mains/3DVar.cc
@@ -17,6 +17,7 @@
 #include "oops/runs/Variational.h"
 #include "oops/generic/instantiateModelFactory.h"
 #include "saber/oops/instantiateLocalizationFactory.h"
+#include "saber/oops/instantiateCovarFactory.h"
 
 int main(int argc,  char ** argv) {
   oops::Run run(argc, argv);
@@ -24,6 +25,7 @@ int main(int argc,  char ** argv) {
   soca::instantiateBalanceOpFactory();
   ufo::instantiateObsFilterFactory<ufo::ObsTraits>();
   saber::instantiateLocalizationFactory<soca::Traits>();
+  saber::instantiateCovarFactory<fv3jedi::Traits>();
   oops::Variational<soca::Traits, ufo::ObsTraits> var;
   return run.execute(var);
 }

--- a/src/mains/3DVar.cc
+++ b/src/mains/3DVar.cc
@@ -25,7 +25,7 @@ int main(int argc,  char ** argv) {
   soca::instantiateBalanceOpFactory();
   ufo::instantiateObsFilterFactory<ufo::ObsTraits>();
   saber::instantiateLocalizationFactory<soca::Traits>();
-  saber::instantiateCovarFactory<fv3jedi::Traits>();
+  saber::instantiateCovarFactory<soca::Traits>();
   oops::Variational<soca::Traits, ufo::ObsTraits> var;
   return run.execute(var);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -391,6 +391,13 @@ soca_add_test( NAME gridgen
                EXE  soca_gridgen.x
                NOCOMPARE )
 
+# Remapping MOM6 (horiz+vertical intterpolation)
+soca_add_test( NAME convertstate
+               EXE  soca_convertstate.x
+               TOL  2e-5 0
+               NOTRAPFPE
+               TEST_DEPENDS test_soca_gridgen )
+
 # Test of read/write restart for MOM6&SIS2, model advance = Id
 soca_add_test( NAME forecast_identity
                EXE  soca_forecast.x
@@ -579,7 +586,8 @@ soca_add_test( NAME ensrecenter
 
 soca_add_test( NAME parameters_bump_cor_nicas
                EXE  soca_parameters.x
-               TEST_DEPENDS test_soca_gridgen_small )
+               TEST_DEPENDS test_soca_gridgen_small
+                            test_soca_convertstate)
 
 
 # Dirac tests
@@ -708,10 +716,3 @@ soca_add_test( NAME checkpointmodel
                EXE  soca_checkpoint_model.x
                NOTRAPFPE
                TEST_DEPENDS test_soca_3dvar_godas)
-
-# Remapping MOM6 (horiz+vertical intterpolation)
-soca_add_test( NAME convertstate
-               EXE  soca_convertstate.x
-               TOL  2e-5 0
-               NOTRAPFPE
-               TEST_DEPENDS test_soca_gridgen )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 list( APPEND soca_test_input
   testinput/3dhyb.yml
   testinput/3dhybfgat.yml
+  testinput/3dvarbump.yml
   testinput/3dvar_godas.yml
   testinput/3dvar_soca.yml
   testinput/3dvarfgat.yml
@@ -40,6 +41,7 @@ list( APPEND soca_test_input
   testinput/makeobs.yml
   testinput/marine2ioda.yml
   testinput/model.yml
+  testinput/parameters_bump_cor_nicas.yml
   testinput/parameters_bump_cov_lct.yml
   testinput/parameters_bump_cov_nicas.yml
   testinput/parameters_bump_loc.yml
@@ -59,6 +61,7 @@ list( APPEND soca_test_input
 list( APPEND soca_test_ref
   testref/3dhyb.test
   testref/3dhybfgat.test
+  testref/3dvarbump.test
   testref/3dvar_godas.test
   testref/3dvar_soca.test
   testref/3dvarfgat.test
@@ -87,6 +90,7 @@ list( APPEND soca_test_ref
   testref/hofx_4d_pseudo.test
   testref/letkf.test
   testref/makeobs.test
+  testref/parameters_bump_cor_nicas.test
   testref/parameters_bump_cov_lct.test
 )
 
@@ -573,6 +577,10 @@ soca_add_test( NAME ensrecenter
 # soca_add_test( NAME dirac_bump_cov
 #                EXE  soca_dirac.x )
 
+soca_add_test( NAME parameters_bump_cor_nicas
+               EXE  soca_parameters.x
+               TEST_DEPENDS test_soca_gridgen_small )
+
 
 # Dirac tests
 
@@ -636,6 +644,12 @@ soca_add_test( NAME 3dvar_soca
                TOL  4e-9 0
                NOTRAPFPE
                TEST_DEPENDS test_soca_static_socaerror_init )
+
+soca_add_test( NAME 3dvarbump
+               EXE  soca_3dvar.x
+               TOL  4e-9 0
+               NOTRAPFPE
+               TEST_DEPENDS test_soca_parameters_bump_cor_nicas )
 
 soca_add_test( NAME 3dvar_godas
                EXE  soca_3dvar.x

--- a/test/testinput/3dvarbump.yml
+++ b/test/testinput/3dvarbump.yml
@@ -14,7 +14,8 @@ cost function:
     num_ice_cat: 5
     num_ice_lev: 4
     num_sno_lev: 1
-    mom6_input_nml: ./inputnml/input.nml
+    mom6_input_nml: ./inputnml/input_small.nml
+    geom_grid_file: soca_gridspec.small.nc
 
   background:
     read_from_file: 1
@@ -160,7 +161,8 @@ variational:
       num_ice_cat: 5
       num_ice_lev: 4
       num_sno_lev: 1
-      mom6_input_nml: ./inputnml/input.nml
+      mom6_input_nml: ./inputnml/input_small.nml
+      geom_grid_file: soca_gridspec.small.nc
     ninner: 5
     gradient norm reduction: 1e-15
     test: on

--- a/test/testinput/3dvarbump_soca.yml
+++ b/test/testinput/3dvarbump_soca.yml
@@ -1,0 +1,177 @@
+# common filters used later on
+_: &land_mask
+  filter: Domain Check
+  where:
+  - variable: {name: sea_area_fraction@GeoVaLs}
+    minvalue: 0.5
+
+cost function:
+  cost type: 3D-Var
+  window begin: 2018-04-14T00:00:00Z
+  window length: P2D
+  analysis variables: &soca_vars [hocn, socn, tocn, ssh]
+  geometry:
+    num_ice_cat: 5
+    num_ice_lev: 4
+    num_sno_lev: 1
+    mom6_input_nml: ./inputnml/input.nml
+
+  background:
+    read_from_file: 1
+    basename: ./INPUT/
+    ocn_filename: MOM.res.nc
+    #ice_filename: ice_model.res.nc
+    #sfc_filename: sfc.res.nc
+    date: 2018-04-15T00:00:00Z
+    state variables: [hocn, socn, tocn, ssh]
+
+  background error:
+    covariance model: BUMP
+    bump:
+      prefix: bump3d
+      datadir: ./bump
+      strategy: specific_univariate
+      load_nicas: 1
+      lsqrt: 1
+      mpicom: 2
+    date: 2018-04-15T00:00:00Z
+    variable changes:
+
+    - variable change: BkgErrFILT
+      ocean_depth_min: 1000 # [m]
+      rescale_bkgerr: 1.0
+      efold_z: 2500.0       # [m]
+      input variables: *soca_vars
+      output variables: *soca_vars
+
+    - variable change: BkgErrGODAS
+      t_min: 0.1
+      t_max: 2.0
+      t_dz:  20.0
+      t_efold: 500.0
+      s_min: 0.0
+      s_max: 0.25
+      ssh_min: 0.0   # value at EQ
+      ssh_max: 0.1   # value in Extratropics
+      ssh_phi_ex: 20 # lat of transition from extratropics
+      cicen_min: 0.1
+      cicen_max: 0.5
+      hicen_min: 10.0
+      hicen_max: 100.0
+      input variables: *soca_vars
+      output variables: *soca_vars
+
+    - variable change: BalanceSOCA
+      dsdtmax: 0.1
+      dsdzmin: 3.0e-6
+      dtdzmin: 1.0e-6
+      nlayers: 10
+      dcdt:
+        filename: ./Data/kmask.nc
+        name: dcdt
+      input variables: *soca_vars
+      output variables: *soca_vars
+
+  observations:
+
+  - obs space:
+      name: SeaSurfaceTemp
+      obsdataout: {obsfile: ./Data/sst.out.nc}
+      obsdatain:  {obsfile: ./Data/sst.nc}
+      simulated variables: [sea_surface_temperature]
+    obs operator:
+      name: Identity
+    obs error:
+      covariance model: diagonal
+    obs filters:
+    - *land_mask
+    - filter: Bounds Check
+      minvalue: 5.0
+      maxvalue: 30.0
+    - filter: Background Check
+      threshold: 8
+    - filter: Thinning
+      amount: 0.1
+      random seed: 0
+
+  - obs space:
+      name: SeaSurfaceSalinity
+      obsdataout: {obsfile: ./Data/sss.out.nc}
+      obsdatain:  {obsfile: ./Data/sss.nc}
+      simulated variables: [sea_surface_salinity]
+    obs operator:
+      name: Identity
+    obs error:
+      covariance model: diagonal
+    obs filters:
+    - *land_mask
+    - filter: Domain Check
+      where:
+      - variable: {name: sea_surface_temperature@GeoVaLs}
+        minvalue: 15
+
+  - obs space:
+      name: ADT
+      obsdataout: {obsfile: ./Data/adt.out.nc}
+      obsdatain:  {obsfile: ./Data/adt.nc}
+      simulated variables: [obs_absolute_dynamic_topography]
+    obs operator:
+      name: ADT
+    obs error:
+      covariance model: diagonal
+    obs filters:
+    - filter: Domain Check
+      where:
+      - variable: {name: sea_floor_depth_below_sea_surface@GeoVaLs}
+        minvalue: 2000
+
+  - obs space:
+      name: InsituTemperature
+      obsdataout: {obsfile: ./Data/prof.T.out.nc}
+      obsdatain:  {obsfile: ./Data/prof.nc}
+      simulated variables: [sea_water_temperature]
+    obs operator:
+      name: InsituTemperature
+    obs error:
+      covariance model: diagonal
+    obs filters:
+    - *land_mask
+    - filter: Background Check
+      threshold: 5
+
+  - obs space:
+      name: InsituSalinity
+      obsdataout: {obsfile: ./Data/prof.S.out.nc}
+      obsdatain:  {obsfile: ./Data/prof.nc}
+      simulated variables: [sea_water_salinity]
+    obs operator:
+      name: MarineVertInterp
+    obs error:
+      covariance model: diagonal
+    obs filters:
+    - *land_mask
+
+
+variational:
+  minimizer:
+    algorithm: RPCG
+  iterations:
+  - geometry:
+      num_ice_cat: 5
+      num_ice_lev: 4
+      num_sno_lev: 1
+      mom6_input_nml: ./inputnml/input.nml
+    ninner: 5
+    gradient norm reduction: 1e-15
+    test: on
+    diagnostics:
+      departures: ombg
+
+output:
+  datadir: Data
+  exp: 3dvarsoca
+  type: an
+
+final:
+  diagnostics:
+    departures: oman

--- a/test/testinput/parameters_bump_cor_nicas.yml
+++ b/test/testinput/parameters_bump_cor_nicas.yml
@@ -4,19 +4,19 @@ geometry:
   num_sno_lev: 1
   mom6_input_nml: ./inputnml/input.nml
 
-input variables: &soca_vars  [socn, tocn, ssh]
+input variables: &soca_vars  [hocn, socn, tocn, ssh]
 
 background:
   read_from_file: 1
   date: &date 2018-04-15T00:00:00Z
   basename: ./INPUT/
   ocn_filename: MOM.res.nc
-  ice_filename: ice_model.res.nc
-  state variables: [cicen, hicen, hocn, socn, tocn, ssh]
+  #ice_filename: ice_model.res.nc
+  state variables: [hocn, socn, tocn, ssh]
 
 bump:
   default_seed: 1
-  prefix: soca
+  prefix: bump3d
   datadir: ./bump
   method: cor
   strategy: specific_univariate

--- a/test/testinput/parameters_bump_cor_nicas.yml
+++ b/test/testinput/parameters_bump_cor_nicas.yml
@@ -1,0 +1,34 @@
+geometry:
+  num_ice_cat: 5
+  num_ice_lev: 4
+  num_sno_lev: 1
+  mom6_input_nml: ./inputnml/input.nml
+
+input variables: &soca_vars  [socn, tocn, ssh]
+
+background:
+  read_from_file: 1
+  date: &date 2018-04-15T00:00:00Z
+  basename: ./INPUT/
+  ocn_filename: MOM.res.nc
+  ice_filename: ice_model.res.nc
+  state variables: [cicen, hicen, hocn, socn, tocn, ssh]
+
+bump:
+  default_seed: 1
+  prefix: soca
+  datadir: ./bump
+  method: cor
+  strategy: specific_univariate
+  new_nicas: 1
+  mask_check: 1
+  ntry: 3
+  nrep:  2
+  lsqrt: 1
+  resol: 6.0
+  network: 1
+  mpicom: 2
+  forced_radii: 1
+  date: *date
+  rh: 3000.0e3
+  rv: 5

--- a/test/testinput/parameters_bump_cor_nicas.yml
+++ b/test/testinput/parameters_bump_cor_nicas.yml
@@ -2,16 +2,16 @@ geometry:
   num_ice_cat: 5
   num_ice_lev: 4
   num_sno_lev: 1
-  mom6_input_nml: ./inputnml/input.nml
+  mom6_input_nml: ./inputnml/input_small.nml
+  geom_grid_file: soca_gridspec.small.nc
 
 input variables: &soca_vars  [hocn, socn, tocn, ssh]
 
 background:
   read_from_file: 1
   date: &date 2018-04-15T00:00:00Z
-  basename: ./INPUT/
-  ocn_filename: MOM.res.nc
-  #ice_filename: ice_model.res.nc
+  basename: ./Data/
+  ocn_filename: ocn.remapped.fc.2018-04-15T00:00:00Z.PT0S.nc
   state variables: [hocn, socn, tocn, ssh]
 
 bump:
@@ -30,5 +30,17 @@ bump:
   mpicom: 2
   forced_radii: 1
   date: *date
-  rh: 3000.0e3
-  rv: 5
+  rh: 6000.0e3
+  rv: 100
+
+output:
+- datadir: bump
+  date: *date
+  exp: parameters_bump_cor_nicas.cor_rh
+  parameter: cor_rh
+  type: an
+- datadir: bump
+  date: *date
+  exp: parameters_bump_cor_nicas.cor_rv
+  parameter: cor_rv
+  type: an

--- a/test/testref/3dvarbump.test
+++ b/test/testref/3dvarbump.test
@@ -1,0 +1,21 @@
+Test     : CostJb   : Nonlinear Jb = 0
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 613.836, nobs = 80, Jo/n = 7.67295, err = 0.381671
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 29.2619, nobs = 42, Jo/n = 0.696712, err = 1
+Test     : CostJo   : Nonlinear Jo(ADT) = 512.768, nobs = 84, Jo/n = 6.10438, err = 0.1
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 450.497, nobs = 134, Jo/n = 3.36192, err = 0.913795
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 412864, nobs = 218, Jo/n = 1893.87, err = 0.608197
+Test     : CostFunction: Nonlinear J = 414470
+Test     : RPCGMinimizer: reduction in residual norm = 0.124988
+Test     : CostFunction::addIncrement: Analysis: 
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    hocn   min=    0.001000   max= 1297.170000   mean=  110.562284
+Test     :    socn   min=    0.000000   max=   37.225035   mean=   28.647561
+Test     :    tocn   min=   -2.450325   max=   38.317084   mean=    5.053064
+Test     :     ssh   min=   -2.010571   max=    0.983558   mean=   -0.142088
+Test     : CostJb   : Nonlinear Jb = 152.469353
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 156.000458, nobs = 72, Jo/n = 2.166673, err = 0.386977
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 26.155467, nobs = 41, Jo/n = 0.637938, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 138.470070, nobs = 84, Jo/n = 1.648453, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 197.422678, nobs = 133, Jo/n = 1.484381, err = 0.916055
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 411580.885932, nobs = 218, Jo/n = 1887.985715, err = 0.608197
+Test     : CostFunction: Nonlinear J = 412251.403958

--- a/test/testref/parameters_bump_cor_nicas.test
+++ b/test/testref/parameters_bump_cor_nicas.test
@@ -1,0 +1,2 @@
+Test     : Norm of cor_rh at 2018-04-15T00:00:00Z: 1.501e+09
+Test     : Norm of cor_rv at 2018-04-15T00:00:00Z: 2.501e+04

--- a/test/valgrind.sup
+++ b/test/valgrind.sup
@@ -186,6 +186,22 @@
    fun:operator<<
    fun:_ZNK4oops6CostJoIN4soca6TraitsEN3ufo9ObsTraitsEE7printJoERKNS_10DeparturesIS4_EES9_
 }
+{
+  <insert_a_suppression_name_here>
+  Memcheck:Cond
+  ...
+  fun:operator<<
+  ...
+  fun:inverseMultiplyNicas
+}
+{
+  <insert_a_suppression_name_here>
+  Memcheck:Value8
+  ...
+  fun:operator<<
+  ...
+  fun:inverseMultiplyNicas
+}
 
 
 


### PR DESCRIPTION
## Description
Minor updates to allow for the use of the saber covariance factory with the variational application. I still don't think we will be able to initialize bump correlations at full resolution, but perhaps at a sub-sampled resolution. The motivation for that work is that bump is perfectly normalized, the soca VertConv is not ... 

### Addition of 2 tests:
1. Initialization of BUMP correlation operator. Use of unrealistic scales to speed up the testing
2. Example of the use of 1. for a 3dvar case at low resolution and only a sub-sample of the possible variables (no sea-ice, no chl, ...)

### Issue(s) addressed
closes #439 

## Testing
How were these changes tested? **Use of saber covariance factory tested with a 3dvar**
What compilers / HPCs was it tested with? **gnu/container**
Are the changes covered by ctests? **Yes, 2 tests added**


