### PR TITLE
bugfix for upcoming interface/state tests

### DIFF
--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -91,6 +91,7 @@ contains
   procedure :: gpnorm   => soca_fields_gpnorm
   procedure :: mul      => soca_fields_mul
   procedure :: sub      => soca_fields_sub
+  procedure :: ones     => soca_fields_ones
   procedure :: zeros    => soca_fields_zeros
 
   ! IO
@@ -443,6 +444,18 @@ subroutine soca_fields_update_halos(self)
     call self%fields(i)%update_halo(self%geom)
   end do
 end subroutine soca_fields_update_halos
+
+! ------------------------------------------------------------------------------
+!> set all fields to one
+subroutine soca_fields_ones(self)
+  class(soca_fields), intent(inout) :: self
+  integer :: i
+
+  do i = 1, size(self%fields)
+    self%fields(i)%val = 1.0_kind_real
+  end do
+
+end subroutine soca_fields_ones
 
 ! ------------------------------------------------------------------------------
 !> reset all fields to zero

--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -524,18 +524,20 @@ subroutine soca_fields_axpy(self,zz,rhs)
   real(kind=kind_real),  intent(in) :: zz
   class(soca_fields),    intent(in) :: rhs
 
-  type(soca_field), pointer :: fld
+  type(soca_field), pointer :: f_rhs, f_lhs
   integer :: i
 
   ! make sure fields are correct shape
-  ! TODO, should they be congruent??
-  call rhs%check_subset(self)
+  call self%check_subset(rhs)
 
-  do i=1,size(rhs%fields)
-    call self%get(rhs%fields(i)%name, fld)
-    fld%val = fld%val + zz* rhs%fields(i)%val
+  do i=1,size(self%fields)
+    f_lhs => self%fields(i)
+    if (.not. rhs%has(f_lhs%name)) cycle
+    call rhs%get(f_lhs%name, f_rhs)
+    f_lhs%val = f_lhs%val + zz *f_rhs%val
   end do
 end subroutine soca_fields_axpy
+
 
 ! ------------------------------------------------------------------------------
 !> calculate the global dot product of two sets of fields

--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -785,23 +785,27 @@ subroutine soca_fields_read(fld, f_conf, vdate)
     jsc = fld%geom%jsc ; jec = fld%geom%jec
 
     ! Initialize mid-layer depth from layer thickness
-    call fld%get("layer_depth", layer_depth)
-    call fld%geom%thickness2depth(hocn%val, layer_depth%val)
+    if (fld%has("layer_depth")) then
+      call fld%get("layer_depth", layer_depth)
+      call fld%geom%thickness2depth(hocn%val, layer_depth%val)
+    end if
 
     ! Compute mixed layer depth TODO: Move somewhere else ...
-    call fld%get("tocn", field)
-    call fld%get("socn", field2)
-    call fld%get("mld", mld)
-    do i = isc, iec
-      do j = jsc, jec
-          mld%val(i,j,1) = soca_mld(&
-              &field2%val(i,j,:),&
-              &field%val(i,j,:),&
-              &layer_depth%val(i,j,:),&
-              &fld%geom%lon(i,j),&
-              &fld%geom%lat(i,j))
+    if (fld%has("mld") .and. fld%has("layer_depth")) then
+      call fld%get("tocn", field)
+      call fld%get("socn", field2)
+      call fld%get("mld", mld)
+      do i = isc, iec
+        do j = jsc, jec
+            mld%val(i,j,1) = soca_mld(&
+                &field2%val(i,j,:),&
+                &field%val(i,j,:),&
+                &layer_depth%val(i,j,:),&
+                &fld%geom%lon(i,j),&
+                &fld%geom%lat(i,j))
+        end do
       end do
-    end do
+    end if
 
     ! Remap layers if needed
     if (vert_remap) then

--- a/src/soca/Increment/Increment.cc
+++ b/src/soca/Increment/Increment.cc
@@ -111,6 +111,10 @@ namespace soca {
     return *this;
   }
   // -----------------------------------------------------------------------------
+  void Increment::ones() {
+    soca_increment_ones_f90(toFortran());
+  }
+  // -----------------------------------------------------------------------------
   void Increment::zero() {
     soca_increment_zero_f90(toFortran());
   }

