### PR TITLE
Wrong axis naming in cice.res.nc

### DIFF
--- a/test/Data/72x35x25/INPUT/cice.res.nc
+++ b/test/Data/72x35x25/INPUT/cice.res.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7d106249b034c0437e2964549261d20f31d64f0cd1136e8ae764ceb345e179ac
-size 143351
+oid sha256:9a74d3692a3f048ec109809184a502a65cb7fd8d3a47c4c3f3f4f948c03ea8ca
+size 139232


### PR DESCRIPTION
## Description
Naming convention in cice.res.nc is wrong. lonq, latq should be lonh, lath. 

**What was done**
Removed the unused lonq, latq variables and renamed the axis to lonh, lath.

![cice res nc](https://user-images.githubusercontent.com/14031856/95806583-09b00f80-0cd6-11eb-8759-f82c9e96418d.png)
 
### Issue(s) addressed
closes #463 
