### PR TITLE
lazy fix to hofx

### DIFF
--- a/src/mains/HofX3D.cc
+++ b/src/mains/HofX3D.cc
@@ -6,7 +6,8 @@
  */
 
 #include "soca/Traits.h"
-#include "oops/runs/HofX3D.h"
+// TODO(travis) use this one instead! #include "oops/runs/HofX3D.h"
+#include "oops/runs/HofX3Dslow.h"
 #include "oops/runs/Run.h"
 #include "ufo/instantiateObsFilterFactory.h"
 #include "ufo/ObsTraits.h"
@@ -14,6 +15,6 @@
 int main(int argc,  char ** argv) {
   oops::Run run(argc, argv);
   ufo::instantiateObsFilterFactory<ufo::ObsTraits>();
-  oops::HofX3D<soca::Traits, ufo::ObsTraits> hofx;
+  oops::HofX3Dslow<soca::Traits, ufo::ObsTraits> hofx;
   return run.execute(hofx);
 }


### PR DESCRIPTION
## Description

Change to hofx to keep anything from changing with https://github.com/JCSDA-internal/oops/pull/1098

Turns out doing it correctly is going to take more work than I'm willing to put in right now, thanks to our fondness of creating derived values in getValues

## Dependencies

requires oops branch of same name.