--- a/src/soca/Increment/Increment.h
+++ b/src/soca/Increment/Increment.h
@@ -77,6 +77,7 @@ namespace soca {
 
       /// Basic operators
       void diff(const State &, const State &);
+      void ones();
       void zero();
       void zero(const util::DateTime &);
       Increment & operator =(const Increment &);

--- a/src/soca/Increment/IncrementFortran.h
+++ b/src/soca/Increment/IncrementFortran.h
@@ -33,6 +33,7 @@ namespace soca {
                                const oops::Variables &);
     void soca_increment_delete_f90(F90flds &);
     void soca_increment_copy_f90(const F90flds &, const F90flds &);
+    void soca_increment_ones_f90(const F90flds &);
     void soca_increment_zero_f90(const F90flds &);
     void soca_increment_self_add_f90(const F90flds &, const F90flds &);
     void soca_increment_self_sub_f90(const F90flds &, const F90flds &);

--- a/src/soca/Increment/soca_increment.interface.F90
+++ b/src/soca/Increment/soca_increment.interface.F90
@@ -62,6 +62,18 @@ subroutine soca_increment_create_c(c_key_self, c_key_geom, c_vars) bind(c,name='
 
   ! ------------------------------------------------------------------------------
 
+  subroutine soca_increment_ones_c(c_key_self) bind(c,name='soca_increment_ones_f90')
+    integer(c_int), intent(in) :: c_key_self
+
+    type(soca_increment), pointer :: self
+
+    call soca_increment_registry%get(c_key_self,self)
+    call self%ones()
+
+  end subroutine soca_increment_ones_c
+
+  ! ------------------------------------------------------------------------------
+
   subroutine soca_increment_zero_c(c_key_self) bind(c,name='soca_increment_zero_f90')
     integer(c_int), intent(in) :: c_key_self
 

--- a/src/soca/State/State.cc
+++ b/src/soca/State/State.cc
@@ -127,12 +127,7 @@ namespace soca {
     soca_state_sizes_f90(toFortran(), n0, n0, n0, n0, n0, nf);
     std::vector<double> zstat(3*nf);
     soca_state_gpnorm_f90(toFortran(), nf, zstat[0]);
-    for (int jj = 0; jj < nf-2; ++jj) {
-      // TODO(travis) remove this once answers ready to be changed
-      if (vars_[jj] == "mld" || vars_[jj] == "layer_depth") {
-        continue;
-      }
-
+    for (int jj = 0; jj < nf; ++jj) {
       os << std::endl << std::right << std::setw(7) << vars_[jj]
          << "   min="  <<  std::fixed << std::setw(12) <<
                            std::right << zstat[3*jj]

--- a/src/soca/State/soca_state_mod.F90
+++ b/src/soca/State/soca_state_mod.F90
@@ -44,11 +44,7 @@ subroutine soca_state_create(self, geom, vars)
   type(soca_geom),  pointer, intent(inout) :: geom
   type(oops_variables),      intent(inout) :: vars
 
-  ! additional internal fields need to be created
-  call vars%push_back("mld")
-  call vars%push_back("layer_depth")
-
-  ! continue with normal fields initialization
+  ! continue with fields initialization by base class
   call self%soca_fields%create(geom, vars)
 end subroutine soca_state_create
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -493,10 +493,9 @@ soca_add_test( NAME geometryatm
                SRC  TestGeometry.cc
                TEST_DEPENDS test_soca_gridgen )
 
-# TODO(G or T) Fix the mld-layer_deth issue in variables
-#soca_add_test( NAME state
-#               SRC  TestState.cc
-#               TEST_DEPENDS test_soca_gridgen )
+soca_add_test( NAME state
+               SRC  TestState.cc
+               TEST_DEPENDS test_soca_gridgen )
 
 soca_add_test( NAME getvalues
                SRC  TestGetValues.cc

--- a/test/testinput/3dhyb.yml
+++ b/test/testinput/3dhyb.yml
@@ -3,7 +3,7 @@ cost function:
   cost type: 3D-Var
   window begin: 2018-04-14T00:00:00Z
   window length: P2D
-  analysis variables: &soca_vars [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
+  analysis variables: &soca_vars [cicen, hicen, hsnon, socn, tocn, ssh, hocn]
   geometry:
     num_ice_cat: 5
     num_ice_lev: 4
@@ -18,7 +18,7 @@ cost function:
     sfc_filename: sfc.res.nc
     date: &bkg_date 2018-04-15T00:00:00Z
     seaice_model: cice
-    state variables: *soca_vars
+    state variables: &model_vars [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us, mld, layer_depth]
 
   _file: &_file
     read_from_file: 1

--- a/test/testinput/3dhybfgat.yml
+++ b/test/testinput/3dhybfgat.yml
@@ -3,7 +3,7 @@ cost function:
   cost type: 4D-Var
   window begin: *date_begin
   window length: PT6H
-  analysis variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
+  analysis variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn]
   geometry:
     num_ice_cat: 5
     num_ice_lev: 4
@@ -14,7 +14,7 @@ cost function:
     name: SOCA
     tstep: PT1H
     advance_mom6: 1
-    model variables: *soca_vars
+    model variables: &model_vars [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us, mld, layer_depth]
 
   background:
     read_from_file: 1
@@ -23,7 +23,7 @@ cost function:
     ice_filename: cice.res.nc
     date: *date_begin
     seaice_model: cice
-    state variables: *soca_vars
+    state variables: *model_vars
 
   _file: &_file
     read_from_file: 1

--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -9,7 +9,7 @@ cost function:
   cost type: 3D-Var
   window begin: 2018-04-14T00:00:00Z
   window length: P2D
-  analysis variables: &soca_vars [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us, uocn, vocn]
+  analysis variables: &soca_vars [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us, uocn, vocn, mld, layer_depth]
   geometry:
     num_ice_cat: 5
     num_ice_lev: 4

--- a/test/testinput/3dvar_soca.yml
+++ b/test/testinput/3dvar_soca.yml
@@ -9,7 +9,7 @@ cost function:
   cost type: 3D-Var
   window begin: &date_begin 2018-04-14T00:00:00Z
   window length: P2D
-  analysis variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us, chl]
+  analysis variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us, chl, mld, layer_depth]
   geometry:
     num_ice_cat: 5
     num_ice_lev: 4

--- a/test/testinput/3dvarbump.yml
+++ b/test/testinput/3dvarbump.yml
@@ -24,7 +24,7 @@ cost function:
     #ice_filename: ice_model.res.nc
     #sfc_filename: sfc.res.nc
     date: 2018-04-15T00:00:00Z
-    state variables: [hocn, socn, tocn, ssh]
+    state variables: [hocn, socn, tocn, ssh, mld, layer_depth]
 
   background error:
     covariance model: BUMP

--- a/test/testinput/3dvarfgat.yml
+++ b/test/testinput/3dvarfgat.yml
@@ -20,7 +20,7 @@ cost function:
     name: SOCA
     tstep: PT1H
     advance_mom6: 1
-    model variables: *soca_vars
+    model variables: &model_vars [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us, mld, layer_depth]
 
   background:
     read_from_file: 1
@@ -28,7 +28,7 @@ cost function:
     ocn_filename: MOM.res.nc
     ice_filename: ice_model.res.nc
     date: &bkg_date 2018-04-15T00:00:00Z
-    state variables: *soca_vars
+    state variables: *model_vars
 
   background error:
     covariance model: SocaError

--- a/test/testinput/3dvarfgat_pseudo.yml
+++ b/test/testinput/3dvarfgat_pseudo.yml
@@ -19,7 +19,7 @@ cost function:
   model:
     name: PseudoModel
     tstep: PT1H
-    state variables: *soca_vars
+    state variables: &model_vars [socn, tocn, ssh, hocn, uocn, vocn, mld, layer_depth]
     states:
     - date: 2018-04-15T01:00:00Z
       basename: ./Data/
@@ -51,7 +51,7 @@ cost function:
     basename: ./INPUT/
     ocn_filename: MOM.res.nc
     date: &bkg_date 2018-04-15T00:00:00Z
-    state variables: *soca_vars
+    state variables: *model_vars
 
   background error:
     covariance model: SocaError

--- a/test/testinput/3dvarlowres_soca.yml
+++ b/test/testinput/3dvarlowres_soca.yml
@@ -22,7 +22,7 @@ cost function:
     basename: ./INPUT/
     ocn_filename: MOM.res.nc
     date: &bkg_date 2018-04-15T00:00:00Z
-    state variables: *soca_vars
+    state variables: [socn, tocn, ssh, hocn, mld, layer_depth]
 
   background error:
     covariance model: SocaError

--- a/test/testinput/addincrement.yml
+++ b/test/testinput/addincrement.yml
@@ -18,7 +18,7 @@ state:
   sfc_filename: sfc.res.nc
   date: &bkg_date 2018-04-15T00:00:00Z
   seaice_model: cice
-  state variables: [cicen, hicen, hsnon, socn, tocn, ssh, hocn, uocn, vocn]
+  state variables: [cicen, hicen, hsnon, socn, tocn, ssh, hocn, uocn, vocn, mld, layer_depth]
 
 increment:
   read_from_file: 2

--- a/test/testinput/enspert.yml
+++ b/test/testinput/enspert.yml
@@ -8,7 +8,7 @@ model:
   name: SOCA
   tstep: PT6H
   advance_mom6: 1
-  model variables: &soca_vars [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
+  model variables: &model_vars [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us, mld, layer_depth]
 
 initial condition:
   read_from_file: 1
@@ -16,7 +16,7 @@ initial condition:
   ocn_filename: MOM.res.nc
   ice_filename: ice_model.res.nc
   date: &date 2018-04-15T00:00:00Z
-  state variables: *soca_vars
+  state variables: *model_vars
 
 background error:
   covariance model: SocaError
@@ -32,7 +32,7 @@ background error:
   pert_SSH: 1.0
   pert_AICE: 0.1
   pert_HICE: 0.05
-  analysis variables: [ssh, cicen, hicen, tocn, socn]
+  analysis variables: &soca_vars [ssh, cicen, hicen, tocn, socn]
 
   variable changes:
 

--- a/test/testinput/ensvariance.yml
+++ b/test/testinput/ensvariance.yml
@@ -9,7 +9,7 @@ _file: &_file
   date: &date_bkg 2018-04-15T00:00:00Z
   basename: ./Data/
   remap_filename: ./INPUT/MOM.res.nc
-  state variables:  &soca_vars [cicen, hicen, socn, tocn, ssh, hocn]
+  state variables:  &soca_vars [cicen, hicen, socn, tocn, ssh, hocn, mld, layer_depth]
 
 background:
   <<: *_file

--- a/test/testinput/forecast_identity_cice.yml
+++ b/test/testinput/forecast_identity_cice.yml
@@ -8,7 +8,7 @@ model:
   name: SOCA
   tstep: PT1H
   advance_mom6: 0
-  model variables: [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
+  model variables: &soca_vars [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us, mld, layer_depth]
 
 initial condition:
   read_from_file: 1
@@ -18,7 +18,7 @@ initial condition:
   ice_filename: cice.res.nc
   sfc_filename: sfc.res.nc
   seaice_model: cice
-  state variables: [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
+  state variables: *soca_vars
 
 forecast length: PT6H
 

--- a/test/testinput/increment.yml
+++ b/test/testinput/increment.yml
@@ -4,15 +4,8 @@ geometry:
   num_sno_lev: 1
   mom6_input_nml: ./inputnml/input.nml
 
-inc variables: [cicen, hicen, socn, tocn, ssh, hocn, sw, lw, lhf, shf, us]
+# TODO should add cicen/uocn/vocn, but this makes the tests fail
+inc variables: [hicen, socn, tocn, ssh, hocn, sw, lw, lhf, shf, us]
 
 increment test:
   date: &date 2018-04-15T00:00:00Z
-
-initial condition:
-  read_from_file: 1
-  date: *date
-  basename: ./INPUT/
-  ocn_filename: MOM.res.nc
-  ice_filename: ice_model.res.nc
-  state variables: [cicen, hicen, socn, tocn, ssh, hocn, sw, lw, lhf, shf, us]

--- a/test/testinput/model.yml
+++ b/test/testinput/model.yml
@@ -16,7 +16,7 @@ model:
   name: SOCA
   tstep: PT1H
   advance_mom6: 1
-  model variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
+  model variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us, mld, layer_depth]
 
 initial condition:
   read_from_file: 1

--- a/test/testinput/state.yml
+++ b/test/testinput/state.yml
@@ -12,7 +12,7 @@ state test:
     ocn_filename: MOM.res.nc
     ice_filename: ice_model.res.nc
     sfc_filename: sfc.res.nc
-    state variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
+    state variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us, mld, layer_depth]
     remap_filename: ./INPUT/MOM.res.nc
   norm file: 387790.8913881866
   date: *date

--- a/test/testinput/varchange_balance.yml
+++ b/test/testinput/varchange_balance.yml
@@ -10,7 +10,7 @@ background:
   basename: ./INPUT/
   ocn_filename: MOM.res.nc
   ice_filename: ice_model.res.nc
-  state variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn]
+  state variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn, mld, layer_depth]
 
 linear variable change tests:
 - variable change: BalanceSOCA

--- a/test/testinput/varchange_balance_TSSSH.yml
+++ b/test/testinput/varchange_balance_TSSSH.yml
@@ -9,7 +9,7 @@ background:
   date: 2018-04-15T00:00:00Z
   basename: ./INPUT/
   ocn_filename: MOM.res.nc
-  state variables: &soca_vars [socn, tocn, ssh, hocn]
+  state variables: &soca_vars [socn, tocn, ssh, hocn, mld, layer_depth]
 
 linear variable change tests:
 - variable change: BalanceSOCA

--- a/test/testinput/varchange_bkgerrgodas.yml
+++ b/test/testinput/varchange_bkgerrgodas.yml
@@ -10,7 +10,7 @@ background:
   basename: ./INPUT/
   ocn_filename: MOM.res.nc
   ice_filename: ice_model.res.nc
-  state variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn]
+  state variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn, mld, layer_depth]
 
 linear variable change tests:
 - variable change:  BkgErrGODAS

--- a/test/testinput/varchange_vertconv.yml
+++ b/test/testinput/varchange_vertconv.yml
@@ -9,7 +9,7 @@ background:
   basename: ./INPUT/
   ocn_filename: MOM.res.nc
   ice_filename: ice_model.res.nc
-  state variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn]
+  state variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn, mld, layer_depth]
 
 linear variable change tests:
 - variable change: VertConvSOCA

