### PR TITLE
Writing the increment is now optional

### DIFF
--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -856,22 +856,6 @@ subroutine soca_fields_read(fld, f_conf, vdate)
     return
   end if
 
-  ! Read diagnostic file
-  if (iread==2) then
-    call f_conf%get_or_die("filename", str)
-    incr_filename = str
-    call fms_io_init()
-    do ii = 1, size(fld%fields)
-      field => fld%fields(ii)
-      if (field%io_name == "" ) cycle
-      if ( field%nz == 1) then
-        call read_data(incr_filename, field%name, field%val(:,:,1), domain=fld%geom%Domain%mpp_domain)
-      else
-        call read_data(incr_filename, field%name, field%val(:,:,:), domain=fld%geom%Domain%mpp_domain)
-      end if
-    end do
-    call fms_io_exit()
-  endif
 end subroutine soca_fields_read
 
 

--- a/src/soca/Fields/soca_fieldsutils_mod.F90
+++ b/src/soca/Fields/soca_fieldsutils_mod.F90
@@ -109,14 +109,10 @@ function soca_genfilename (f_conf,length,vdate,domain_type)
      soca_genfilename = TRIM(prefix) // "." // TRIM(referencedate) // "." // TRIM(sstep)
   endif
 
-  if (typ=="an") then
+  if (typ=="an" .or. typ=="incr") then
      call datetime_to_string(vdate, validitydate)
      lenfn = lenfn + 1 + LEN_TRIM(validitydate)
      soca_genfilename = TRIM(prefix) // "." // TRIM(validitydate)
-  endif
-
-  if (typ=="incr") then
-     soca_genfilename = 'test-incr.nc'
   endif
 
   if (lenfn>length) &

--- a/src/soca/State/soca_state_mod.F90
+++ b/src/soca/State/soca_state_mod.F90
@@ -111,8 +111,6 @@ subroutine soca_state_add_incr(self, rhs)
   class(soca_state),  intent(inout) :: self
   class(soca_increment), intent(in) :: rhs
 
-  integer, save :: cnt_outer = 1
-  character(len=800) :: filename, str_cnt
   type(soca_field), pointer :: fld, fld_r
   integer :: i, k
 
@@ -163,17 +161,6 @@ subroutine soca_state_add_incr(self, rhs)
       fld%val = fld%val + fld_r%val
     end select
   end do
-
-  ! Save increment for outer loop cnt_outer
-  write(str_cnt,*) cnt_outer
-  filename='incr.'//adjustl(trim(str_cnt))//'.nc'
-
-  ! Save increment and clean memory
-  call incr%write_file(filename)
-  call incr%delete()
-
-  ! Update outer loop counter
-  cnt_outer = cnt_outer + 1
 
 end subroutine soca_state_add_incr
 

--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -191,6 +191,13 @@ variational:
     test: on
     diagnostics:
       departures: ombg
+    online diagnostics:
+      write increment: true
+    increment:
+      datadir: Data
+      date: *bkg_date
+      exp: incr.iter1
+      type: incr
 
 output:
   datadir: Data

--- a/test/testinput/addincrement.yml
+++ b/test/testinput/addincrement.yml
@@ -21,8 +21,10 @@ state:
   state variables: [cicen, hicen, hsnon, socn, tocn, ssh, hocn, uocn, vocn, mld, layer_depth]
 
 increment:
-  read_from_file: 2
-  filename: ./incr.1.nc
+  read_from_file: 1
+  basename: ./Data/
+  ocn_filename: ocn.incr.iter1.incr.2018-04-15T00:00:00Z.nc
+  date: *bkg_date
   added variables: [hsnon, socn, tocn, hocn, uocn, vocn]
 
 output:


### PR DESCRIPTION
## Description
Thanks to @fabiolrdiniz 's https://github.com/JCSDA-internal/oops/pull/955, we can now remove the hard-coded writing of the increment in add_increment.
What was done:
- By default, the increment is not written. Happy  @travissluka ?
- Removed a `save` statement!
- Copy/pasted the increment write example in l95 into soca 3dvar_godas (but I did change the date ... hard work)

The example implemented if for one outer loop only, but the increment can be saved at every outer loop.

### Issue(s) addressed
closes #451

## Testing
What compilers / HPCs was it tested with? **gnu/container**
Are the changes covered by ctests? **added to the 3dvar_godas ctest**


