### PR TITLE
Use ATLAS instead of STRIPACK to generate meshes

### DIFF
--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -32,11 +32,6 @@ if ( BUILD_CRTM )
   ecbuild_bundle( PROJECT crtm          GIT "https://github.com/JCSDA/crtm.git"            UPDATE BRANCH develop )
 endif ()
 
-option(BUILD_METIS "download and build METIS (required for points remapping in BUMP)")
-if ( BUILD_METIS )
-  ecbuild_bundle( PROJECT metis         GIT "https://github.com/JCSDA/metis.git"           UPDATE BRANCH develop )
-endif ()
-
 option(BUILD_FMS "download and build fms" ON)
 if ( BUILD_FMS )
   ecbuild_bundle( PROJECT fms           GIT "https://github.com/JCSDA/FMS.git"             UPDATE BRANCH release-stable-ecbuild )

--- a/test/testref/3dhyb.test
+++ b/test/testref/3dhyb.test
@@ -1,23 +1,23 @@
 Test     : CostJb   : Nonlinear Jb = 0
 Test     : CostJo   : Nonlinear Jo(ADT) = 224.622, nobs = 100, Jo/n = 2.24622, err = 0.1
 Test     : CostFunction: Nonlinear J = 224.622
-Test     : RPCGMinimizer: reduction in residual norm = 0.567025
+Test     : RPCGMinimizer: reduction in residual norm = 0.382339
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023967
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023939
 Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.115987
 Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.562844
-Test     :    tocn   min=   -1.906352   max=   31.700465   mean=    6.011403
-Test     :     ssh   min=   -2.339636   max=    0.921909   mean=   -0.287151
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.546542
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.016836
+Test     :     ssh   min=   -2.293457   max=    0.916564   mean=   -0.278063
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :      sw   min= -225.097763   max=    0.000000   mean=  -71.739321
+Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
 Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395529
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008644
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 5.883834
-Test     : CostJo   : Nonlinear Jo(ADT) = 142.828960, nobs = 100, Jo/n = 1.428290, err = 0.100000
-Test     : CostFunction: Nonlinear J = 148.712794
+Test     : CostJb   : Nonlinear Jb = 13.179296
+Test     : CostJo   : Nonlinear Jo(ADT) = 131.709153, nobs = 100, Jo/n = 1.317092, err = 0.100000
+Test     : CostFunction: Nonlinear J = 144.888449

--- a/test/testref/3dhybfgat.test
+++ b/test/testref/3dhybfgat.test
@@ -1,14 +1,14 @@
 Test     : CostJb   : Nonlinear Jb = 0
 Test     : CostJo   : Nonlinear Jo(ADT) = 88.4792, nobs = 31, Jo/n = 2.85417, err = 0.1
 Test     : CostFunction: Nonlinear J = 88.4792
-Test     : RPCGMinimizer: reduction in residual norm = 0.489985
+Test     : RPCGMinimizer: reduction in residual norm = 0.311255
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023949
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023937
 Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.115987
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.550859
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.013511
-Test     :     ssh   min=   -1.924420   max=    0.913775   mean=   -0.283256
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544016
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017118
+Test     :     ssh   min=   -1.924497   max=    0.919340   mean=   -0.277123
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
@@ -17,6 +17,6 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 2.338907
-Test     : CostJo   : Nonlinear Jo(ADT) = 71.784594, nobs = 31, Jo/n = 2.315632, err = 0.100000
-Test     : CostFunction: Nonlinear J = 74.123501
+Test     : CostJb   : Nonlinear Jb = 4.682573
+Test     : CostJo   : Nonlinear Jo(ADT) = 74.609468, nobs = 31, Jo/n = 2.406757, err = 0.100000
+Test     : CostFunction: Nonlinear J = 79.292041

--- a/test/testref/3dvar_godas.test
+++ b/test/testref/3dvar_godas.test
@@ -7,31 +7,31 @@ Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 343.523, nobs = 206, Jo/
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 350.504, nobs = 218, Jo/n = 1.60782, err = 0.608197
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 370.055, nobs = 89, Jo/n = 4.15792, err = 0.1
 Test     : CostFunction: Nonlinear J = 20228.2
-Test     : RPCGMinimizer: reduction in residual norm = 0.130645
-Test     : CostFunction::addIncrement: Analysis:
+Test     : RPCGMinimizer: reduction in residual norm = 0.231814
+Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023945
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023940
 Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.115987
 Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544421
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018248
-Test     :     ssh   min=   -1.924847   max=    0.927291   mean=   -0.276779
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544395
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017687
+Test     :     ssh   min=   -1.924521   max=    0.927291   mean=   -0.276786
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :      sw   min= -225.094437   max=    0.000000   mean=  -71.738390
-Test     :     lhf   min=  -38.137473   max=  256.595744   mean=   42.009726
-Test     :     shf   min=  -58.949303   max=  201.374228   mean=    6.075328
-Test     :      lw   min=    0.000000   max=   88.036090   mean=   31.395535
-Test     :      us   min=    0.004396   max=    0.019666   mean=    0.008686
-Test     :    uocn   min=   -0.858170   max=    0.700095   mean=   -0.000260
+Test     :      sw   min= -225.097763   max=    0.000000   mean=  -71.739030
+Test     :     lhf   min=  -38.137398   max=  256.595357   mean=   42.009940
+Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075333
+Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395531
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008656
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 0.536443
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 16675.531122, nobs = 201, Jo/n = 82.962841, err = 0.364832
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 1595.837533, nobs = 173, Jo/n = 9.224494, err = 0.363227
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.011841, nobs = 51, Jo/n = 0.961016, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 212.793260, nobs = 95, Jo/n = 2.239929, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 341.912673, nobs = 206, Jo/n = 1.659770, err = 0.897281
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 348.966110, nobs = 218, Jo/n = 1.600762, err = 0.608197
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 368.695358, nobs = 89, Jo/n = 4.142644, err = 0.100000
-Test     : CostFunction: Nonlinear J = 19593.284341
+Test     : CostJb   : Nonlinear Jb = 0.822395
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 16725.154841, nobs = 201, Jo/n = 83.209726, err = 0.364832
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 1584.409214, nobs = 173, Jo/n = 9.158435, err = 0.363227
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.007960, nobs = 51, Jo/n = 0.960940, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 212.744423, nobs = 95, Jo/n = 2.239415, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 342.128833, nobs = 206, Jo/n = 1.660820, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 348.362322, nobs = 218, Jo/n = 1.597992, err = 0.608197
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 368.837031, nobs = 89, Jo/n = 4.144236, err = 0.100000
+Test     : CostFunction: Nonlinear J = 19631.467018