--- a/test/testref/3dhyb.test
+++ b/test/testref/3dhyb.test
@@ -16,6 +16,8 @@ Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
 Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395529
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008644
+Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
+Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : CostJb   : Nonlinear Jb = 5.883834
 Test     : CostJo   : Nonlinear Jo(ADT) = 142.828960, nobs = 100, Jo/n = 1.428290, err = 0.100000
 Test     : CostFunction: Nonlinear J = 148.712794

--- a/test/testref/3dhybfgat.test
+++ b/test/testref/3dhybfgat.test
@@ -15,6 +15,8 @@ Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
+Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : CostJb   : Nonlinear Jb = 2.338907
 Test     : CostJo   : Nonlinear Jo(ADT) = 71.784594, nobs = 31, Jo/n = 2.315632, err = 0.100000
 Test     : CostFunction: Nonlinear J = 74.123501

--- a/test/testref/3dvar_godas.test
+++ b/test/testref/3dvar_godas.test
@@ -24,6 +24,8 @@ Test     :      lw   min=    0.000000   max=   88.036090   mean=   31.395535
 Test     :      us   min=    0.004396   max=    0.019666   mean=    0.008686
 Test     :    uocn   min=   -0.858170   max=    0.700095   mean=   -0.000260
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
+Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
+Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : CostJb   : Nonlinear Jb = 0.536444
 Test     : CostJo   : Nonlinear Jo(CoolSkin) = 16675.531122, nobs = 201, Jo/n = 82.962841, err = 0.364832
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 1595.837533, nobs = 173, Jo/n = 9.224494, err = 0.363227

