### PR TITLE
BUMP factory missing in the dirac application

### DIFF
--- a/src/mains/Dirac.cc
+++ b/src/mains/Dirac.cc
@@ -14,11 +14,13 @@
 #include "oops/runs/Dirac.h"
 #include "oops/runs/Run.h"
 #include "saber/oops/instantiateLocalizationFactory.h"
+#include "saber/oops/instantiateCovarFactory.h"
 
 int main(int argc,  char ** argv) {
   oops::Run run(argc, argv);
   soca::instantiateBalanceOpFactory();
   saber::instantiateLocalizationFactory<soca::Traits>();
+  saber::instantiateCovarFactory<soca::Traits>();
   oops::Dirac<soca::Traits> dir;
   return run.execute(dir);
 }


### PR DESCRIPTION
## Description
Exactly what the title says, also "more" prose can be found [here](https://github.com/JCSDA-internal/soca/issues/545). This PR is a simple fix that adds the bump factory to the dirac application. 

### Issue(s) addressed
- closes #545 

## Testing
Not reviving the commented out tests, but it was tested ...


