### PR TITLE
remove ioda-converters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,14 @@ env:
   global:
     - MAIN_REPO=soca
     - LIB_REPOS="fms gsw mom6 crtm
-                 fckit atlas oops saber ioda ufo ioda-converters"
+                 fckit atlas oops saber ioda ufo"
     - BUILD_OPT=""
     - BUILD_OPT_crtm="-DBUILD_CRTM=ON"
     - BUILD_OPT_mom6="-DENABLE_OCEAN_BGC=ON"
     - BUILD_OPT_oops="-DENABLE_QG_MODEL=OFF -DENABLE_LORENZ95_MODEL=OFF"
     - BUILD_OPT_ufo="-DLOCAL_PATH_TESTFILES_IODA=NONE"
     - BUILD_OPT_soca="-DSOCA_TESTS_FORC_DEFAULT_TOL=ON -DENABLE_OCEAN_BGC=ON"
-    - MATCH_REPOS="saber oops ioda ioda-converters ufo mom6 soca"
+    - MATCH_REPOS="saber oops ioda ufo mom6 soca"
     - LFS_REPOS=""
     # ENABLE_VALGRIND="ON"
 

--- a/bundle/.gitignore
+++ b/bundle/.gitignore
@@ -4,7 +4,6 @@ eckit/
 fckit/
 fms/
 gsw/
-ioda-converters/
 ioda/
 mom6/
 oops/

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -44,7 +44,6 @@ ecbuild_bundle( PROJECT atlas           GIT "https://github.com/jcsda-internal/a
 ecbuild_bundle( PROJECT oops            GIT "https://github.com/jcsda-internal/oops.git"            UPDATE BRANCH develop )
 ecbuild_bundle( PROJECT saber           GIT "https://github.com/jcsda-internal/saber.git"           UPDATE BRANCH develop )
 ecbuild_bundle( PROJECT ioda            GIT "https://github.com/jcsda-internal/ioda.git"            UPDATE BRANCH develop )
-ecbuild_bundle( PROJECT ioda-converters GIT "https://github.com/jcsda-internal/ioda-converters.git" UPDATE BRANCH develop )
 ecbuild_bundle( PROJECT gsw             GIT "https://github.com/jcsda-internal/GSW-Fortran.git"     UPDATE BRANCH develop )
 ecbuild_bundle( PROJECT ufo             GIT "https://github.com/jcsda-internal/ufo.git"             UPDATE BRANCH develop )
 ecbuild_bundle( PROJECT mom6            GIT "https://github.com/jcsda-internal/MOM6.git"            UPDATE BRANCH main-ecbuild RECURSIVE)


### PR DESCRIPTION
## Description
SOCA's TravisCI builds are currently broken after https://github.com/JCSDA-internal/ioda-converters/pull/388

Since the soca repo does not directly depend on `ioda-converters` I'm removing it, it shouldn't be a part of these tests. If you want `ioda-converters` odds are you're pulling it from the `soca-science` repo instead anyway.

Short explanation of why suddenly broken: if `ioda` and `bufr` are present, `ioda-converters` will now compile the BUFR related code (previously required `ioda-engines` as well, which we never had in our bundle), however the containers have not been updated with the correct bufr library, so compilation fails. 