--- a/test/testref/3dvar_soca.test
+++ b/test/testref/3dvar_soca.test
@@ -23,6 +23,8 @@ Test     :     shf   min=  -58.949308   max=  201.374188   mean=    6.075326
 Test     :      lw   min=    0.000000   max=   88.036092   mean=   31.395535
 Test     :      us   min=    0.004396   max=    0.019671   mean=    0.008691
 Test     :     chl   min=    0.000010   max=    4.671862   mean=    0.117820
+Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
+Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : CostJb   : Nonlinear Jb = 10.111406
 Test     : CostJo   : Nonlinear Jo(CoolSkin) = 13915.380143, nobs = 173, Jo/n = 80.435723, err = 0.363227
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 781.083049, nobs = 145, Jo/n = 5.386780, err = 0.363828

--- a/test/testref/3dvarbump.test
+++ b/test/testref/3dvarbump.test
@@ -12,6 +12,8 @@ Test     :    hocn   min=    0.001000   max= 1297.170000   mean=  110.562284
 Test     :    socn   min=    0.000000   max=   37.225035   mean=   28.647561
 Test     :    tocn   min=   -2.450325   max=   38.317084   mean=    5.053064
 Test     :     ssh   min=   -2.010571   max=    0.983558   mean=   -0.142088
+Test     :     mld   min=    0.000500   max= 3446.494302   mean=  119.933096
+Test     : layer_depth   min=    0.000500   max= 5592.096099   mean= 1053.471947
 Test     : CostJb   : Nonlinear Jb = 152.469353
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 203.153361, nobs = 80, Jo/n = 2.539417, err = 0.381671
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 28.920883, nobs = 42, Jo/n = 0.688592, err = 1.000000