--- a/test/testref/3dvar_soca.test
+++ b/test/testref/3dvar_soca.test
@@ -8,30 +8,30 @@ Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 350.504, nobs = 218, Jo/n =
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 679.22, nobs = 89, Jo/n = 7.63169, err = 0.1
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceChlorophyll) = 1536.63, nobs = 129, Jo/n = 11.9119, err = 0.061865
 Test     : CostFunction: Nonlinear J = 18383.4
-Test     : RPCGMinimizer: reduction in residual norm = 0.177451
+Test     : RPCGMinimizer: reduction in residual norm = 0.275551
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    0.999973   mean=    0.023547
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023511
 Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544418
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.019545
-Test     :     ssh   min=   -1.924689   max=    0.927289   mean=   -0.276709
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544393
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017906
+Test     :     ssh   min=   -1.924496   max=    0.927284   mean=   -0.276773
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :      sw   min= -225.095244   max=    0.000000   mean=  -71.738232
-Test     :     lhf   min=  -38.137487   max=  256.595653   mean=   42.009659
-Test     :     shf   min=  -58.949308   max=  201.374188   mean=    6.075326
-Test     :      lw   min=    0.000000   max=   88.036092   mean=   31.395535
-Test     :      us   min=    0.004396   max=    0.019671   mean=    0.008691
-Test     :     chl   min=    0.000010   max=    4.671862   mean=    0.117820
+Test     :      sw   min= -225.097763   max=    0.000000   mean=  -71.739040
+Test     :     lhf   min=  -38.137398   max=  256.595097   mean=   42.009943
+Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075333
+Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395531
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008656
+Test     :     chl   min=    0.000010   max=    4.671990   mean=    0.118165
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 10.111406
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 13915.380143, nobs = 173, Jo/n = 80.435723, err = 0.363227
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 781.083049, nobs = 145, Jo/n = 5.386780, err = 0.363828
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.012319, nobs = 51, Jo/n = 0.961026, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 159.414728, nobs = 92, Jo/n = 1.732769, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 343.435269, nobs = 206, Jo/n = 1.667162, err = 0.897281
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 348.770746, nobs = 218, Jo/n = 1.599866, err = 0.608197
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 671.616068, nobs = 89, Jo/n = 7.546248, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceChlorophyll) = 1273.732848, nobs = 129, Jo/n = 9.873898, err = 0.061865
-Test     : CostFunction: Nonlinear J = 17552.556576
+Test     : CostJb   : Nonlinear Jb = 3.888123
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 13994.334300, nobs = 173, Jo/n = 80.892106, err = 0.363227
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 782.876729, nobs = 145, Jo/n = 5.399150, err = 0.363828
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.008900, nobs = 51, Jo/n = 0.960959, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 159.420742, nobs = 92, Jo/n = 1.732834, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 343.460701, nobs = 206, Jo/n = 1.667285, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 348.788049, nobs = 218, Jo/n = 1.599945, err = 0.608197
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 675.229623, nobs = 89, Jo/n = 7.586850, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceChlorophyll) = 1213.441220, nobs = 129, Jo/n = 9.406521, err = 0.061865
+Test     : CostFunction: Nonlinear J = 17570.448387

--- a/test/testref/3dvarbump.test
+++ b/test/testref/3dvarbump.test
@@ -5,19 +5,19 @@ Test     : CostJo   : Nonlinear Jo(ADT) = 512.768, nobs = 84, Jo/n = 6.10438, er
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 450.497, nobs = 134, Jo/n = 3.36192, err = 0.913795
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 412864, nobs = 218, Jo/n = 1893.87, err = 0.608197
 Test     : CostFunction: Nonlinear J = 414470
-Test     : RPCGMinimizer: reduction in residual norm = 0.124988
+Test     : RPCGMinimizer: reduction in residual norm = 0.125976
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    hocn   min=    0.001000   max= 1297.170000   mean=  110.562284
-Test     :    socn   min=    0.000000   max=   37.225035   mean=   28.647561
-Test     :    tocn   min=   -2.450325   max=   38.317084   mean=    5.053064
-Test     :     ssh   min=   -2.010571   max=    0.983558   mean=   -0.142088
+Test     :    socn   min=    0.000000   max=   36.718327   mean=   28.614104
+Test     :    tocn   min=   -1.859573   max=   37.199936   mean=    5.090820
+Test     :     ssh   min=   -1.850956   max=    0.860843   mean=   -0.089986
 Test     :     mld   min=    0.000500   max= 3446.494302   mean=  119.933096
 Test     : layer_depth   min=    0.000500   max= 5592.096099   mean= 1053.471947
