### PR TITLE
Feature/nl varchange

### DIFF
--- a/src/soca/State/soca_state_mod.F90
+++ b/src/soca/State/soca_state_mod.F90
@@ -257,6 +257,9 @@ subroutine soca_state_logexpon(self, transfunc, trvars)
 
     ! update halos
     call trocn%update_halo(self%geom)
+
+    ! deallocate trn for next variable
+    deallocate(trn)
   end do
 end subroutine soca_state_logexpon
 ! ------------------------------------------------------------------------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ list( APPEND soca_test_input
   testinput/balance_mask.yml
   testinput/checkpointmodel.yml
   testinput/convertstate.yml
+  testinput/convertstate_changevar.yml
   testinput/diffstates.yml
   testinput/dirac_bump_cov.yml
   testinput/dirac_horizfilt.yml
@@ -76,6 +77,7 @@ list( APPEND soca_test_ref
   testref/balance_mask.test
   testref/checkpointmodel.test
   testref/convertstate.test
+  testref/convertstate_changevar.test
   testref/diffstates.test
   testref/dirac_bump_cov.test
   testref/dirac_horizfilt.test
@@ -404,6 +406,13 @@ soca_add_test( NAME gridgen
 
 # Remapping MOM6 (horiz+vertical intterpolation)
 soca_add_test( NAME convertstate
+               EXE  soca_convertstate.x
+               TOL  2e-5 0
+               NOTRAPFPE
+               TEST_DEPENDS test_soca_gridgen )
+
+# Apply a nonlinear change of variable to an ensemble of states
+soca_add_test( NAME convertstate_changevar
                EXE  soca_convertstate.x
                TOL  2e-5 0
                NOTRAPFPE

--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -15,10 +15,6 @@ cost function:
     num_ice_lev: 4
     num_sno_lev: 1
     mom6_input_nml: ./inputnml/input.nml
-  variable change: Ana2Model #Identity
-  rotate:
-    u: [uocn]
-    v: [vocn]
 
   background:
     read_from_file: 1

--- a/test/testinput/convertstate.yml
+++ b/test/testinput/convertstate.yml
@@ -12,7 +12,6 @@ output geometry:
   num_sno_lev: 1
   geom_grid_file: soca_gridspec.small.nc
   mom6_input_nml: ./inputnml/input_small.nml
-output variables: *soca_vars
 
 states:
 - input:

--- a/test/testinput/convertstate_changevar.yml
+++ b/test/testinput/convertstate_changevar.yml
@@ -1,0 +1,55 @@
+inputVariables:
+  variables: &soca_vars [ssh, tocn, socn, uocn, vocn, hocn, cicen, chl]
+input geometry:
+  num_ice_cat: 5
+  num_ice_lev: 4
+  num_sno_lev: 1
+  geom_grid_file: soca_gridspec.nc
+  mom6_input_nml: ./inputnml/input.nml
+output geometry:
+  num_ice_cat: 5
+  num_ice_lev: 4
+  num_sno_lev: 1
+  geom_grid_file: soca_gridspec.nc
+  mom6_input_nml: ./inputnml/input.nml
+
+variable changes:
+  - variable change: Ana2Model
+    do inverse: false
+    rotate:
+      u: [uocn]
+      v: [vocn]
+    log:
+      var: [socn, chl]
+    output variables: *soca_vars
+
+states:
+- input:
+     read_from_file: 1
+     basename: ./INPUT/
+     ocn_filename: MOM.res.nc
+     ice_filename: cice.res.nc
+     sfc_filename: sfc.res.nc
+     date: &bkg_date 2018-04-15T00:00:00Z
+     seaice_model: cice
+     state variables: *soca_vars
+  output:
+     datadir: Data
+     exp: rotate-log
+     type: fc
+     seaice_model: cice
+     date: &bkg_date 2018-04-15T00:00:00Z
+- input:
+     read_from_file: 1
+     basename: ./INPUT/
+     ocn_filename: MOM.res.nc
+     sfc_filename: sfc.res.nc
+     date: &bkg_date 2018-04-15T00:00:00Z
+     seaice_model: cice
+     state variables: *soca_vars
+  output:
+     datadir: Data
+     exp: rotate-log-dummy-member
+     type: fc
+     seaice_model: cice
+     date: &bkg_date 2018-04-15T00:00:00Z

--- a/test/testref/convertstate_changevar.test
+++ b/test/testref/convertstate_changevar.test
@@ -1,0 +1,60 @@
+Test     : Input state: 
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023937
+Test     :     chl   min=    0.000010   max=    4.671990   mean=    0.118483
+Test     : State after Ana2Model transform: 
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
+Test     :    socn   min=    2.372209   max=    3.699860   mean=    3.541539
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000218
+Test     :    vocn   min=   -0.766110   max=    1.437578   mean=    0.002099
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023937
+Test     :     chl   min=  -11.417615   max=    1.541585   mean=   -4.163698
+Test     : Output state: 
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
+Test     :    socn   min=    2.372209   max=    3.699860   mean=    3.541539
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000218
+Test     :    vocn   min=   -0.766110   max=    1.437578   mean=    0.002099
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.023937
+Test     :     chl   min=  -11.417615   max=    1.541585   mean=   -4.163698
+Test     : Input state: 
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :   cicen   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=    0.000010   max=    4.671990   mean=    0.118483
+Test     : State after Ana2Model transform: 
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
+Test     :    socn   min=    2.372209   max=    3.699860   mean=    3.541539
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000218
+Test     :    vocn   min=   -0.766110   max=    1.437578   mean=    0.002099
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :   cicen   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=  -11.417615   max=    1.541585   mean=   -4.163698
+Test     : Output state: 
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
+Test     :    socn   min=    2.372209   max=    3.699860   mean=    3.541539
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000218
+Test     :    vocn   min=   -0.766110   max=    1.437578   mean=    0.002099
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :   cicen   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=  -11.417615   max=    1.541585   mean=   -4.163698


### PR DESCRIPTION
## Description
As an alternative to using 3DFGAT instead of 3DVAR to apply the Ana2Model variable change, we could apply it in a separate applications. This strategy would be relatively easy to implement within our current workflow. This branch addresses a few things:
- Addition of a ctest as an example of non linear variable change applied to an ensemble of state using the `ConvertState` application.
- Removal of the unused Ana2Model variable change in the 3dvar yaml 
- A reviewer :neutral_face: (<-- That guys ... let's burn him!) introduced a bug in @liuxiao37k 's variable change PR from a few days ago. 

### Issue(s) addressed
closes #481 


## Testing
How were these changes tested? **Staring at the log output of the new ctest**
What compilers / HPCs was it tested with? **gnu only**
Are the changes covered by ctests? **Yes**

