### PR TITLE
relax codecov threshold, prevent it from 'failing' PRs

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,2 +1,10 @@
 codecov:
   token: 7e489333-8f39-4b00-8377-402f46db4a15
+
+coverage:
+  round: up
+  status:
+    project:
+      default:
+        threshold: 0.1%
+        informational: true


### PR DESCRIPTION
## Description

I'm tired of codecoverage decreasing by as little as 0.01% failing our tests. This increases the threshold to 0.1%, but also switches codecov to an informational mode, which should still give us reports but not give us a  :x: if code coverage decreases.

### Issue(s) addressed

closes #496

## Testing

none. not sure the best way to test other than merge it in and hope it works. :man_shrugging: 