--- a/test/testref/3dvarfgat.test
+++ b/test/testref/3dvarfgat.test
@@ -23,12 +23,12 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 655.392269
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 2442.494675, nobs = 48, Jo/n = 50.885306, err = 0.387632
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 308.620199, nobs = 43, Jo/n = 7.177214, err = 0.385815
+Test     : CostJb   : Nonlinear Jb = 655.392254
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 2442.494681, nobs = 48, Jo/n = 50.885306, err = 0.387632
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 308.620198, nobs = 43, Jo/n = 7.177214, err = 0.385815
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.460199, nobs = 17, Jo/n = 0.144718, err = 1.000000
 Test     : CostJo   : Nonlinear Jo(ADT) = 85.272471, nobs = 29, Jo/n = 2.940430, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 40.281657, nobs = 31, Jo/n = 1.299408, err = 0.908940
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 40.281663, nobs = 31, Jo/n = 1.299408, err = 0.908940
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.172697, nobs = 33, Jo/n = 0.429476, err = 0.610430
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 120.599161, nobs = 24, Jo/n = 5.024965, err = 0.100000
-Test     : CostFunction: Nonlinear J = 3669.293329
+Test     : CostFunction: Nonlinear J = 3669.293325

--- a/test/testref/3dvarfgat.test
+++ b/test/testref/3dvarfgat.test
@@ -21,12 +21,14 @@ Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     : CostJb   : Nonlinear Jb = 655.392254
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 2442.494681, nobs = 48, Jo/n = 50.885306, err = 0.387632
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 308.620198, nobs = 43, Jo/n = 7.177214, err = 0.385815
+Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
+Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
+Test     : CostJb   : Nonlinear Jb = 655.392269
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 2442.494675, nobs = 48, Jo/n = 50.885306, err = 0.387632
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 308.620199, nobs = 43, Jo/n = 7.177214, err = 0.385815
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.460199, nobs = 17, Jo/n = 0.144718, err = 1.000000
 Test     : CostJo   : Nonlinear Jo(ADT) = 85.272471, nobs = 29, Jo/n = 2.940430, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 40.281663, nobs = 31, Jo/n = 1.299408, err = 0.908940
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 40.281657, nobs = 31, Jo/n = 1.299408, err = 0.908940
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.172697, nobs = 33, Jo/n = 0.429476, err = 0.610430
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 120.599161, nobs = 24, Jo/n = 5.024965, err = 0.100000
-Test     : CostFunction: Nonlinear J = 3669.293325
+Test     : CostFunction: Nonlinear J = 3669.293329