-Test     : CostJb   : Nonlinear Jb = 152.469353
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 203.153361, nobs = 80, Jo/n = 2.539417, err = 0.381671
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 28.920883, nobs = 42, Jo/n = 0.688592, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 138.470070, nobs = 84, Jo/n = 1.648453, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 210.699780, nobs = 134, Jo/n = 1.572386, err = 0.913795
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 411580.885932, nobs = 218, Jo/n = 1887.985715, err = 0.608197
-Test     : CostFunction: Nonlinear J = 412314.599379
+Test     : CostJb   : Nonlinear Jb = 204.385703
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 191.015578, nobs = 80, Jo/n = 2.387695, err = 0.381671
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 26.148292, nobs = 42, Jo/n = 0.622578, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 80.757313, nobs = 84, Jo/n = 0.961397, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 167.386306, nobs = 134, Jo/n = 1.249152, err = 0.913795
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 411485.377245, nobs = 218, Jo/n = 1887.547602, err = 0.608197
+Test     : CostFunction: Nonlinear J = 412155.070438

--- a/test/testref/3dvarfgat.test
+++ b/test/testref/3dvarfgat.test
@@ -23,12 +23,12 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 370.653848
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 2622.749045, nobs = 48, Jo/n = 54.640605, err = 0.387632
+Test     : CostJb   : Nonlinear Jb = 370.653849
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 2622.749044, nobs = 48, Jo/n = 54.640605, err = 0.387632
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 312.004259, nobs = 43, Jo/n = 7.255913, err = 0.385815
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.457895, nobs = 17, Jo/n = 0.144582, err = 1.000000
 Test     : CostJo   : Nonlinear Jo(ADT) = 85.508255, nobs = 29, Jo/n = 2.948561, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 40.340083, nobs = 31, Jo/n = 1.301293, err = 0.908940
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.194864, nobs = 33, Jo/n = 0.430147, err = 0.610430
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 40.340086, nobs = 31, Jo/n = 1.301293, err = 0.908940
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.194858, nobs = 33, Jo/n = 0.430147, err = 0.610430
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 130.822788, nobs = 24, Jo/n = 5.450949, err = 0.100000
-Test     : CostFunction: Nonlinear J = 3578.731037
+Test     : CostFunction: Nonlinear J = 3578.731034

--- a/test/testref/3dvarfgat.test
+++ b/test/testref/3dvarfgat.test
@@ -7,14 +7,14 @@ Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 41.1264, nobs = 31, Jo/n
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.7824, nobs = 33, Jo/n = 0.447953, err = 0.61043
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 255.973, nobs = 24, Jo/n = 10.6655, err = 0.1
 Test     : CostFunction: Nonlinear J = 3826.16
-Test     : RPCGMinimizer: reduction in residual norm = 0.627496
+Test     : RPCGMinimizer: reduction in residual norm = 0.48582
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    0.999998   mean=    0.026564
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.024100
 Test     :   hicen   min=    0.000000   max=    2.265451   mean=    0.094250
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.546697
-Test     :    tocn   min=   -3.966116   max=   31.700465   mean=    6.008829
-Test     :     ssh   min=   -1.925886   max=    0.927186   mean=   -0.277404
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544614
+Test     :    tocn   min=   -3.259415   max=   31.700465   mean=    6.017685
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276786
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
@@ -23,12 +23,12 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 655.392254
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 2442.494681, nobs = 48, Jo/n = 50.885306, err = 0.387632
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 308.620198, nobs = 43, Jo/n = 7.177214, err = 0.385815
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.460199, nobs = 17, Jo/n = 0.144718, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 85.272471, nobs = 29, Jo/n = 2.940430, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 40.281663, nobs = 31, Jo/n = 1.299408, err = 0.908940
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.172697, nobs = 33, Jo/n = 0.429476, err = 0.610430
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 120.599161, nobs = 24, Jo/n = 5.024965, err = 0.100000
-Test     : CostFunction: Nonlinear J = 3669.293325
+Test     : CostJb   : Nonlinear Jb = 370.653848
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 2622.749045, nobs = 48, Jo/n = 54.640605, err = 0.387632
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 312.004259, nobs = 43, Jo/n = 7.255913, err = 0.385815
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.457895, nobs = 17, Jo/n = 0.144582, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 85.508255, nobs = 29, Jo/n = 2.948561, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 40.340083, nobs = 31, Jo/n = 1.301293, err = 0.908940
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.194864, nobs = 33, Jo/n = 0.430147, err = 0.610430
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 130.822788, nobs = 24, Jo/n = 5.450949, err = 0.100000
+Test     : CostFunction: Nonlinear J = 3578.731037

--- a/test/testref/3dvarfgat_pseudo.test
+++ b/test/testref/3dvarfgat_pseudo.test
@@ -5,21 +5,21 @@ Test     : CostJo   : Nonlinear Jo(ADT) = 86.7406, nobs = 29, Jo/n = 2.99106, er
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 41.1264, nobs = 31, Jo/n = 1.32666, err = 0.90894
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.7824, nobs = 33, Jo/n = 0.447953, err = 0.61043
 Test     : CostFunction: Nonlinear J = 451.517
