### PR TITLE
fix interface and geometry iterator test

### DIFF
--- a/src/soca/Increment/Increment.cc
+++ b/src/soca/Increment/Increment.cc
@@ -132,7 +132,7 @@ namespace soca {
   }
   // -----------------------------------------------------------------------------
   void Increment::accumul(const double & zz, const State & xx) {
-    soca_increment_axpy_f90(toFortran(), zz, xx.toFortran());
+    soca_increment_accumul_f90(toFortran(), zz, xx.toFortran());
   }
   // -----------------------------------------------------------------------------
   void Increment::schur_product_with(const Increment & dx) {

--- a/src/soca/Increment/IncrementFortran.h
+++ b/src/soca/Increment/IncrementFortran.h
@@ -37,6 +37,8 @@ namespace soca {
     void soca_increment_self_add_f90(const F90flds &, const F90flds &);
     void soca_increment_self_sub_f90(const F90flds &, const F90flds &);
     void soca_increment_self_mul_f90(const F90flds &, const double &);
+    void soca_increment_accumul_f90(const F90flds &, const double &,
+                                    const F90flds &);
     void soca_increment_axpy_f90(const F90flds &, const double &,
                                  const F90flds &);
     void soca_increment_dot_prod_f90(const F90flds &, const F90flds &,

--- a/src/soca/Increment/soca_increment.interface.F90
+++ b/src/soca/Increment/soca_increment.interface.F90
@@ -179,6 +179,25 @@ subroutine soca_increment_create_c(c_key_self, c_key_geom, c_vars) bind(c,name='
 
   ! ------------------------------------------------------------------------------
 
+  subroutine soca_increment_accumul_c(c_key_self,c_zz,c_key_rhs) bind(c,name='soca_increment_accumul_f90')
+    integer(c_int), intent(in) :: c_key_self
+    real(c_double), intent(in) :: c_zz
+    integer(c_int), intent(in) :: c_key_rhs
+
+    type(soca_increment), pointer :: self
+    real(kind=kind_real)          :: zz
+    type(soca_state),     pointer :: rhs
+
+    call soca_increment_registry%get(c_key_self,self)
+    call soca_state_registry%get(c_key_rhs,rhs)
+    zz = c_zz
+
+    call self%axpy(zz,rhs)
+
+  end subroutine soca_increment_accumul_c
+
+  ! ------------------------------------------------------------------------------
+
   subroutine soca_increment_axpy_c(c_key_self,c_zz,c_key_rhs) bind(c,name='soca_increment_axpy_f90')
     integer(c_int), intent(in) :: c_key_self
     real(c_double), intent(in) :: c_zz

--- a/test/testinput/geometry_iterator.yml
+++ b/test/testinput/geometry_iterator.yml
@@ -6,4 +6,5 @@ geometry:
 
 inc variables: [cicen, hicen, socn, tocn, ssh, hocn]
 
-test date: &date 2018-04-15T00:00:00Z
+increment test:
+  date: &date 2018-04-15T00:00:00Z

--- a/test/testinput/increment.yml
+++ b/test/testinput/increment.yml
@@ -6,7 +6,8 @@ geometry:
 
 inc variables: [cicen, hicen, socn, tocn, ssh, hocn, sw, lw, lhf, shf, us]
 
-test date: &date 2018-04-15T00:00:00Z
+increment test:
+  date: &date 2018-04-15T00:00:00Z
 
 initial condition:
   read_from_file: 1


### PR DESCRIPTION
## Description

someone made a change to the yaml syntax required for the interface and geometry iterator tests. Good to know. All tests should pass.... for now.... the day is early. (https://github.com/JCSDA/oops/pull/868)

I guess I forgot to change branches before doing that fix, and my `accumul` fix snuck in here. Might as well merge that as well because it will get tested soon anyway. `Increment::accumul()` was just using the `axpy` interface, but it can't do that because `axpy` takes an increment, whereas `accumul` takes a state. as a result it was using the wrong registry in the interface . Luckily it seems nothing we have was actually using `accumul` . This will get tested later.