### PR TITLE
Use BlaskList instead of Domain Check w/ ufo `any_bit_set_of`refactoring

### DIFF
--- a/test/testinput/3dvar_soca.yml
+++ b/test/testinput/3dvar_soca.yml
@@ -206,7 +206,7 @@ cost function:
     - filter: Gaussian_Thinning
       horizontal_mesh:   111
       use_reduced_horizontal_grid: false
-    - filter: Domain Check
+    - filter: BlackList
       filter variables:
       - name: sea_surface_chlorophyll
       where:


### PR DESCRIPTION
## Description

There was a recent [refactoring in ufo qc_filter](https://github.com/JCSDA-internal/ufo/pull/283#event-3990260213) `any_bit_set_of` (an 'inversion' of what this filter does) that affects soca ctests (i.e. 3dvar_soca uses this filter for chlorophyll) -> now requires the use of `BlackList` instead of `Domain Check` with `any_bit_set_of`. This PR makes this simple change.



### Issue(s) addressed
- fixes #486 


## Testing

Tested on Hera with Intel18 compiler.



