### PR TITLE
workaround for thinning filter in LETKF

### DIFF
--- a/test/testinput/letkf.yml
+++ b/test/testinput/letkf.yml
@@ -50,6 +50,7 @@ observations:
   - *land_mask
   - filter: Thinning
     amount: 0.1
+    defer to post: true
     random seed: 0
 
 driver:


### PR DESCRIPTION
## Description
https://github.com/JCSDA-internal/oops/pull/965 accidentally broke the thinning filter in LETKF. This provides a workaround until we can redo how qc is done in the letkf via https://github.com/JCSDA-internal/oops/issues/904
