### PR TITLE
Fix misc travisci stuff

### DIFF
--- a/.github/travisci/Dockerfile
+++ b/.github/travisci/Dockerfile
@@ -1,13 +1,5 @@
 FROM  jcsda/docker-gnu-openmpi-dev:latest
 
-RUN cd /usr/local/src \
-    && curl -L -O https://github.com/ccache/ccache/releases/download/v3.7.4/ccache-3.7.4.tar.gz \
-    && tar -xaf ccache-3.7.4.tar.gz \
-    && cd ccache-3.7.4 \
-    && ./configure \
-    && make \
-    && make install
-
 RUN groupadd jcsda -g 9999 \
     && adduser jcsdauser \
     && mkdir -p /jcsda \

--- a/.github/travisci/build.sh
+++ b/.github/travisci/build.sh
@@ -14,9 +14,11 @@ set -e
 
 cwd=$(pwd)
 
+CCACHE=ccache-swig
+
 # zero out the ccache stats
 echo -e "\nzeroing out 'ccache' statistics"
-ccache -z
+$CCACHE -z
 
 # for each dependency repo...
 for repo in $LIB_REPOS; do
@@ -47,7 +49,7 @@ for repo in $LIB_REPOS; do
     build_opt_var=BUILD_OPT_${repo_underscore}
     build_opt="$BUILD_OPT ${!build_opt_var}"
     time ecbuild $src_dir -DCMAKE_INSTALL_PREFIX=${install_dir} -DCMAKE_BUILD_TYPE=${LIB_BUILD_TYPE} \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DENABLE_TESTS=OFF -DBUILD_TESTING=OFF $build_opt
+            -DCMAKE_CXX_COMPILER_LAUNCHER=$CCACHE -DENABLE_TESTS=OFF -DBUILD_TESTING=OFF $build_opt
 
     # build and install
     time make -j4
@@ -80,11 +82,11 @@ else
 fi
 
 
-time ecbuild $src_dir -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+time ecbuild $src_dir -DCMAKE_CXX_COMPILER_LAUNCHER=$CCACHE \
        -DCMAKE_BUILD_TYPE=${MAIN_BUILD_TYPE} $build_opt
 time make -j4
 
 
 # how useful was ccache?
 echo -e "\nccache statistics:"
-ccache -s
+$CCACHE -s

--- a/.github/travisci/stable_commit.sh
+++ b/.github/travisci/stable_commit.sh
@@ -22,10 +22,8 @@ cwd=$(pwd)
 cd repo.src/$MAIN_REPO
 ref_develop=$(git rev-parse HEAD)
 
-# get a modified source url.
-# (We have to modify it with a credential token so we can later push to github)
+# get a source url.
 url=$(git remote get-url origin)
-url=${url/github.com/"${GH_TOKEN}@github.com"}
 
 # check out release branch in a new directory
 # (otherwise, if we do it here, this script may change!)

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,25 +111,26 @@ before_install:
 script:
   - |
     # Build code
-    docker exec jcsda_container bash \
-     -c 'cd /jcsda/work && /jcsda/work/repo.src/${MAIN_REPO}/.github/travisci/build.sh'
+    docker exec -it jcsda_container bash \
+     -c 'cd /jcsda/work && /jcsda/work/repo.src/${MAIN_REPO}/.github/travisci/build.sh; exit $?' \
+     || travis_terminate 1
 
   - |
     # run tests
-    docker exec jcsda_container bash \
-     -c 'cd /jcsda/work/repo.build/${MAIN_REPO} && ctest --output-on-failure'
+    docker exec -it jcsda_container bash \
+     -c 'cd /jcsda/work/repo.build/${MAIN_REPO} && ctest --output-on-failure' \
+     || travis_terminate 1
 
+
+#======================================================================
+#======================================================================
+after_success:
   - |
     # upload code coverage
     docker exec jcsda_container bash -c \
       'cd /jcsda/work/repo.src/${MAIN_REPO} \
        && bash <(curl -s https://codecov.io/bash) -p /jcsda/work/repo.build/${MAIN_REPO} -s . -X gcovout'
 