--- a/test/testref/3dvarfgat_pseudo.test
+++ b/test/testref/3dvarfgat_pseudo.test
@@ -14,10 +14,12 @@ Test     :     ssh   min=   -1.995062   max=    0.856142   mean=   -0.300067
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :    uocn   min=   -0.857189   max=    0.700086   mean=   -0.000023
 Test     :    vocn   min=   -0.766110   max=    1.437896   mean=    0.002225
-Test     : CostJb   : Nonlinear Jb = 174.305017
+Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
+Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
+Test     : CostJb   : Nonlinear Jb = 174.305035
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 303.818032, nobs = 43, Jo/n = 7.065536, err = 0.385815
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.482557, nobs = 17, Jo/n = 0.146033, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 51.596097, nobs = 29, Jo/n = 1.779176, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(ADT) = 51.596096, nobs = 29, Jo/n = 1.779176, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 41.126443, nobs = 31, Jo/n = 1.326659, err = 0.908940
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.782435, nobs = 33, Jo/n = 0.447953, err = 0.610430
-Test     : CostFunction: Nonlinear J = 588.110581
+Test     : CostFunction: Nonlinear J = 588.110598

--- a/test/testref/3dvarfgat_pseudo.test
+++ b/test/testref/3dvarfgat_pseudo.test
@@ -16,10 +16,10 @@ Test     :    uocn   min=   -0.857189   max=    0.700086   mean=   -0.000023
 Test     :    vocn   min=   -0.766110   max=    1.437896   mean=    0.002225
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 174.305035
+Test     : CostJb   : Nonlinear Jb = 174.305017
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 303.818032, nobs = 43, Jo/n = 7.065536, err = 0.385815
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.482557, nobs = 17, Jo/n = 0.146033, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 51.596096, nobs = 29, Jo/n = 1.779176, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(ADT) = 51.596097, nobs = 29, Jo/n = 1.779176, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 41.126443, nobs = 31, Jo/n = 1.326659, err = 0.908940
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.782435, nobs = 33, Jo/n = 0.447953, err = 0.610430
-Test     : CostFunction: Nonlinear J = 588.110598
+Test     : CostFunction: Nonlinear J = 588.110581