-Test     : RPCGMinimizer: reduction in residual norm = 0.887085
+Test     : RPCGMinimizer: reduction in residual norm = 0.740088
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.553889
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.016146
-Test     :     ssh   min=   -1.995062   max=    0.856142   mean=   -0.300067
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.545420
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017544
+Test     :     ssh   min=   -2.039979   max=    0.927283   mean=   -0.278632
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 174.249862
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 303.818032, nobs = 43, Jo/n = 7.065536, err = 0.385815
+Test     : CostJb   : Nonlinear Jb = 44.485383
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 305.137960, nobs = 43, Jo/n = 7.096232, err = 0.385815
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.482557, nobs = 17, Jo/n = 0.146033, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 51.596097, nobs = 29, Jo/n = 1.779176, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(ADT) = 48.950681, nobs = 29, Jo/n = 1.687955, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 41.126443, nobs = 31, Jo/n = 1.326659, err = 0.908940
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.782435, nobs = 33, Jo/n = 0.447953, err = 0.610430
-Test     : CostFunction: Nonlinear J = 588.055426
+Test     : CostFunction: Nonlinear J = 456.965459

--- a/test/testref/3dvarfgat_pseudo.test
+++ b/test/testref/3dvarfgat_pseudo.test
@@ -16,10 +16,10 @@ Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 44.485383
+Test     : CostJb   : Nonlinear Jb = 44.485377
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 305.137960, nobs = 43, Jo/n = 7.096232, err = 0.385815
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.482557, nobs = 17, Jo/n = 0.146033, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 48.950681, nobs = 29, Jo/n = 1.687955, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(ADT) = 48.950683, nobs = 29, Jo/n = 1.687955, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 41.126443, nobs = 31, Jo/n = 1.326659, err = 0.908940
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.782435, nobs = 33, Jo/n = 0.447953, err = 0.610430
-Test     : CostFunction: Nonlinear J = 456.965459
+Test     : CostFunction: Nonlinear J = 456.965455

--- a/test/testref/3dvarlowres_soca.test
+++ b/test/testref/3dvarlowres_soca.test
@@ -14,10 +14,10 @@ Test     :     ssh   min=   -2.412433   max=    0.915336   mean=   -0.352418
 Test     :    hocn   min=    0.002000   max= 2691.280000   mean=  257.256128
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 74041.854732
+Test     : CostJb   : Nonlinear Jb = 74051.947212
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 328.390183, nobs = 147, Jo/n = 2.233947, err = 0.361776
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 48.915117, nobs = 51, Jo/n = 0.959120, err = 1.000000
 Test     : CostJo   : Nonlinear Jo(ADT) = 75.183569, nobs = 87, Jo/n = 0.864179, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 4520.522118, nobs = 206, Jo/n = 21.944282, err = 0.897281
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 330.725259, nobs = 218, Jo/n = 1.517088, err = 0.608197
-Test     : CostFunction: Nonlinear J = 79345.590979
+Test     : CostFunction: Nonlinear J = 79355.683459

--- a/test/testref/3dvarlowres_soca.test
+++ b/test/testref/3dvarlowres_soca.test
@@ -5,19 +5,19 @@ Test     : CostJo   : Nonlinear Jo(ADT) = 147.738, nobs = 87, Jo/n = 1.69814, er
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 343.523, nobs = 206, Jo/n = 1.66759, err = 0.897281
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 350.504, nobs = 218, Jo/n = 1.60782, err = 0.608197
 Test     : CostFunction: Nonlinear J = 1659.2
-Test     : RPCGMinimizer: reduction in residual norm = 0.351858
+Test     : RPCGMinimizer: reduction in residual norm = 0.26939
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721152   max=   40.445580   mean=   34.574511
-Test     :    tocn   min=   -1.897299   max=   31.726994   mean=    6.030320
-Test     :     ssh   min=   -2.392379   max=    0.840945   mean=   -0.369342
+Test     :    socn   min=   10.721046   max=   40.442689   mean=   34.570152
+Test     :    tocn   min=   -1.893751   max=   31.780435   mean=    6.041802
+Test     :     ssh   min=   -2.412433   max=    0.915336   mean=   -0.352418
 Test     :    hocn   min=    0.002000   max= 2691.280000   mean=  257.256128
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 73208.452057
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 403.570841, nobs = 147, Jo/n = 2.745380, err = 0.361776
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.272360, nobs = 51, Jo/n = 0.966125, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 84.846470, nobs = 87, Jo/n = 0.975247, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 4470.224158, nobs = 206, Jo/n = 21.700117, err = 0.897281
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 351.348799, nobs = 218, Jo/n = 1.611692, err = 0.608197
-Test     : CostFunction: Nonlinear J = 78567.714685
+Test     : CostJb   : Nonlinear Jb = 74041.854732
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 328.390183, nobs = 147, Jo/n = 2.233947, err = 0.361776
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 48.915117, nobs = 51, Jo/n = 0.959120, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 75.183569, nobs = 87, Jo/n = 0.864179, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 4520.522118, nobs = 206, Jo/n = 21.944282, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 330.725259, nobs = 218, Jo/n = 1.517088, err = 0.608197
+Test     : CostFunction: Nonlinear J = 79345.590979

--- a/test/testref/balance_mask.test
+++ b/test/testref/balance_mask.test
@@ -12,5 +12,5 @@ Test     :   cicen   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :   hicen   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :    socn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :    tocn   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     :     ssh   min=    0.000000   max=    1.000000   mean=    0.066007
+Test     :     ssh   min=    0.000000   max=    1.000000   mean=    0.003786
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000

