### PR TITLE
Move FMS default branch to release-stable-ecbuild

### DIFF
--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -37,6 +37,10 @@ if ( BUILD_METIS )
   ecbuild_bundle( PROJECT metis         GIT "https://github.com/JCSDA/metis.git"           UPDATE BRANCH develop )
 endif ()
 
+option(BUILD_FMS "download and build fms" ON)
+if ( BUILD_FMS )
+  ecbuild_bundle( PROJECT fms           GIT "https://github.com/JCSDA/FMS.git"             UPDATE BRANCH release-stable-ecbuild )
+endif ()
 
 # required repositories
 
@@ -48,7 +52,6 @@ ecbuild_bundle( PROJECT ioda            GIT "https://github.com/JCSDA/ioda.git" 
 ecbuild_bundle( PROJECT ioda-converters GIT "https://github.com/JCSDA/ioda-converters.git" UPDATE BRANCH develop )
 ecbuild_bundle( PROJECT gsw             GIT "https://github.com/JCSDA/GSW-Fortran.git"     UPDATE BRANCH develop )
 ecbuild_bundle( PROJECT ufo             GIT "https://github.com/JCSDA/ufo.git"             UPDATE BRANCH develop )
-ecbuild_bundle( PROJECT fms             GIT "https://github.com/JCSDA/FMS.git"             UPDATE BRANCH release-stable )
 ecbuild_bundle( PROJECT mom6            GIT "https://github.com/JCSDA/MOM6.git"            UPDATE BRANCH dev/master-ecbuild RECURSIVE)
 ecbuild_bundle( PROJECT soca            SOURCE "../" )
 


### PR DESCRIPTION
## Description

Switch branch of fms to release-stable-ecbuild so we can move release-stable-new to release-stable as a first step to building fms in AWS.

Adding option for FMS since the default will move to OFF once we have the module ready. You can build with ON when you're making changes to FMS and can't be bothered to create a module.