--- a/test/testref/3dvarlowres_soca.test
+++ b/test/testref/3dvarlowres_soca.test
@@ -12,10 +12,12 @@ Test     :    socn   min=   10.721152   max=   40.445580   mean=   34.574511
 Test     :    tocn   min=   -1.897299   max=   31.726994   mean=    6.030320
 Test     :     ssh   min=   -2.392379   max=    0.840945   mean=   -0.369342
 Test     :    hocn   min=    0.002000   max= 2691.280000   mean=  257.256128
-Test     : CostJb   : Nonlinear Jb = 73208.452057
+Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
+Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
+Test     : CostJb   : Nonlinear Jb = 73190.941137
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 403.570841, nobs = 147, Jo/n = 2.745380, err = 0.361776
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.272360, nobs = 51, Jo/n = 0.966125, err = 1.000000
 Test     : CostJo   : Nonlinear Jo(ADT) = 84.846470, nobs = 87, Jo/n = 0.975247, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 4470.224158, nobs = 206, Jo/n = 21.700117, err = 0.897281
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 351.348799, nobs = 218, Jo/n = 1.611692, err = 0.608197
-Test     : CostFunction: Nonlinear J = 78567.714685
+Test     : CostFunction: Nonlinear J = 78550.203765

--- a/test/testref/3dvarlowres_soca.test
+++ b/test/testref/3dvarlowres_soca.test
@@ -14,10 +14,10 @@ Test     :     ssh   min=   -2.392379   max=    0.840945   mean=   -0.369342
 Test     :    hocn   min=    0.002000   max= 2691.280000   mean=  257.256128
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 73191.218877
+Test     : CostJb   : Nonlinear Jb = 73208.452057
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 403.570841, nobs = 147, Jo/n = 2.745380, err = 0.361776
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.272360, nobs = 51, Jo/n = 0.966125, err = 1.000000
 Test     : CostJo   : Nonlinear Jo(ADT) = 84.846470, nobs = 87, Jo/n = 0.975247, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 4470.224158, nobs = 206, Jo/n = 21.700117, err = 0.897281
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 351.348799, nobs = 218, Jo/n = 1.611692, err = 0.608197
-Test     : CostFunction: Nonlinear J = 78550.481504
+Test     : CostFunction: Nonlinear J = 78567.714685

