### PR TITLE
fix serialize/deserialize

### DIFF
--- a/src/soca/Increment/Increment.cc
+++ b/src/soca/Increment/Increment.cc
@@ -256,9 +256,6 @@ namespace soca {
   /// Serialization
   // -----------------------------------------------------------------------------
   size_t Increment::serialSize() const {
-    return 0;
-    // TOOD (someone) figure out why testIncrementSerialize fails
-
     // Field
     size_t nn;
     soca_increment_serial_size_f90(toFortran(), geom_->toFortran(), nn);
@@ -273,13 +270,11 @@ namespace soca {
   // -----------------------------------------------------------------------------
   constexpr double SerializeCheckValue = -54321.98765;
   void Increment::serialize(std::vector<double> & vect) const {
-    return;
-    // TOOD (someone) figure out why testIncrementSerialize fails
-
     // Serialize the field
     size_t nn;
     soca_increment_serial_size_f90(toFortran(), geom_->toFortran(), nn);
     std::vector<double> vect_field(nn, 0);
+    vect.reserve(vect.size() + nn + 1 + time_.serialSize());
     soca_increment_serialize_f90(toFortran(), geom_->toFortran(), nn,
                                  vect_field.data());
     vect.insert(vect.end(), vect_field.begin(), vect_field.end());
@@ -293,10 +288,8 @@ namespace soca {
   // -----------------------------------------------------------------------------
   void Increment::deserialize(const std::vector<double> & vect,
                               size_t & index) {
-    return;
-    // TOOD (someone) figure out why testIncrementSerialize fails
+    // Deserialize the field
 
-    // Deserialize te field
     soca_increment_deserialize_f90(toFortran(), geom_->toFortran(), vect.size(),
                                    vect.data(), index);
 

--- a/src/soca/Increment/soca_increment.interface.F90
+++ b/src/soca/Increment/soca_increment.interface.F90
@@ -463,15 +463,18 @@ end subroutine soca_increment_change_resol_c
   implicit none
   integer(c_int), intent(in) :: c_key_self
   integer(c_int), intent(in) :: c_key_geom
-  integer(c_int), intent(out) :: c_vec_size
+  integer(c_size_t), intent(out) :: c_vec_size
 
   type(soca_increment), pointer :: self
   type(soca_geom),  pointer :: geom
 
+  integer :: vec_size
+
   call soca_increment_registry%get(c_key_self,self)
   call soca_geom_registry%get(c_key_geom,geom)
 
-  call self%serial_size(geom,c_vec_size)
+  call self%serial_size(geom,vec_size)
+  c_vec_size = vec_size
 
   end subroutine soca_increment_serial_size_c
 
@@ -480,18 +483,20 @@ end subroutine soca_increment_change_resol_c
   subroutine soca_increment_serialize_c(c_key_self,c_key_geom,c_vec_size,c_vec) bind (c,name='soca_increment_serialize_f90')
 
   implicit none
-  integer(c_int), intent(in) :: c_key_self
-  integer(c_int), intent(in) :: c_key_geom
-  integer(c_int), intent(in) :: c_vec_size
-  real(c_double), intent(out) :: c_vec(c_vec_size)
+  integer(c_int),    intent(in) :: c_key_self
+  integer(c_int),    intent(in) :: c_key_geom
+  integer(c_size_t), intent(in) :: c_vec_size
+  real(c_double),   intent(out) :: c_vec(c_vec_size)
 
+  integer :: vec_size
   type(soca_increment), pointer :: self
   type(soca_geom),  pointer :: geom
 
+  vec_size = c_vec_size
   call soca_increment_registry%get(c_key_self,self)
   call soca_geom_registry%get(c_key_geom,geom)
 
-  call self%serialize(geom,c_vec_size,c_vec)
+  call self%serialize(geom, vec_size, c_vec)
 
   end subroutine soca_increment_serialize_c
 
@@ -500,19 +505,23 @@ end subroutine soca_increment_change_resol_c
   subroutine soca_increment_deserialize_c(c_key_self,c_key_geom,c_vec_size,c_vec,c_index) bind (c,name='soca_increment_deserialize_f90')
 
   implicit none
-  integer(c_int), intent(in) :: c_key_self
-  integer(c_int), intent(in) :: c_key_geom
-  integer(c_int), intent(in) :: c_vec_size
-  real(c_double), intent(in) :: c_vec(c_vec_size)
-  integer(c_int), intent(inout) :: c_index
+  integer(c_int),    intent(in) :: c_key_self
+  integer(c_int),    intent(in) :: c_key_geom
+  integer(c_size_t), intent(in) :: c_vec_size
+  real(c_double),    intent(in) :: c_vec(c_vec_size)
+  integer(c_size_t), intent(inout) :: c_index
 
+  integer :: vec_size, idx
   type(soca_increment), pointer :: self
   type(soca_geom),  pointer :: geom
 
+  vec_size = c_vec_size
+  idx = c_index
   call soca_increment_registry%get(c_key_self,self)
   call soca_geom_registry%get(c_key_geom,geom)
 
-  call self%deserialize(geom,c_vec_size,c_vec,c_index)
+  call self%deserialize(geom, vec_size, c_vec, idx)
+  c_index=idx
 
   end subroutine soca_increment_deserialize_c
 

--- a/src/soca/Increment/soca_increment_mod.F90
+++ b/src/soca/Increment/soca_increment_mod.F90
@@ -37,10 +37,6 @@ contains
   procedure :: schur       => soca_increment_schur
   procedure :: convert     => soca_increment_change_resol
 
-  ! serialization
-  procedure :: serial_size => soca_increment_serial_size
-  procedure :: serialize   => soca_increment_serialize
-  procedure :: deserialize => soca_increment_deserialize
 end type
 
 
@@ -431,81 +427,5 @@ subroutine soca_increment_change_resol(self, rhs)
 end subroutine soca_increment_change_resol
 
 ! ------------------------------------------------------------------------------
-subroutine soca_increment_serial_size(self, geom, vec_size)
-  class(soca_increment), intent(in)  :: self
-  type(soca_geom),       intent(in)  :: geom
-  integer,               intent(out) :: vec_size
-
-  integer :: i
-  type(soca_field), pointer :: field
-
-  ! Initialization
-  vec_size = 0
-
-  ! Loop over fields, levels and horizontal points
-  do i=1,size(self%fields)
-    field => self%fields(i)
-    vec_size = vec_size+(geom%iec-geom%isc+1)*(geom%jec-geom%jsc+1)*field%nz
-  end do
-
-end subroutine soca_increment_serial_size
-
-
-! ------------------------------------------------------------------------------
-subroutine soca_increment_serialize(self, geom, vec_size, vec)
-  class(soca_increment), intent(in)  :: self
-  type(soca_geom),       intent(in)  :: geom
-  integer,               intent(in)  :: vec_size
-  real(kind=kind_real),  intent(out) :: vec(vec_size)
-
-  integer :: index, i, jx, jy, jz
-  type(soca_field), pointer :: field
-
-  ! Initialization
-  index = 0
-
-  ! Loop over fields, levels and horizontal points
-  do i=1,size(self%fields)
-    field => self%fields(i)
-    do jz=1,field%nz
-      do jy=geom%jsc,geom%jec
-        do jx=geom%isc,geom%iec
-          vec(index+1) = field%val(jx,jy,jz)
-          index = index+1
-        end do
-      end do
-    end do
-  end do
-
-end subroutine soca_increment_serialize
-
-
-! ------------------------------------------------------------------------------
-subroutine soca_increment_deserialize(self, geom, vec_size, vec, index)
-  class(soca_increment), intent(inout) :: self
-  type(soca_geom),       intent(in)    :: geom
-  integer,               intent(in)    :: vec_size
-  real(kind=kind_real),  intent(in)    :: vec(vec_size)
-  integer,               intent(inout) :: index
-
-
-  integer :: i, jx, jy, jz
-  type(soca_field), pointer :: field
-
-  ! Loop over fields, levels and horizontal points
-  do i=1,size(self%fields)
-    field => self%fields(i)
-    do jz=1,field%nz
-      do jy=geom%jsc,geom%jec
-        do jx=geom%isc,geom%iec
-          field%val(jx,jy,jz) = vec(index+1)
-          index = index+1
-        end do
-      end do
-    end do
-  end do
-
-end subroutine soca_increment_deserialize
-
 
 end module soca_increment_mod

--- a/src/soca/State/State.cc
+++ b/src/soca/State/State.cc
@@ -146,9 +146,6 @@ namespace soca {
   /// Serialization
   // -----------------------------------------------------------------------------
   size_t State::serialSize() const {
-    return 0;
-    // TODO(someone) re-enable this when needed
-
     // Field
     size_t nn;
     soca_state_serial_size_f90(toFortran(), geom_->toFortran(), nn);
@@ -163,13 +160,11 @@ namespace soca {
   // -----------------------------------------------------------------------------
   constexpr double SerializeCheckValue = -54321.98765;
   void State::serialize(std::vector<double> & vect) const {
-    return;
-    // TODO(someone) re-enable this when needed
-
     // Serialize the field
     size_t nn;
     soca_state_serial_size_f90(toFortran(), geom_->toFortran(), nn);
     std::vector<double> vect_field(nn, 0);
+    vect.reserve(vect.size() + nn + 1 + time_.serialSize());
     soca_state_serialize_f90(toFortran(), geom_->toFortran(), nn,
                              vect_field.data());
     vect.insert(vect.end(), vect_field.begin(), vect_field.end());
@@ -182,10 +177,7 @@ namespace soca {
   }
   // -----------------------------------------------------------------------------
   void State::deserialize(const std::vector<double> & vect, size_t & index) {
-    return;
-    // TODO(someone) re-enable this when needed
-
-    // Deserialize te field
+    // Deserialize the field
     soca_state_deserialize_f90(toFortran(), geom_->toFortran(), vect.size(),
                                vect.data(), index);
 

--- a/src/soca/State/soca_state.interface.F90
+++ b/src/soca/State/soca_state.interface.F90
@@ -282,15 +282,17 @@ end subroutine soca_state_change_resol_c
   implicit none
   integer(c_int), intent(in) :: c_key_self
   integer(c_int), intent(in) :: c_key_geom
-  integer(c_int), intent(out) :: c_vec_size
+  integer(c_size_t), intent(out) :: c_vec_size
 
   type(soca_state), pointer :: self
   type(soca_geom),  pointer :: geom
+  integer :: vec_size
 
   call soca_state_registry%get(c_key_self,self)
   call soca_geom_registry%get(c_key_geom,geom)
 
-  call self%serial_size(geom,c_vec_size)
+  call self%serial_size(geom, vec_size)
+  c_vec_size = vec_size
 
   end subroutine soca_state_serial_size_c
 
@@ -301,16 +303,19 @@ end subroutine soca_state_change_resol_c
   implicit none
   integer(c_int), intent(in) :: c_key_self
   integer(c_int), intent(in) :: c_key_geom
-  integer(c_int), intent(in) :: c_vec_size
+  integer(c_size_t), intent(in) :: c_vec_size
   real(c_double), intent(out) :: c_vec(c_vec_size)
 
   type(soca_state), pointer :: self
   type(soca_geom),  pointer :: geom
 
+  integer :: vec_size
+
+  vec_size = c_vec_size
   call soca_state_registry%get(c_key_self,self)
   call soca_geom_registry%get(c_key_geom,geom)
 
-  call self%serialize(geom,c_vec_size,c_vec)
+  call self%serialize(geom, vec_size, c_vec)
 
   end subroutine soca_state_serialize_c
 
@@ -321,17 +326,21 @@ end subroutine soca_state_change_resol_c
   implicit none
   integer(c_int), intent(in) :: c_key_self
   integer(c_int), intent(in) :: c_key_geom
-  integer(c_int), intent(in) :: c_vec_size
+  integer(c_size_t), intent(in) :: c_vec_size
   real(c_double), intent(in) :: c_vec(c_vec_size)
-  integer(c_int), intent(inout) :: c_index
+  integer(c_size_t), intent(inout) :: c_index
 
   type(soca_state), pointer :: self
   type(soca_geom),  pointer :: geom
+  integer :: vec_size, idx
 
+  vec_size = c_vec_size
+  idx = c_index
   call soca_state_registry%get(c_key_self,self)
   call soca_geom_registry%get(c_key_geom,geom)
 
-  call self%deserialize(geom,c_vec_size,c_vec,c_index)
+  call self%deserialize(geom,vec_size,c_vec, idx)
+  c_index=idx
 
   end subroutine soca_state_deserialize_c
 

--- a/src/soca/State/soca_state_mod.F90
+++ b/src/soca/State/soca_state_mod.F90
@@ -32,11 +32,6 @@ contains
   procedure :: rotate => soca_state_rotate
   procedure :: convert => soca_state_convert
 
-  ! serialization
-  procedure :: serial_size => soca_state_serial_size
-  procedure :: serialize   => soca_state_serialize
-  procedure :: deserialize => soca_state_deserialize
-
 end type
 
 !------------------------------------------------------------------------------
@@ -264,80 +259,5 @@ subroutine soca_state_convert(self, rhs)
 end subroutine soca_state_convert
 
 ! ------------------------------------------------------------------------------
-subroutine soca_state_serial_size(self, geom, vec_size)
-  class(soca_state), intent(in)  :: self
-  type(soca_geom),   intent(in)  :: geom
-  integer,           intent(out) :: vec_size
-
-  integer :: i
-  type(soca_field), pointer :: field
-
-  ! Initialization
-  vec_size = 0
-
-  ! Loop over fields, levels and horizontal points
-  do i=1,size(self%fields)
-    field => self%fields(i)
-    vec_size = vec_size+(geom%iec-geom%isc+1)*(geom%jec-geom%jsc+1)*field%nz
-  end do
-
-end subroutine soca_state_serial_size
-
-
-! ------------------------------------------------------------------------------
-subroutine soca_state_serialize(self, geom, vec_size, vec)
-  class(soca_state),    intent(in)  :: self
-  type(soca_geom),      intent(in)  :: geom
-  integer,              intent(in)  :: vec_size
-  real(kind=kind_real), intent(out) :: vec(vec_size)
-
-  integer :: index, i, jx, jy, jz
-  type(soca_field), pointer :: field
-
-  ! Initialization
-  index = 0
-
-  ! Loop over fields, levels and horizontal points
-  do i=1,size(self%fields)
-    field => self%fields(i)
-    do jz=1,field%nz
-      do jy=geom%jsc,geom%jec
-        do jx=geom%isc,geom%iec
-          vec(index+1) = field%val(jx,jy,jz)
-          index = index+1
-        end do
-      end do
-    end do
-  end do
-
-end subroutine soca_state_serialize
-
-
-! ------------------------------------------------------------------------------
-subroutine soca_state_deserialize(self, geom, vec_size, vec, index)
-  class(soca_state),    intent(inout) :: self
-  type(soca_geom),      intent(in)    :: geom
-  integer,              intent(in)    :: vec_size
-  real(kind=kind_real), intent(in)    :: vec(vec_size)
-  integer,              intent(inout) :: index
-
-
-  integer :: i, jx, jy, jz
-  type(soca_field), pointer :: field
-
-  ! Loop over fields, levels and horizontal points
-  do i=1,size(self%fields)
-    field => self%fields(i)
-    do jz=1,field%nz
-      do jy=geom%jsc,geom%jec
-        do jx=geom%isc,geom%iec
-          field%val(jx,jy,jz) = vec(index+1)
-          index = index+1
-        end do
-      end do
-    end do
-  end do
-
-end subroutine soca_state_deserialize
 
 end module


### PR DESCRIPTION
## Description

This fixes the increment/state serialize/deserialize that was started in https://github.com/JCSDA/soca/pull/442

- methods of the Fortan `State` and `Increment` were move to the `Fields` base class.
- use fortran slicing notation instead of nested for loops
- fix `c_int` / `c_size_t` mixup in the interface

### Issue(s) addressed

- closes #453 

## Testing

`interface/Increment/testIncrementSerialize` now passes with the serialization code enabled