-
-
-#======================================================================
-#======================================================================
-after_success:
   - |
     # If this is a cron run, update the release/stable branch of the bundle
     if [[ "$TRAVIS_EVENT_TYPE" == "cron" && "$TRAVIS_BRANCH" == "develop" ]]; then

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![travis_develop](https://travis-ci.com/JCSDA/soca.svg?token=Vu1Csdj6JEdxNw6xXKz8&branch=develop)](http://travis-ci.com/JCSDA/soca)
+[![Build Status](https://travis-ci.com/JCSDA-internal/soca.svg?branch=develop)](https://travis-ci.com/JCSDA-internal/soca)
 [![Documentation Status](https://readthedocs.com/projects/jointcenterforsatellitedataassimilation-soca/badge/?version=develop)](https://jointcenterforsatellitedataassimilation-soca.readthedocs-hosted.com/en/develop/?badge=develop)
 [![codecov](https://codecov.io/gh/JCSDA/soca/branch/develop/graph/badge.svg?token=uFJ62a68D7)](https://codecov.io/gh/JCSDA/soca)
 

--- a/README.md
+++ b/README.md
@@ -34,16 +34,13 @@ export BUILD_OPT_oops="-DENABLE_QG_MODEL=OFF -DENABLE_LORENZ95_MODEL=OFF"
 export BUILD_OPT_ufo="-DLOCAL_PATH_TESTFILES_IODA=NONE"
 export BUILD_OPT_soca="-DSOCA_TESTS_FORC_DEFAULT_TOL=ON -DCRTM_FIX_DIR=../../repo.src/crtm/fix"
 export MATCH_REPOS="atlas oops saber ioda ioda-converters ufo soca"
-export LFS_REPOS="crtm"
+export LFS_REPOS=""
 export REPO_CACHE="/path/to/somewhere/repo.cache"
 mkdir -p repo.src
 cd repo.src
 git clone https://github.com/JCSDA/soca.git
 cd ..
 ./repo.src/soca/.github/travisci/prep.sh
-```
-Note that ccache needs to be installed or loaded. If testing within singularity, swap ccache with ccache-swig in `./github/travisci/build.sh`.
-```
  ./repo.src/soca/.github/travisci/build.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Build Status](https://travis-ci.com/JCSDA-internal/soca.svg?branch=develop)](https://travis-ci.com/JCSDA-internal/soca)
 [![Documentation Status](https://readthedocs.com/projects/jointcenterforsatellitedataassimilation-soca/badge/?version=develop)](https://jointcenterforsatellitedataassimilation-soca.readthedocs-hosted.com/en/develop/?badge=develop)
-[![codecov](https://codecov.io/gh/JCSDA/soca/branch/develop/graph/badge.svg?token=uFJ62a68D7)](https://codecov.io/gh/JCSDA/soca)
-
+[![codecov](https://codecov.io/gh/JCSDA-internal/soca/branch/develop/graph/badge.svg?token=uFJ62a68D7)](https://codecov.io/gh/jcsda-internal/soca)
 JEDI encapsulation of MOM6
 
 (C) Copyright 2017-2020 UCAR.


### PR DESCRIPTION
## Description

A couple of semi-related fixes for TravisCI that I have been meaning to do for a while

- replace `ccache` with `ccache-swig` which is available in the container, meaning I no longer have to build `ccache` in the Dockerfile at test time. Very small decrease in TravisCI runtime
- Fix the creation of the `release/stable-nightly` branch (closes #437) . To test this, I forced a TravisCI run and created the `feature/release_test` branch (https://travis-ci.com/github/JCSDA-internal/soca/builds/193450780#L1842)
- Fix the TravisCI and CodeCov badges, which were broken due to the repo url changes (see working badges here https://github.com/JCSDA-internal/soca/tree/bugfix/travisci_stuff)
- CodeCov had been updated even if compilation and tests failed. We don't want this. This caused big drops in the assumed code codecoverage whenever `develop` was broken. Modified `.travis.yaml` to only upload to codecov if everything succeeds.