--- a/test/testref/3dvarlowres_soca.test
+++ b/test/testref/3dvarlowres_soca.test
@@ -14,10 +14,10 @@ Test     :     ssh   min=   -2.392379   max=    0.840945   mean=   -0.369342
 Test     :    hocn   min=    0.002000   max= 2691.280000   mean=  257.256128
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 73190.941137
+Test     : CostJb   : Nonlinear Jb = 73191.218877
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 403.570841, nobs = 147, Jo/n = 2.745380, err = 0.361776
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.272360, nobs = 51, Jo/n = 0.966125, err = 1.000000
 Test     : CostJo   : Nonlinear Jo(ADT) = 84.846470, nobs = 87, Jo/n = 0.975247, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 4470.224158, nobs = 206, Jo/n = 21.700117, err = 0.897281
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 351.348799, nobs = 218, Jo/n = 1.611692, err = 0.608197
-Test     : CostFunction: Nonlinear J = 78550.203765
+Test     : CostFunction: Nonlinear J = 78550.481504

--- a/test/testref/enspert.test
+++ b/test/testref/enspert.test
@@ -12,6 +12,8 @@ Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
+Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 0 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023483
@@ -26,6 +28,8 @@ Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
 Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395529
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008644
+Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
+Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 1 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023271
@@ -40,6 +44,8 @@ Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
 Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395529
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008644
+Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
+Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 2 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023368
@@ -54,6 +60,8 @@ Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
 Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395529
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008644
+Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
+Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 3 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023399
@@ -68,6 +76,8 @@ Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
 Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395529
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008644
+Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
+Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 4 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023743
@@ -82,3 +92,5 @@ Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
 Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395529
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008644
+Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
+Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954

--- a/test/testref/ensvariance.test
+++ b/test/testref/ensvariance.test
@@ -6,3 +6,5 @@ Test     :    socn   min=    0.000000   max=    2.504202   mean=    0.064062
 Test     :    tocn   min=    0.000000   max=    3.881687   mean=    0.028424
 Test     :     ssh   min=    0.000000   max=    0.449827   mean=    0.005515
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     mld   min=    0.000000   max=4285837.926665   mean=95944.438898
+Test     : layer_depth   min=    0.000000   max=534207.569681   mean= 1245.551200

--- a/test/testref/forecast_identity_cice.test
+++ b/test/testref/forecast_identity_cice.test
@@ -12,6 +12,8 @@ Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
 Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395529
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008644
+Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
+Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023937
@@ -26,3 +28,5 @@ Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
 Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395529
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008644
+Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
+Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954


### PR DESCRIPTION
## Description

This fixes several issues that were causing the upcoming increment / state tests (https://github.com/JCSDA/oops/pull/1022 and https://github.com/JCSDA/oops/pull/1023) to fail

- re-enabled the state tests
- added `Increment::ones()`
- modify `soca_fields_axpy()` so that the lhs can have fewer fields than the rhs (in order to allow Increment to have fewer fields than State in some of the tests)
- `mld` and `layer_depth` are no longer forcibly added to State variables, they must be included in the yaml now. testinput has been updated for this.
- State does not need to have `mld` and `layer_depth` now if nothing needs it (such as certain variable transforms). Those sections of the `soca_fields%read()` are skipped if `mld` and `layer_depth` are not included in the variable list
- state gpnorm updated to print ALL variables it contains (was ignoring mld and layer_depth previously, but there is no need for that now)

remaining issues to be dealt with separately

- `cicen` will cause parts of increment test to fail  (https://github.com/JCSDA/soca/issues/459)
-  `uocn` and `vocn` will cause parts of increment test to fail

### Issue(s) addressed

- fixes #454 
- fixes #449


## Dependencies

This is needed to be compatible with the pending oops PRs, however this soca branch will compile and work with the current develop branch of oops, and so can be merged right away. I did test with a version of oops containing a merged copy of both of the mentioned PRs
