### PR TITLE
add ioda-engines dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ include_directories( ${SABER_INCLUDE_DIRS} )
 # ioda
 ecbuild_use_package( PROJECT ioda VERSION 0.1.0 REQUIRED )
 include_directories( ${IODA_INCLUDE_DIRS} )
+find_package(gsl-lite REQUIRED HINTS $ENV{gsl_lite_DIR})
 
 # ufo
 ecbuild_use_package( PROJECT ufo VERSION 0.1.0 REQUIRED )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ ecbuild_use_package( PROJECT mom6 REQUIRED )
 include_directories( ${MOM6_INCLUDE_DIRS} )
 
 # MPI
-ecbuild_find_mpi( COMPONENTS CXX Fortran REQUIRED )
+ecbuild_find_mpi( COMPONENTS C CXX Fortran REQUIRED )
 ecbuild_include_mpi()
 link_libraries(${MPI_CXX_LIBRARIES} ${MPI_Fortran_LIBRARIES})
 


### PR DESCRIPTION
## Description

ufo uses ioda-engines now, which breaks the unique way we do travisci tests. This, along with a matching branch in UFO, find gsl and the C interfaces for MPI and which are required for ioda-engines.


### Issue(s) addressed

- fixes #525

## Testing

... wait for the TravisCI tests to finish.

## Dependencies

requires matching branch in UFO to compile successfully (https://github.com/JCSDA-internal/ufo/pull/794). Don't need to wait for it to merge though.