--- a/test/testref/checkpointmodel.test
+++ b/test/testref/checkpointmodel.test
@@ -14,12 +14,12 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023945
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023940
 Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.115987
 Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544421
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018248
-Test     :     ssh   min=   -1.924847   max=    0.927291   mean=   -0.276779
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544395
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017687
+Test     :     ssh   min=   -1.924521   max=    0.927291   mean=   -0.276786
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
@@ -28,12 +28,12 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : output background: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023945
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023940
 Test     :   hicen   min=    0.000000   max=    2.923064   mean=    0.115987
 Test     :   hsnon   min=    0.000000   max=    0.608625   mean=    0.028358
-Test     :    socn   min=   10.721046   max=   38.000000   mean=   34.539801
-Test     :    tocn   min=   -1.800000   max=   31.700465   mean=    6.018387
-Test     :     ssh   min=   -1.924847   max=    0.927291   mean=   -0.276779
+Test     :    socn   min=   10.721046   max=   38.000000   mean=   34.539775
+Test     :    tocn   min=   -1.800000   max=   31.700465   mean=    6.017826
+Test     :     ssh   min=   -1.924521   max=    0.927291   mean=   -0.276786
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000

--- a/test/testref/dirac_soca_cov.test
+++ b/test/testref/dirac_soca_cov.test
@@ -10,11 +10,11 @@ Test     :     mld   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : layer_depth   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : B * Increment: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.048402   max=    0.000000   mean=   -0.000436
-Test     :   hicen   min=    0.000000   max=  100.000000   mean=    0.131457
-Test     :    socn   min=   -0.037491   max=    0.282721   mean=    0.000287
-Test     :    tocn   min=    0.000000   max=    5.268716   mean=    0.018760
-Test     :     ssh   min=   -0.001907   max=    0.056011   mean=    0.000717
+Test     :   cicen   min=   -0.048402   max=    0.000000   mean=   -0.000046
+Test     :   hicen   min=    0.000000   max=  100.000000   mean=    0.012173
+Test     :    socn   min=   -0.016775   max=    0.103294   mean=    0.000007
+Test     :    tocn   min=    0.000000   max=    5.268716   mean=    0.001737
+Test     :     ssh   min=   -0.001214   max=    0.056011   mean=    0.000085
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : layer_depth   min=    0.000000   max=    0.000000   mean=    0.000000

--- a/test/testref/dirac_socahyb_cov.test
+++ b/test/testref/dirac_socahyb_cov.test
@@ -10,11 +10,11 @@ Test     :     mld   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : layer_depth   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : B * Increment: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.024201   max=    0.000000   mean=   -0.000194
-Test     :   hicen   min=    0.000000   max=   50.000000   mean=    0.065729
-Test     :    socn   min=   -0.161677   max=    0.098265   mean=   -0.000190
-Test     :    tocn   min=   -0.009398   max=    2.790900   mean=    0.008644
-Test     :     ssh   min=   -0.000462   max=    0.086274   mean=    0.000642
+Test     :   cicen   min=   -0.024201   max=    0.000000   mean=   -0.000020
+Test     :   hicen   min=    0.000000   max=   50.000000   mean=    0.006086
+Test     :    socn   min=   -0.082132   max=    0.068185   mean=    0.000010
+Test     :    tocn   min=   -0.015006   max=    2.667214   mean=    0.000843
+Test     :     ssh   min=   -0.007843   max=    0.031099   mean=    0.000030
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : layer_depth   min=    0.000000   max=    0.000000   mean=    0.000000

--- a/test/testref/enspert.test
+++ b/test/testref/enspert.test
@@ -16,13 +16,13 @@ Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 0 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023483
-Test     :   hicen   min=   -1.719140   max=    2.671684   mean=    0.112486
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023431
+Test     :   hicen   min=   -1.942120   max=    2.758858   mean=    0.098928
 Test     :   hsnon   min=    0.000000   max=    0.674660   mean=    0.017737
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.553779
-Test     :    tocn   min=   -1.888232   max=   31.711300   mean=    6.009064
-Test     :     ssh   min=   -1.871776   max=    0.915031   mean=   -0.276741
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628072
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.541760
+Test     :    tocn   min=   -1.947776   max=   31.710843   mean=    6.011094
+Test     :     ssh   min=   -2.080819   max=    0.912915   mean=   -0.276773
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628067
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
@@ -32,13 +32,13 @@ Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 1 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023271
-Test     :   hicen   min=   -1.839142   max=    3.360503   mean=    0.105226
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023380
+Test     :   hicen   min=   -2.301490   max=    2.854819   mean=    0.097941
 Test     :   hsnon   min=    0.000000   max=    0.674660   mean=    0.017737
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.542907
-Test     :    tocn   min=   -1.911362   max=   31.711235   mean=    6.008198
-Test     :     ssh   min=   -1.900760   max=    0.908202   mean=   -0.276599
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628088
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.539344
+Test     :    tocn   min=   -1.904218   max=   31.711099   mean=    6.010970
+Test     :     ssh   min=   -2.081763   max=    0.907672   mean=   -0.276633
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628090
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
@@ -48,13 +48,13 @@ Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 2 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023368
-Test     :   hicen   min=   -1.958858   max=    2.920055   mean=    0.100950
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023424
+Test     :   hicen   min=   -1.784373   max=    3.222792   mean=    0.095686
 Test     :   hsnon   min=    0.000000   max=    0.674660   mean=    0.017737
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.533150
-Test     :    tocn   min=   -1.911347   max=   31.711504   mean=    6.009704
-Test     :     ssh   min=   -1.902320   max=    0.912202   mean=   -0.276382
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628111
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.537446
+Test     :    tocn   min=   -1.924342   max=   31.711429   mean=    6.009770
+Test     :     ssh   min=   -2.014069   max=    0.909076   mean=   -0.276382
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628113
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
@@ -64,13 +64,13 @@ Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 3 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023399
-Test     :   hicen   min=   -1.841900   max=    3.016463   mean=    0.091114
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023390
+Test     :   hicen   min=   -2.079102   max=    2.880655   mean=    0.093230
 Test     :   hsnon   min=    0.000000   max=    0.674660   mean=    0.017737
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.543025
-Test     :    tocn   min=   -1.888761   max=   31.711512   mean=    6.015925
-Test     :     ssh   min=   -1.891510   max=    0.910825   mean=   -0.276170
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628110
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.544738
+Test     :    tocn   min=   -1.888373   max=   31.711838   mean=    6.011418
+Test     :     ssh   min=   -1.929267   max=    0.901604   mean=   -0.276169
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628111
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
@@ -80,13 +80,13 @@ Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 4 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023743
-Test     :   hicen   min=   -1.791553   max=    3.179430   mean=    0.097358
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023555
+Test     :   hicen   min=   -1.840380   max=    2.946154   mean=    0.094911
 Test     :   hsnon   min=    0.000000   max=    0.674660   mean=    0.017737
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.558091
-Test     :    tocn   min=   -1.909253   max=   31.711081   mean=    6.011292
-Test     :     ssh   min=   -1.884366   max=    0.909684   mean=   -0.276150
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628073
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.542907
+Test     :    tocn   min=   -1.927639   max=   31.711397   mean=    6.008401
+Test     :     ssh   min=   -1.960688   max=    0.903406   mean=   -0.276121
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628083
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334

