### PR TITLE
Initialize BUMP instance index

### DIFF
--- a/src/soca/Transforms/VertConv/soca_vertconv_mod.F90
+++ b/src/soca/Transforms/VertConv/soca_vertconv_mod.F90
@@ -23,7 +23,7 @@ public :: soca_vertconv, &
 
 !> Fortran derived type to hold the setup for Vertconv
 type :: soca_vertconv
-   integer                   :: iinst              !> Instance index
+   integer                   :: iinst = 0          !> Instance index
    real(kind=kind_real)      :: lz_min             !> Vertical decorrelation minimum [m]
    real(kind=kind_real)      :: lz_mld             !> if /= 0, Use MLD to calculate Lz
    real(kind=kind_real)      :: lz_mld_max         !> if calculating Lz from MLD, max value to use


### PR DESCRIPTION
This is the smallest PR I've ever written: "1 changed file with 1 addition and 1 deletion".
It initialized the BUMP instance index to zero, which is required if the BUMP instrumentation is activated.
Absolutely no impact expected!