### PR TITLE
Fix to broken soca

### DIFF
--- a/src/soca/GetValues/soca_getvalues_mod.F90
+++ b/src/soca/GetValues/soca_getvalues_mod.F90
@@ -181,6 +181,10 @@ subroutine soca_getvalues_fillgeovals(self, geom, fld, t1, t2, locs, geovals)
       call fld%get("chl", fldptr)
       fld3d(isc:iec,jsc:jec,1) = fldptr%val(isc:iec,jsc:jec,1)
 
+    case ("sea_ice_area_fraction")
+      call fld%get("cicen", fldptr)
+      fld3d(isc:iec,jsc:jec,1) = fldptr%val(isc:iec,jsc:jec,1)
+
     case default
       call fckit_log%debug("soca_interpfields_mod:interp geoval does not exist")
     end select
@@ -326,6 +330,10 @@ subroutine soca_getvalues_fillgeovals_ad(self, geom, incr, t1, t2, locs, geovals
         call incr%get("chl", field)
         field%val(isc:iec,jsc:jec,1) = field%val(isc:iec,jsc:jec,1) + incr3d(isc:iec,jsc:jec,1)
 
+      case ("sea_ice_area_fraction")
+        call incr%get("cicen", field)
+        field%val(isc:iec,jsc:jec,1) = field%val(isc:iec,jsc:jec,1) + incr3d(isc:iec,jsc:jec,1)
+
       case default
         call abor1_ftn("soca_interpfields_mod:getvalues_ad geoval does not exist")
 
@@ -367,7 +375,8 @@ function nlev_from_ufovar(fld, var) result(nval)
         "sea_surface_salinity", &
         "sea_floor_depth_below_sea_surface", &
         "sea_area_fraction", &
-        "sea_surface_chlorophyll")
+        "sea_surface_chlorophyll", &
+        "sea_ice_area_fraction")
      nval = 1
 
   case ("sea_water_salinity")

--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -164,7 +164,7 @@ cost function:
       obsdatain:  {obsfile:  ./Data/icec.nc}
       simulated variables: [sea_ice_area_fraction]
     obs operator:
-      name: SeaIceFraction
+      name: Identity
     obs error:
       covariance model: diagonal
     obs filters:

--- a/test/testinput/3dvar_soca.yml
+++ b/test/testinput/3dvar_soca.yml
@@ -181,7 +181,7 @@ cost function:
       obsdatain:  {obsfile:  ./Data/icec.nc}
       simulated variables: [sea_ice_area_fraction]
     obs operator:
-      name: SeaIceFraction
+      name: Identity
     obs error:
       covariance model: diagonal
     obs filters:

--- a/test/testinput/3dvarfgat.yml
+++ b/test/testinput/3dvarfgat.yml
@@ -173,7 +173,7 @@ cost function:
       obsdatain:  {obsfile:  ./Data/icec.nc}
       simulated variables: [sea_ice_area_fraction]
     obs operator:
-      name: SeaIceFraction
+      name: Identity
     obs error:
       covariance model: diagonal
     obs filters:


### PR DESCRIPTION
## Description
Since we recently imposed the sea-ice state to be 2D (instead of 3D with multiple categories), we can switch from using the currently broken sea ice fraction ufo to the identity. This fixes the currently broken tests that are using the tlm/ad of the sea ice fraction ufo.

## Issue(s) addressed
- closes #517 