--- a/test/testref/ensrecenter.test
+++ b/test/testref/ensrecenter.test
@@ -1,88 +1,88 @@
 Test     : Original member 0 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023483
-Test     :   hicen   min=   -0.001900   max=    0.002952   mean=    0.000124
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.555962
-Test     :    tocn   min=   -1.888232   max=   31.711300   mean=    6.005688
-Test     :     ssh   min=   -1.871776   max=    0.915031   mean=   -0.276741
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023431
+Test     :   hicen   min=   -0.002146   max=    0.003048   mean=    0.000109
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.543743
+Test     :    tocn   min=   -1.947774   max=   31.710843   mean=    6.007700
+Test     :     ssh   min=   -2.080819   max=    0.912915   mean=   -0.276773
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Original member 1 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023271
-Test     :   hicen   min=   -0.002032   max=    0.003713   mean=    0.000116
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.546160
-Test     :    tocn   min=   -1.911361   max=   31.711235   mean=    6.002526
-Test     :     ssh   min=   -1.900760   max=    0.908202   mean=   -0.276599
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023380
+Test     :   hicen   min=   -0.002543   max=    0.003154   mean=    0.000108
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.542068
+Test     :    tocn   min=   -1.904166   max=   31.711099   mean=    6.006142
+Test     :     ssh   min=   -2.081763   max=    0.907672   mean=   -0.276633
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Original member 2 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023368
-Test     :   hicen   min=   -0.002164   max=    0.003227   mean=    0.000112
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.534832
-Test     :    tocn   min=   -1.911347   max=   31.711504   mean=    6.003366
-Test     :     ssh   min=   -1.902320   max=    0.912202   mean=   -0.276382
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023424
+Test     :   hicen   min=   -0.001972   max=    0.003561   mean=    0.000106
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.540152
+Test     :    tocn   min=   -1.924342   max=   31.711429   mean=    6.004006
+Test     :     ssh   min=   -2.014069   max=    0.909076   mean=   -0.276382
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Original member 3 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023399
-Test     :   hicen   min=   -0.002035   max=    0.003333   mean=    0.000101
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.544689
-Test     :    tocn   min=   -1.888761   max=   31.711512   mean=    6.008622
-Test     :     ssh   min=   -1.891510   max=    0.910825   mean=   -0.276170
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023390
+Test     :   hicen   min=   -0.002297   max=    0.003183   mean=    0.000103
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.547196
+Test     :    tocn   min=   -1.888373   max=   31.711838   mean=    6.002952
+Test     :     ssh   min=   -1.929267   max=    0.901604   mean=   -0.276169
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Original member 4 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023743
-Test     :   hicen   min=   -0.001980   max=    0.003513   mean=    0.000108
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.559258
-Test     :    tocn   min=   -1.909252   max=   31.711081   mean=    6.001754
-Test     :     ssh   min=   -1.884366   max=    0.909684   mean=   -0.276150
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023555
+Test     :   hicen   min=   -0.002034   max=    0.003255   mean=    0.000105
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.544756
+Test     :    tocn   min=   -1.927639   max=   31.711397   mean=    5.997679
+Test     :     ssh   min=   -1.960688   max=    0.903406   mean=   -0.276121
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Ensemble mean: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    0.997424   mean=    0.023453
-Test     :   hicen   min=   -0.000868   max=    0.002760   mean=    0.000112
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.548180
-Test     :    tocn   min=   -1.888215   max=   31.711326   mean=    6.004391
-Test     :     ssh   min=   -1.865424   max=    0.911189   mean=   -0.276408
+Test     :   cicen   min=    0.000000   max=    0.998165   mean=    0.023436
+Test     :   hicen   min=   -0.000996   max=    0.002688   mean=    0.000106
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.543583
+Test     :    tocn   min=   -1.887857   max=   31.711321   mean=    6.003696
+Test     :     ssh   min=   -1.993873   max=    0.906140   mean=   -0.276415
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 0 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023488
-Test     :   hicen   min=   -0.001615   max=    2.265665   mean=    0.094263
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.552171
-Test     :    tocn   min=   -2.121962   max=   31.700438   mean=    6.018861
-Test     :     ssh   min=   -1.918572   max=    0.931125   mean=   -0.277123
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023455
+Test     :   hicen   min=   -0.001812   max=    2.265880   mean=    0.094253
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544550
+Test     :    tocn   min=   -2.322121   max=   31.699986   mean=    6.021569
+Test     :     ssh   min=   -1.989168   max=    0.934058   mean=   -0.277148
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 1 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023316
-Test     :   hicen   min=   -0.001719   max=    2.266448   mean=    0.094255
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.542369
-Test     :    tocn   min=   -2.176380   max=   31.700373   mean=    6.015700
-Test     :     ssh   min=   -1.904205   max=    0.924296   mean=   -0.276982
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023424
+Test     :   hicen   min=   -0.002009   max=    2.265639   mean=    0.094252
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.542874
+Test     :    tocn   min=   -2.469173   max=   31.700242   mean=    6.020011
+Test     :     ssh   min=   -1.950673   max=    0.928814   mean=   -0.277007
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 2 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023402
-Test     :   hicen   min=   -0.002130   max=    2.265107   mean=    0.094250
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.531042
-Test     :    tocn   min=   -2.155337   max=   31.700642   mean=    6.016540
-Test     :     ssh   min=   -1.900793   max=    0.928296   mean=   -0.276764
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023458
+Test     :   hicen   min=   -0.001723   max=    2.265302   mean=    0.094250
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.540959
+Test     :    tocn   min=   -2.180867   max=   31.700572   mean=    6.017875
+Test     :     ssh   min=   -1.930023   max=    0.930218   mean=   -0.276756
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 3 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023415
-Test     :   hicen   min=   -0.001786   max=    2.264288   mean=    0.094239
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.540899
-Test     :    tocn   min=   -2.241187   max=   31.700650   mean=    6.021796
-Test     :     ssh   min=   -1.964330   max=    0.926919   mean=   -0.276552
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023423
+Test     :   hicen   min=   -0.001852   max=    2.264428   mean=    0.094247
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.548003
+Test     :    tocn   min=   -2.460195   max=   31.700982   mean=    6.016821
+Test     :     ssh   min=   -2.035506   max=    0.922746   mean=   -0.276544
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 4 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023749
-Test     :   hicen   min=   -0.001742   max=    2.265747   mean=    0.094246
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.555468
-Test     :    tocn   min=   -2.296515   max=   31.700219   mean=    6.014928
-Test     :     ssh   min=   -2.028313   max=    0.925778   mean=   -0.276532
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023577
+Test     :   hicen   min=   -0.002052   max=    2.266007   mean=    0.094249
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.545562
+Test     :    tocn   min=   -2.487122   max=   31.700540   mean=    6.011548
+Test     :     ssh   min=   -2.015869   max=    0.920577   mean=   -0.276496
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064

--- a/test/testref/ensvariance.test
+++ b/test/testref/ensvariance.test
@@ -1,10 +1,10 @@
 Test     : Variance: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000000   max=    0.001193   mean=    0.000010
+Test     :   cicen   min=    0.000000   max=    0.001779   mean=    0.000010
 Test     :   hicen   min=    0.000000   max=    0.000002   mean=    0.000000
-Test     :    socn   min=    0.000000   max=    2.504202   mean=    0.064062
-Test     :    tocn   min=    0.000000   max=    3.881687   mean=    0.028424
-Test     :     ssh   min=    0.000000   max=    0.449827   mean=    0.005515
+Test     :    socn   min=    0.000000   max=    2.594663   mean=    0.064089
+Test     :    tocn   min=    0.000000   max=    4.200491   mean=    0.027429
+Test     :     ssh   min=    0.000000   max=    0.230016   mean=    0.003929
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     :     mld   min=    0.000000   max=4285837.926665   mean=95944.438898
-Test     : layer_depth   min=    0.000000   max=534207.569681   mean= 1245.551200
+Test     :     mld   min=    0.000000   max=4346419.768458   mean=85840.042767
+Test     : layer_depth   min=    0.000000   max=715111.721903   mean= 1426.856889

--- a/test/testref/ensvariance.test
+++ b/test/testref/ensvariance.test
@@ -7,4 +7,4 @@ Test     :    tocn   min=    0.000000   max=    4.200491   mean=    0.027429
 Test     :     ssh   min=    0.000000   max=    0.230016   mean=    0.003929
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    0.000000   max=4346419.768458   mean=85840.042767
-Test     : layer_depth   min=    0.000000   max=715111.721903   mean= 1426.856889
+Test     : layer_depth   min=    0.000000   max=715111.721901   mean= 1426.856889

--- a/test/testref/letkf.test
+++ b/test/testref/letkf.test
@@ -1,66 +1,66 @@
 Test     : Initial state for member 1:
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.553779
-Test     :    tocn   min=   -1.888232   max=   31.711300   mean=    6.009064
-Test     :     ssh   min=   -1.871776   max=    0.915031   mean=   -0.276741
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628072
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.541760
+Test     :    tocn   min=   -1.947776   max=   31.710843   mean=    6.011094
+Test     :     ssh   min=   -2.080819   max=    0.912915   mean=   -0.276773
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628067
 Test     : Initial state for member 2:
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.542907
-Test     :    tocn   min=   -1.911362   max=   31.711235   mean=    6.008198
-Test     :     ssh   min=   -1.900760   max=    0.908202   mean=   -0.276599
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628088
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.539344
+Test     :    tocn   min=   -1.904218   max=   31.711099   mean=    6.010970
+Test     :     ssh   min=   -2.081763   max=    0.907672   mean=   -0.276633
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628090
 Test     : Initial state for member 3:
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.533150
-Test     :    tocn   min=   -1.911347   max=   31.711504   mean=    6.009704
-Test     :     ssh   min=   -1.902320   max=    0.912202   mean=   -0.276382
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628111
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.537446
+Test     :    tocn   min=   -1.924342   max=   31.711429   mean=    6.009770
+Test     :     ssh   min=   -2.014069   max=    0.909076   mean=   -0.276382
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628113
 Test     : Initial state for member 4:
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.543025
-Test     :    tocn   min=   -1.888761   max=   31.711512   mean=    6.015925
-Test     :     ssh   min=   -1.891510   max=    0.910825   mean=   -0.276170
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628110
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.544738
+Test     :    tocn   min=   -1.888373   max=   31.711838   mean=    6.011418
+Test     :     ssh   min=   -1.929267   max=    0.901604   mean=   -0.276169
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628111
 Test     : Initial state for member 5:
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.558091
-Test     :    tocn   min=   -1.909253   max=   31.711081   mean=    6.011292
-Test     :     ssh   min=   -1.884366   max=    0.909684   mean=   -0.276150
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628073
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.542907
+Test     :    tocn   min=   -1.927639   max=   31.711397   mean=    6.008401
+Test     :     ssh   min=   -1.960688   max=    0.903406   mean=   -0.276121
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628083
 Test     : H(x) for member 1:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.989938, Max=30.635348, RMS=24.134892
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.989938, Max=30.640072, RMS=24.129849
 Test     : H(x) for member 2:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.990173, Max=30.552313, RMS=24.143773
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.990173, Max=30.522534, RMS=24.134863
 Test     : H(x) for member 3:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.990299, Max=30.658198, RMS=24.136941
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.990300, Max=30.653767, RMS=24.128657
 Test     : H(x) for member 4:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.990285, Max=30.528468, RMS=24.122853
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.990287, Max=30.587968, RMS=24.127498
 Test     : H(x) for member 5:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.990194, Max=30.675729, RMS=24.145010
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.990208, Max=30.650347, RMS=24.138998
 Test     : H(x) ensemble background mean: 
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.990178, Max=30.610011, RMS=24.136578
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.990181, Max=30.610938, RMS=24.131903
 Test     : background y - H(x): 
-Test     : SeaSurfaceTemp nobs= 201 Min=-5.030729, Max=4.376730, RMS=1.333374
+Test     : SeaSurfaceTemp nobs= 201 Min=-5.078795, Max=4.313797, RMS=1.329287
 Test     : Background mean :
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.546190
-Test     :    tocn   min=   -1.888215   max=   31.711326   mean=    6.010837
-Test     :     ssh   min=   -1.865424   max=    0.911189   mean=   -0.276408
-Test     :    hocn   min=    0.001000   max= 1341.993909   mean=  128.628091
+Test     :    socn   min=   10.720592   max=   40.441655   mean=   34.541239
+Test     :    tocn   min=   -1.887857   max=   31.711321   mean=    6.010331
+Test     :     ssh   min=   -1.993873   max=    0.906140   mean=   -0.276415
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628093
 Test     : H(x) for member 1:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.989933, Max=30.610826, RMS=24.105150
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.989934, Max=30.618518, RMS=24.088066
 Test     : H(x) for member 2:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.990172, Max=30.526473, RMS=24.114085
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.990173, Max=30.499209, RMS=24.093239
 Test     : H(x) for member 3:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.990301, Max=30.634047, RMS=24.107459
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.990302, Max=30.632373, RMS=24.087326
 Test     : H(x) for member 4:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.990287, Max=30.502221, RMS=24.093296
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.990290, Max=30.565561, RMS=24.085745
 Test     : H(x) for member 5:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.990194, Max=30.651910, RMS=24.115162
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.990209, Max=30.628965, RMS=24.097271
 Test     : H(x) ensemble analysis mean: 
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.990177, Max=30.585096, RMS=24.106920
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.990182, Max=30.588925, RMS=24.090260
 Test     : analysis y - H(x): 
-Test     : SeaSurfaceTemp nobs= 201 Min=-4.357089, Max=4.364544, RMS=1.232827
-Test     : ombg RMS: 1.333374
-Test     : oman RMS: 1.232827
+Test     : SeaSurfaceTemp nobs= 201 Min=-4.666036, Max=4.312163, RMS=1.235737
+Test     : ombg RMS: 1.329287
+Test     : oman RMS: 1.235737


### PR DESCRIPTION
## Description

Update tests references to take into account the modifications of PR https://github.com/JCSDA/saber/pull/177.
Contrary to FV3 and MPAS, differences for SOCA are significant. Maybe a deeper analysis would be needed here.

### Issue(s) addressed

- SABER PR potentially fixes issue https://github.com/JCSDA/saber/issues/62

## Dependencies

Waiting on the following PRs:
- waiting on https://github.com/JCSDA/saber/pull/177

## Impact

No impact.