### PR TITLE
split letkf observer/solver for ctests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,7 +39,8 @@ set( soca_test_input
   testinput/hofx_4d.yml
   testinput/hofx_4d_pseudo.yml
   testinput/increment.yml
-  testinput/letkf.yml
+  testinput/letkf_observer.yml
+  testinput/letkf_solver.yml
   testinput/lineargetvalues.yml
   testinput/linearmodel.yml
   testinput/makeobs.yml
@@ -95,7 +96,8 @@ set( soca_test_ref
   testref/hofx_3dcrtm.test
   testref/hofx_4d.test
   testref/hofx_4d_pseudo.test
-  testref/letkf.test
+  testref/letkf_observer.test
+  testref/letkf_solver.test
   testref/makeobs.test
   testref/parameters_bump_cor_nicas.test
   testref/parameters_bump_cov_lct.test
@@ -730,12 +732,20 @@ soca_add_test( NAME 3dhybfgat
 #                TEST_DEPENDS test_soca_static_socaerror_init
 #                             test_soca_parameters_bump_loc )
 
-soca_add_test( NAME letkf
+soca_add_test( NAME letkf_observer
                EXE  soca_letkf.x
-               TOL  2e-5 0
                NOTRAPFPE
                TEST_DEPENDS test_soca_enspert )
 
+ecbuild_add_test( TARGET letkf_observer_post
+                  TYPE SCRIPT
+                  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/letkf_obscat.sh
+                  TEST_DEPENDS letkf_observer)
+
+soca_add_test( NAME letkf_solver
+               EXE  soca_letkf.x
+               NOTRAPFPE
+               TEST_DEPENDS letkf_observer_post )
 
 # restart checkpointing
 soca_add_test( NAME checkpointmodel

--- a/test/letkf_obscat.sh
+++ b/test/letkf_obscat.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# concatenate observation files between the letkf observer and solver
+# steps. This is temporary, and *should* go away when we go to a halo
+# distribution.
+
+cd Data
+files=sst.letkf.observer_*.nc
+for f in $files; do
+    ncks -3 -O -h --mk_rec_dmn nlocs $f -o $f
+done
+ncrcat -h -O $files sst.letkf.observer.nc

--- a/test/testinput/enshofx_1.yml
+++ b/test/testinput/enshofx_1.yml
@@ -20,7 +20,7 @@ initial condition:
     ice_filename: ../INPUT/cice.res.nc
     state variables: [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
   <<: *state
-  ocn_filename: ../Data/ocn.pert.ens.1.2018-04-15T00:00:00Z.PT6H.nc
+  ocn_filename: ../Data/ocn.pert.ens.1.2018-04-15T00:00:00Z.PT0S.nc
 
 observations:
   - obs space:

--- a/test/testinput/enshofx_2.yml
+++ b/test/testinput/enshofx_2.yml
@@ -20,7 +20,7 @@ initial condition:
     ice_filename: ../INPUT/cice.res.nc
     state variables: [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
   <<: *state
-  ocn_filename: ../Data/ocn.pert.ens.2.2018-04-15T00:00:00Z.PT6H.nc
+  ocn_filename: ../Data/ocn.pert.ens.2.2018-04-15T00:00:00Z.PT0S.nc
 
 observations:
   - obs space:

--- a/test/testinput/enshofx_3.yml
+++ b/test/testinput/enshofx_3.yml
@@ -20,7 +20,7 @@ initial condition:
     ice_filename: ../INPUT/cice.res.nc
     state variables: [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
   <<: *state
-  ocn_filename: ../Data/ocn.pert.ens.3.2018-04-15T00:00:00Z.PT6H.nc
+  ocn_filename: ../Data/ocn.pert.ens.3.2018-04-15T00:00:00Z.PT0S.nc
 
 observations:
   - obs space:

--- a/test/testinput/enspert.yml
+++ b/test/testinput/enspert.yml
@@ -24,9 +24,9 @@ background error:
   load_nicas: 1
   mpicom: 2
   date: *date
-  pert_T: 0.1
+  pert_T: 1.0
   pert_S: 1.0
-  pert_SSH: 1.0
+  pert_SSH: 0.0
   pert_AICE: 0.1
   pert_HICE: 0.05
   pert_CHL: 0.1
@@ -34,6 +34,14 @@ background error:
   analysis variables: &soca_vars [ssh, cicen, hicen, tocn, socn, chl, biop]
 
   variable changes:
+
+  - variable change: VertConvSOCA
+    Lz_min: 2.0
+    Lz_mld: 1
+    Lz_mld_max: 500.0
+    scale_layer_thick: 1.5
+    input variables: *soca_vars
+    output variables: *soca_vars
 
   - variable change: BkgErrFILT
     ocean_depth_min: 1000 # [m]
@@ -63,11 +71,9 @@ background error:
     input variables: *soca_vars
     output variables: *soca_vars
 
-  - variable change: VertConvSOCA
-    Lz_min: 2.0
-    Lz_mld: 1
-    Lz_mld_max: 500.0
-    scale_layer_thick: 1.5
+  - variable change: HorizFiltSOCA
+    niter: 1
+    filter variables: *soca_vars
     input variables: *soca_vars
     output variables: *soca_vars
 

--- a/test/testinput/ensrecenter.yml
+++ b/test/testinput/ensrecenter.yml
@@ -18,20 +18,20 @@ center:
 
 ensemble:
 - <<: *_file
-  ocn_filename: ocn.pert.ens.1.2018-04-15T00:00:00Z.PT6H.nc
-  ice_filename: ice.pert.ens.1.2018-04-15T00:00:00Z.PT6H.nc
+  ocn_filename: ocn.pert.ens.1.2018-04-15T00:00:00Z.PT0S.nc
+  ice_filename: ice.pert.ens.1.2018-04-15T00:00:00Z.PT0S.nc
 - <<: *_file
-  ocn_filename: ocn.pert.ens.2.2018-04-15T00:00:00Z.PT6H.nc
-  ice_filename: ice.pert.ens.2.2018-04-15T00:00:00Z.PT6H.nc
+  ocn_filename: ocn.pert.ens.2.2018-04-15T00:00:00Z.PT0S.nc
+  ice_filename: ice.pert.ens.2.2018-04-15T00:00:00Z.PT0S.nc
 - <<: *_file
-  ocn_filename: ocn.pert.ens.3.2018-04-15T00:00:00Z.PT6H.nc
-  ice_filename: ice.pert.ens.3.2018-04-15T00:00:00Z.PT6H.nc
+  ocn_filename: ocn.pert.ens.3.2018-04-15T00:00:00Z.PT0S.nc
+  ice_filename: ice.pert.ens.3.2018-04-15T00:00:00Z.PT0S.nc
 - <<: *_file
-  ocn_filename: ocn.pert.ens.4.2018-04-15T00:00:00Z.PT6H.nc
-  ice_filename: ice.pert.ens.4.2018-04-15T00:00:00Z.PT6H.nc
+  ocn_filename: ocn.pert.ens.4.2018-04-15T00:00:00Z.PT0S.nc
+  ice_filename: ice.pert.ens.4.2018-04-15T00:00:00Z.PT0S.nc
 - <<: *_file
-  ocn_filename: ocn.pert.ens.5.2018-04-15T00:00:00Z.PT6H.nc
-  ice_filename: ice.pert.ens.5.2018-04-15T00:00:00Z.PT6H.nc
+  ocn_filename: ocn.pert.ens.5.2018-04-15T00:00:00Z.PT0S.nc
+  ice_filename: ice.pert.ens.5.2018-04-15T00:00:00Z.PT0S.nc
 
 recentered output:
   datadir: Data

--- a/test/testinput/ensvariance.yml
+++ b/test/testinput/ensvariance.yml
@@ -24,20 +24,20 @@ ensemble:
   output variables: *soca_vars
   members:
   - <<: *_file
-    ocn_filename: ocn.pert.ens.1.2018-04-15T00:00:00Z.PT6H.nc
-    ice_filename: ice.pert.ens.1.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.1.2018-04-15T00:00:00Z.PT0S.nc
+    ice_filename: ice.pert.ens.1.2018-04-15T00:00:00Z.PT0S.nc
   - <<: *_file
-    ocn_filename: ocn.pert.ens.2.2018-04-15T00:00:00Z.PT6H.nc
-    ice_filename: ice.pert.ens.2.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.2.2018-04-15T00:00:00Z.PT0S.nc
+    ice_filename: ice.pert.ens.2.2018-04-15T00:00:00Z.PT0S.nc
   - <<: *_file
-    ocn_filename: ocn.pert.ens.3.2018-04-15T00:00:00Z.PT6H.nc
-    ice_filename: ice.pert.ens.3.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.3.2018-04-15T00:00:00Z.PT0S.nc
+    ice_filename: ice.pert.ens.3.2018-04-15T00:00:00Z.PT0S.nc
   - <<: *_file
-    ocn_filename: ocn.pert.ens.4.2018-04-15T00:00:00Z.PT6H.nc
-    ice_filename: ice.pert.ens.4.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.4.2018-04-15T00:00:00Z.PT0S.nc
+    ice_filename: ice.pert.ens.4.2018-04-15T00:00:00Z.PT0S.nc
   - <<: *_file
-    ocn_filename: ocn.pert.ens.5.2018-04-15T00:00:00Z.PT6H.nc
-    ice_filename: ice.pert.ens.5.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.5.2018-04-15T00:00:00Z.PT0S.nc
+    ice_filename: ice.pert.ens.5.2018-04-15T00:00:00Z.PT0S.nc
   variable changes:
   - variable change: BalanceSOCA
     dsdtmax: 1.0

--- a/test/testinput/letkf_observer.yml
+++ b/test/testinput/letkf_observer.yml
@@ -14,15 +14,15 @@ background:
     state variables: *soca_vars
   members:
   - <<: *state
-    ocn_filename: ocn.pert.ens.1.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.1.2018-04-15T00:00:00Z.PT0S.nc
   - <<: *state
-    ocn_filename: ocn.pert.ens.2.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.2.2018-04-15T00:00:00Z.PT0S.nc
   - <<: *state
-    ocn_filename: ocn.pert.ens.3.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.3.2018-04-15T00:00:00Z.PT0S.nc
   - <<: *state
-    ocn_filename: ocn.pert.ens.4.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.4.2018-04-15T00:00:00Z.PT0S.nc
   - <<: *state
-    ocn_filename: ocn.pert.ens.5.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.5.2018-04-15T00:00:00Z.PT0S.nc
 
 
 # common filters used later on
@@ -36,8 +36,8 @@ observations:
 
 - obs space:
     name: SeaSurfaceTemp
-    distribution: InefficientDistribution
-    obsdataout: {obsfile: ./Data/sst.letkf.nc}
+    distribution: RoundRobin
+    obsdataout: {obsfile: ./Data/sst.letkf.observer.nc}
     obsdatain:  {obsfile: ./Data/sst.nc}
     simulated variables: [sea_surface_temperature]
   obs operator:
@@ -46,22 +46,18 @@ observations:
     covariance model: diagonal
   obs localization:
       localization method: Gaspari-Cohn
-      lengthscale: 2000e3
+      lengthscale: 0
   obs filters:
   - *land_mask
   - filter: Thinning
     amount: 0.1
-    defer to post: true
     random seed: 0
 
 driver:
+  run as observer only: true
 
 local ensemble DA:
   solver: LETKF
-  inflation:
-    rtps: 0.5
-    rtpp: 0.6
-    mult: 1.1
 
 output:
   datadir: Data

--- a/test/testinput/letkf_solver.yml
+++ b/test/testinput/letkf_solver.yml
@@ -1,0 +1,95 @@
+geometry:
+  mom6_input_nml: ./inputnml/input.nml
+  fields metadata: ./fields_metadata.yml
+
+window begin: &date 2018-04-14T00:00:00Z
+window length: P2D
+
+background:
+  variables: &soca_vars [socn, tocn, ssh, uocn, vocn, hocn, chl, biop]
+  _: &state
+    date: 2018-04-15T00:00:00Z
+    read_from_file: 1
+    basename: ./Data/
+    state variables: *soca_vars
+  members:
+  - <<: *state
+    ocn_filename: ocn.pert.ens.1.2018-04-15T00:00:00Z.PT0S.nc
+  - <<: *state
+    ocn_filename: ocn.pert.ens.2.2018-04-15T00:00:00Z.PT0S.nc
+  - <<: *state
+    ocn_filename: ocn.pert.ens.3.2018-04-15T00:00:00Z.PT0S.nc
+  - <<: *state
+    ocn_filename: ocn.pert.ens.4.2018-04-15T00:00:00Z.PT0S.nc
+  - <<: *state
+    ocn_filename: ocn.pert.ens.5.2018-04-15T00:00:00Z.PT0S.nc
+
+
+# common filters used later on
+_: &land_mask
+  filter: Domain Check
+  where:
+  - variable: {name: sea_area_fraction@GeoVaLs}
+    minvalue: 0.5
+
+observations:
+
+- obs space:
+    name: SeaSurfaceTemp
+    distribution: InefficientDistribution
+    obsdataout: {obsfile: ./Data/sst.letkf.solver.nc}
+    obsdatain:  {obsfile: ./Data/sst.letkf.observer.nc}
+    simulated variables: [sea_surface_temperature]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  obs localization:
+      localization method: Gaspari-Cohn
+      lengthscale: 1000e3
+
+driver:
+  read HX from disk: true
+  do posterior observer: false
+  save posterior mean: true
+  save prior mean: true
+  save posterior variance: true
+  save prior variance: true
+  save posterior mean increment: true
+
+local ensemble DA:
+  solver: LETKF
+  inflation:
+    rtps: 0.5
+    rtpp: 0.6
+    mult: 1.1
+
+output:
+  datadir: Data
+  date: *date
+  exp: letkf
+  type: ens
+
+output mean prior:
+  datadir: Data
+  date: *date
+  exp: letkf
+  type: fc
+
+output variance prior:
+  datadir: Data
+  date: *date
+  exp: letkf.var
+  type: fc
+
+output variance posterior:
+  datadir: Data
+  date: *date
+  exp: letkf.var
+  type: an
+
+output increment:
+  datadir: Data
+  date: *date
+  exp: letkf.inc
+  type: an

--- a/test/testinput/parameters_bump_cov_lct.yml
+++ b/test/testinput/parameters_bump_cov_lct.yml
@@ -40,20 +40,20 @@ ensemble:
   variables: *soca_vars
   members:
   - <<: *ensfile
-    ocn_filename: ocn.pert.ens.1.2018-04-15T00:00:00Z.PT6H.nc
-    ice_filename: ice.pert.ens.1.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.1.2018-04-15T00:00:00Z.PT0S.nc
+    ice_filename: ice.pert.ens.1.2018-04-15T00:00:00Z.PT0S.nc
   - <<: *ensfile
-    ocn_filename: ocn.pert.ens.2.2018-04-15T00:00:00Z.PT6H.nc
-    ice_filename: ice.pert.ens.2.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.2.2018-04-15T00:00:00Z.PT0S.nc
+    ice_filename: ice.pert.ens.2.2018-04-15T00:00:00Z.PT0S.nc
   - <<: *ensfile
-    ocn_filename: ocn.pert.ens.3.2018-04-15T00:00:00Z.PT6H.nc
-    ice_filename: ice.pert.ens.3.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.3.2018-04-15T00:00:00Z.PT0S.nc
+    ice_filename: ice.pert.ens.3.2018-04-15T00:00:00Z.PT0S.nc
   - <<: *ensfile
-    ocn_filename: ocn.pert.ens.4.2018-04-15T00:00:00Z.PT6H.nc
-    ice_filename: ice.pert.ens.4.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.4.2018-04-15T00:00:00Z.PT0S.nc
+    ice_filename: ice.pert.ens.4.2018-04-15T00:00:00Z.PT0S.nc
   - <<: *ensfile
-    ocn_filename: ocn.pert.ens.5.2018-04-15T00:00:00Z.PT6H.nc
-    ice_filename: ice.pert.ens.5.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.5.2018-04-15T00:00:00Z.PT0S.nc
+    ice_filename: ice.pert.ens.5.2018-04-15T00:00:00Z.PT0S.nc
 
   variable_changes:
   - varchange: BalanceSOCA

--- a/test/testinput/parameters_bump_cov_nicas.yml
+++ b/test/testinput/parameters_bump_cov_nicas.yml
@@ -37,17 +37,17 @@ ensemble:
   variables: *soca_vars
   members:
   - <<: *ensfile
-    ocn_filename: ocn.pert.ens.1.2018-04-15T00:00:00Z.PT6H.nc
-    ice_filename: ice.pert.ens.1.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.1.2018-04-15T00:00:00Z.PT0S.nc
+    ice_filename: ice.pert.ens.1.2018-04-15T00:00:00Z.PT0S.nc
   - <<: *ensfile
-    ocn_filename: ocn.pert.ens.2.2018-04-15T00:00:00Z.PT6H.nc
-    ice_filename: ice.pert.ens.2.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.2.2018-04-15T00:00:00Z.PT0S.nc
+    ice_filename: ice.pert.ens.2.2018-04-15T00:00:00Z.PT0S.nc
   - <<: *ensfile
-    ocn_filename: ocn.pert.ens.3.2018-04-15T00:00:00Z.PT6H.nc
-    ice_filename: ice.pert.ens.3.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.3.2018-04-15T00:00:00Z.PT0S.nc
+    ice_filename: ice.pert.ens.3.2018-04-15T00:00:00Z.PT0S.nc
   - <<: *ensfile
-    ocn_filename: ocn.pert.ens.4.2018-04-15T00:00:00Z.PT6H.nc
-    ice_filename: ice.pert.ens.4.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.4.2018-04-15T00:00:00Z.PT0S.nc
+    ice_filename: ice.pert.ens.4.2018-04-15T00:00:00Z.PT0S.nc
   - <<: *ensfile
-    ocn_filename: ocn.pert.ens.5.2018-04-15T00:00:00Z.PT6H.nc
-    ice_filename: ice.pert.ens.5.2018-04-15T00:00:00Z.PT6H.nc
+    ocn_filename: ocn.pert.ens.5.2018-04-15T00:00:00Z.PT0S.nc
+    ice_filename: ice.pert.ens.5.2018-04-15T00:00:00Z.PT0S.nc

--- a/test/testref/3dhyb.test
+++ b/test/testref/3dhyb.test
@@ -1,15 +1,15 @@
 Test     : CostJb   : Nonlinear Jb = 0
 Test     : CostJo   : Nonlinear Jo(ADT) = 224.622, nobs = 100, Jo/n = 2.24622, err = 0.1
 Test     : CostFunction: Nonlinear J = 224.622
-Test     : RPCGMinimizer: reduction in residual norm = 0.585163
+Test     : RPCGMinimizer: reduction in residual norm = 0.549457
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.000050   max=    1.000000   mean=    0.117517
+Test     :   cicen   min=   -0.000048   max=    1.000000   mean=    0.117517
 Test     :   hicen   min=    0.000000   max=    4.032667   mean=    0.471252
 Test     :   hsnon   min=    0.000000   max=    1.271283   mean=    0.088687
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.572595
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.011035
-Test     :     ssh   min=   -2.358669   max=    0.929673   mean=   -0.290344
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.569756
+Test     :    tocn   min=   -1.902273   max=   31.700462   mean=    6.007583
+Test     :     ssh   min=   -2.354529   max=    0.925835   mean=   -0.289742
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
@@ -18,6 +18,6 @@ Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395529
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008644
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 6.721436
-Test     : CostJo   : Nonlinear Jo(ADT) = 138.333410, nobs = 100, Jo/n = 1.383334, err = 0.100000
-Test     : CostFunction: Nonlinear J = 145.054846
+Test     : CostJb   : Nonlinear Jb = 6.676220
+Test     : CostJo   : Nonlinear Jo(ADT) = 153.783975, nobs = 100, Jo/n = 1.537840, err = 0.100000
+Test     : CostFunction: Nonlinear J = 160.460194

--- a/test/testref/3dhybfgat.test
+++ b/test/testref/3dhybfgat.test
@@ -1,14 +1,14 @@
 Test     : CostJb   : Nonlinear Jb = 0
 Test     : CostJo   : Nonlinear Jo(ADT) = 88.4808, nobs = 31, Jo/n = 2.85422, err = 0.1
 Test     : CostFunction: Nonlinear J = 88.4808
-Test     : RPCGMinimizer: reduction in residual norm = 0.508041
+Test     : RPCGMinimizer: reduction in residual norm = 0.481887
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.000027   max=    1.000000   mean=    0.117514
+Test     :   cicen   min=   -0.000026   max=    1.000000   mean=    0.117514
 Test     :   hicen   min=    0.000000   max=    4.032667   mean=    0.471252
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.554906
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.013609
-Test     :     ssh   min=   -1.924420   max=    0.925992   mean=   -0.284591
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.554375
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.010392
+Test     :     ssh   min=   -1.924410   max=    0.922616   mean=   -0.283633
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
@@ -17,6 +17,6 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 2.642099
-Test     : CostJo   : Nonlinear Jo(ADT) = 73.543914, nobs = 31, Jo/n = 2.372384, err = 0.100000
-Test     : CostFunction: Nonlinear J = 76.186013
+Test     : CostJb   : Nonlinear Jb = 2.428177
+Test     : CostJo   : Nonlinear Jo(ADT) = 77.092707, nobs = 31, Jo/n = 2.486862, err = 0.100000
+Test     : CostFunction: Nonlinear J = 79.520885

--- a/test/testref/dirac_socahyb_cov.test
+++ b/test/testref/dirac_socahyb_cov.test
@@ -11,10 +11,10 @@ Test     : layer_depth   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : B * Increment: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=   -0.001746   max=    0.000000   mean=   -0.000009
-Test     :   hicen   min=    0.000000   max=   50.204949   mean=    0.328768
-Test     :    socn   min=   -0.014030   max=    0.073735   mean=    0.000263
-Test     :    tocn   min=   -0.002950   max=    2.660492   mean=    0.008501
-Test     :     ssh   min=   -0.005715   max=    0.031172   mean=    0.000285
+Test     :   hicen   min=    0.000000   max=   50.049749   mean=    0.328673
+Test     :    socn   min=   -0.052871   max=    0.506083   mean=    0.001919
+Test     :    tocn   min=   -0.162503   max=    3.680461   mean=    0.014847
+Test     :     ssh   min=   -0.072326   max=    0.029681   mean=   -0.000036
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : layer_depth   min=    0.000000   max=    0.000000   mean=    0.000000

--- a/test/testref/enspert.test
+++ b/test/testref/enspert.test
@@ -20,16 +20,16 @@ Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 0 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=   -0.027664   max=    1.028266   mean=    0.117093
-Test     :   hicen   min=   -1.378334   max=    4.115007   mean=    0.491388
+Test     :   cicen   min=   -0.019689   max=    1.025740   mean=    0.117087
+Test     :   hicen   min=   -0.928262   max=    4.128004   mean=    0.490854
 Test     :   hsnon   min=    0.000000   max=    1.271283   mean=    0.088687
-Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.529265
-Test     :    tocn   min=   -1.919691   max=   31.711710   mean=    6.015286
-Test     :    uocn   min=   -0.854850   max=    0.695505   mean=   -0.000219
-Test     :    vocn   min=   -0.804789   max=    1.210937   mean=    0.001999
-Test     :     ssh   min=   -1.984981   max=    0.919364   mean=   -0.276772
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628067
-Test     :     chl   min=   -0.000706   max=    4.672126   mean=    0.118477
+Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.530000
+Test     :    tocn   min=   -1.931041   max=   31.566823   mean=    6.041861
+Test     :    uocn   min=   -0.854580   max=    0.695502   mean=   -0.000320
+Test     :    vocn   min=   -0.800340   max=    1.220078   mean=    0.001958
+Test     :     ssh   min=   -1.915334   max=    0.925063   mean=   -0.276765
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628068
+Test     :     chl   min=   -0.000604   max=    4.672095   mean=    0.118477
 Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
@@ -40,16 +40,16 @@ Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 1 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=   -0.030976   max=    1.023300   mean=    0.117974
-Test     :   hicen   min=   -1.741343   max=    4.390644   mean=    0.456280
+Test     :   cicen   min=   -0.017240   max=    1.022735   mean=    0.117996
+Test     :   hicen   min=   -1.019575   max=    4.125772   mean=    0.455130
 Test     :   hsnon   min=    0.000000   max=    1.271283   mean=    0.088687
-Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.536926
-Test     :    tocn   min=   -1.888403   max=   31.711947   mean=    6.011277
-Test     :    uocn   min=   -0.856128   max=    0.708682   mean=   -0.000297
-Test     :    vocn   min=   -0.829302   max=    1.432336   mean=    0.002310
-Test     :     ssh   min=   -2.343745   max=    0.918818   mean=   -0.276971
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628031
-Test     :     chl   min=   -0.000930   max=    4.672043   mean=    0.118482
+Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.536920
+Test     :    tocn   min=   -1.917105   max=   31.465180   mean=    6.005602
+Test     :    uocn   min=   -0.853313   max=    0.699470   mean=   -0.000116
+Test     :    vocn   min=   -0.746604   max=    1.263707   mean=    0.002166
+Test     :     ssh   min=   -2.134823   max=    0.923897   mean=   -0.276818
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628054
+Test     :     chl   min=   -0.000741   max=    4.672040   mean=    0.118481
 Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
@@ -60,16 +60,16 @@ Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 2 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=   -0.033720   max=    1.025187   mean=    0.119214
-Test     :   hicen   min=   -1.682241   max=    4.521281   mean=    0.456621
+Test     :   cicen   min=   -0.021402   max=    1.017778   mean=    0.119155
+Test     :   hicen   min=   -0.818294   max=    4.556486   mean=    0.457848
 Test     :   hsnon   min=    0.000000   max=    1.271283   mean=    0.088687
-Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.567029
-Test     :    tocn   min=   -1.929864   max=   31.711882   mean=    6.020350
-Test     :    uocn   min=   -0.855025   max=    0.691556   mean=   -0.000199
-Test     :    vocn   min=   -0.704799   max=    1.331277   mean=    0.001886
-Test     :     ssh   min=   -2.263595   max=    0.919650   mean=   -0.277158
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628041
-Test     :     chl   min=   -0.000912   max=    4.672096   mean=    0.118489
+Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.568902
+Test     :    tocn   min=   -1.928958   max=   31.875271   mean=    6.042428
+Test     :    uocn   min=   -0.853151   max=    0.633003   mean=   -0.000101
+Test     :    vocn   min=   -0.771857   max=    1.196984   mean=    0.001925
+Test     :     ssh   min=   -2.146851   max=    0.924332   mean=   -0.276873
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628062
+Test     :     chl   min=   -0.000678   max=    4.672024   mean=    0.118489
 Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
@@ -80,16 +80,16 @@ Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 3 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=   -0.037115   max=    1.021851   mean=    0.118482
-Test     :   hicen   min=   -1.361390   max=    4.898182   mean=    0.556573
+Test     :   cicen   min=   -0.023443   max=    1.020330   mean=    0.118464
+Test     :   hicen   min=   -0.906336   max=    4.652072   mean=    0.556610
 Test     :   hsnon   min=    0.000000   max=    1.271283   mean=    0.088687
-Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.516528
-Test     :    tocn   min=   -1.888755   max=   31.712084   mean=    6.011813
-Test     :    uocn   min=   -0.854496   max=    0.696298   mean=   -0.000212
-Test     :    vocn   min=   -0.761672   max=    1.414200   mean=    0.001871
-Test     :     ssh   min=   -2.190411   max=    0.921300   mean=   -0.277176
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628068
-Test     :     chl   min=   -0.001240   max=    4.671992   mean=    0.118503
+Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.515737
+Test     :    tocn   min=   -1.890450   max=   32.066478   mean=    6.021877
+Test     :    uocn   min=   -0.851368   max=    0.688408   mean=   -0.000218
+Test     :    vocn   min=   -0.658992   max=    1.185960   mean=    0.001827
+Test     :     ssh   min=   -2.129719   max=    0.929467   mean=   -0.276830
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628084
+Test     :     chl   min=   -0.000986   max=    4.671970   mean=    0.118504
 Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
@@ -100,16 +100,16 @@ Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 4 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=   -0.029782   max=    1.013964   mean=    0.116786
-Test     :   hicen   min=   -1.980610   max=    4.055459   mean=    0.477348
+Test     :   cicen   min=   -0.022532   max=    1.012507   mean=    0.116824
+Test     :   hicen   min=   -1.721025   max=    3.718620   mean=    0.478197
 Test     :   hsnon   min=    0.000000   max=    1.271283   mean=    0.088687
-Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.545831
-Test     :    tocn   min=   -1.915741   max=   31.711959   mean=    6.008463
-Test     :    uocn   min=   -0.850860   max=    0.714069   mean=   -0.000265
-Test     :    vocn   min=   -0.820932   max=    1.444786   mean=    0.001863
-Test     :     ssh   min=   -2.212271   max=    0.918260   mean=   -0.277093
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628062
-Test     :     chl   min=   -0.001079   max=    4.671879   mean=    0.118466
+Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.546484
+Test     :    tocn   min=   -1.914041   max=   31.637199   mean=    6.013100
+Test     :    uocn   min=   -0.846680   max=    0.713136   mean=    0.000045
+Test     :    vocn   min=   -0.820975   max=    1.280726   mean=    0.001942
+Test     :     ssh   min=   -2.113567   max=    0.931606   mean=   -0.276670
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628111
+Test     :     chl   min=   -0.000687   max=    4.671862   mean=    0.118466
 Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040

--- a/test/testref/ensrecenter.test
+++ b/test/testref/ensrecenter.test
@@ -1,88 +1,88 @@
 Test     : Original member 0 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.027664   max=    1.028266   mean=    0.117093
-Test     :   hicen   min=   -1.378334   max=    4.115007   mean=    0.491388
-Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.532325
-Test     :    tocn   min=   -1.919691   max=   31.711710   mean=    6.012435
-Test     :     ssh   min=   -1.984981   max=    0.919364   mean=   -0.276772
+Test     :   cicen   min=   -0.019689   max=    1.025740   mean=    0.117087
+Test     :   hicen   min=   -0.928262   max=    4.128004   mean=    0.490854
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.530414
+Test     :    tocn   min=   -3.921668   max=   31.555520   mean=    6.045493
+Test     :     ssh   min=   -2.318490   max=    0.961947   mean=   -0.270186
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Original member 1 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.030976   max=    1.023300   mean=    0.117974
-Test     :   hicen   min=   -1.741343   max=    4.390644   mean=    0.456280
-Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.539194
-Test     :    tocn   min=   -1.888403   max=   31.711947   mean=    6.004192
-Test     :     ssh   min=   -2.343745   max=    0.918818   mean=   -0.276971
+Test     :   cicen   min=   -0.017240   max=    1.022735   mean=    0.117996
+Test     :   hicen   min=   -1.019575   max=    4.125772   mean=    0.455130
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.538916
+Test     :    tocn   min=   -3.373237   max=   31.466833   mean=    6.009999
+Test     :     ssh   min=   -1.920096   max=    0.991057   mean=   -0.280513
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Original member 2 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.033720   max=    1.025187   mean=    0.119214
-Test     :   hicen   min=   -1.682241   max=    4.521281   mean=    0.456621
-Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.569308
-Test     :    tocn   min=   -1.929864   max=   31.711882   mean=    6.017399
-Test     :     ssh   min=   -2.263595   max=    0.919650   mean=   -0.277158
+Test     :   cicen   min=   -0.021402   max=    1.017778   mean=    0.119155
+Test     :   hicen   min=   -0.818294   max=    4.556486   mean=    0.457848
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.571084
+Test     :    tocn   min=   -4.025426   max=   31.863681   mean=    6.030053
+Test     :     ssh   min=   -1.981225   max=    0.948331   mean=   -0.286933
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Original member 3 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.037115   max=    1.021851   mean=    0.118482
-Test     :   hicen   min=   -1.361390   max=    4.898182   mean=    0.556573
-Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.521539
-Test     :    tocn   min=   -1.888755   max=   31.712084   mean=    6.003907
-Test     :     ssh   min=   -2.190411   max=    0.921300   mean=   -0.277176
+Test     :   cicen   min=   -0.023443   max=    1.020330   mean=    0.118464
+Test     :   hicen   min=   -0.906336   max=    4.652072   mean=    0.556610
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.515829
+Test     :    tocn   min=   -3.777201   max=   32.054886   mean=    6.024774
+Test     :     ssh   min=   -1.878931   max=    0.946667   mean=   -0.260414
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Original member 4 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.029782   max=    1.013964   mean=    0.116786
-Test     :   hicen   min=   -1.980610   max=    4.055459   mean=    0.477348
-Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.548387
-Test     :    tocn   min=   -1.915741   max=   31.711959   mean=    5.995017
-Test     :     ssh   min=   -2.212271   max=    0.918260   mean=   -0.277093
+Test     :   cicen   min=   -0.022532   max=    1.012507   mean=    0.116824
+Test     :   hicen   min=   -1.721025   max=    3.718620   mean=    0.478197
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.547259
+Test     :    tocn   min=   -4.053497   max=   31.658321   mean=    6.016663
+Test     :     ssh   min=   -1.906226   max=    0.934702   mean=   -0.272621
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Ensemble mean: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.017040   max=    1.009388   mean=    0.117910
-Test     :   hicen   min=   -0.682862   max=    3.932895   mean=    0.487642
-Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.542150
-Test     :    tocn   min=   -1.888683   max=   31.711916   mean=    6.006590
-Test     :     ssh   min=   -2.135367   max=    0.919478   mean=   -0.277034
+Test     :   cicen   min=   -0.010625   max=    1.008153   mean=    0.117905
+Test     :   hicen   min=   -0.584902   max=    3.886001   mean=    0.487728
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.540700
+Test     :    tocn   min=   -2.719240   max=   31.710701   mean=    6.025396
+Test     :     ssh   min=   -1.898450   max=    0.956541   mean=   -0.274133
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 0 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.025338   max=    1.023984   mean=    0.116695
-Test     :   hicen   min=   -1.365407   max=    4.234753   mean=    0.474997
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.534564
-Test     :    tocn   min=   -2.184691   max=   31.700258   mean=    6.023411
-Test     :     ssh   min=   -2.098992   max=    0.927168   mean=   -0.276528
+Test     :   cicen   min=   -0.015736   max=    1.020791   mean=    0.116695
+Test     :   hicen   min=   -0.895371   max=    4.218134   mean=    0.474378
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.534104
+Test     :    tocn   min=   -3.783949   max=   31.545283   mean=    6.037661
+Test     :     ssh   min=   -2.252162   max=    0.932689   mean=   -0.272843
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 1 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.024914   max=    1.018513   mean=    0.117577
-Test     :   hicen   min=   -1.271811   max=    4.193218   mean=    0.439889
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.541433
-Test     :    tocn   min=   -2.186952   max=   31.700496   mean=    6.015167
-Test     :     ssh   min=   -1.953792   max=    0.926622   mean=   -0.276727
+Test     :   cicen   min=   -0.016117   max=    1.016802   mean=    0.117604
+Test     :   hicen   min=   -0.896029   max=    4.166843   mean=    0.438653
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.542605
+Test     :    tocn   min=   -2.965016   max=   31.443301   mean=    6.002167
+Test     :     ssh   min=   -1.946130   max=    0.961799   mean=   -0.283170
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 2 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.031110   max=    1.020754   mean=    0.118817
-Test     :   hicen   min=   -1.558886   max=    4.847709   mean=    0.440231
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.571547
-Test     :    tocn   min=   -2.206139   max=   31.700430   mean=    6.028374
-Test     :     ssh   min=   -1.948415   max=    0.927454   mean=   -0.276914
+Test     :   cicen   min=   -0.016698   max=    1.012434   mean=    0.118762
+Test     :   hicen   min=   -0.806092   max=    4.703152   mean=    0.441372
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.574774
+Test     :    tocn   min=   -4.343349   max=   31.853445   mean=    6.022222
+Test     :     ssh   min=   -1.980939   max=    0.919072   mean=   -0.289590
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 3 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.025344   max=    1.016274   mean=    0.118085
-Test     :   hicen   min=   -1.370007   max=    4.487655   mean=    0.540183
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.523778
-Test     :    tocn   min=   -2.260112   max=   31.700632   mean=    6.014882
-Test     :     ssh   min=   -1.859508   max=    0.929104   mean=   -0.276933
+Test     :   cicen   min=   -0.020010   max=    1.014585   mean=    0.118071
+Test     :   hicen   min=   -0.923519   max=    4.350799   mean=    0.540134
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.519518
+Test     :    tocn   min=   -3.004164   max=   32.044650   mean=    6.016943
+Test     :     ssh   min=   -1.858187   max=    0.917408   mean=   -0.263071
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 4 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.026103   max=    1.013576   mean=    0.116389
-Test     :   hicen   min=   -1.512478   max=    4.043134   mean=    0.460957
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.550626
-Test     :    tocn   min=   -2.394953   max=   31.700507   mean=    6.005992
-Test     :     ssh   min=   -1.936157   max=    0.926065   mean=   -0.276849
+Test     :   cicen   min=   -0.022627   max=    1.012548   mean=    0.116431
+Test     :   hicen   min=   -1.297737   max=    3.827960   mean=    0.461721
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.550948
+Test     :    tocn   min=   -5.275255   max=   31.615644   mean=    6.008832
+Test     :     ssh   min=   -1.911796   max=    0.905444   mean=   -0.275278
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064

--- a/test/testref/ensvariance.test
+++ b/test/testref/ensvariance.test
@@ -1,12 +1,12 @@
 Test     : Variance: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000001   max=    0.000471   mean=    0.000097
-Test     :   hicen   min=    0.001066   max=    1.307220   mean=    0.258185
-Test     :    socn   min=    0.000000   max=    1.934859   mean=    0.066508
-Test     :    tocn   min=    0.000000   max=    3.292323   mean=    0.025634
-Test     :    uocn   min=    0.000000   max=    0.094293   mean=    0.000193
-Test     :    vocn   min=    0.000000   max=    0.169489   mean=    0.000149
-Test     :     ssh   min=    0.000000   max=    0.387556   mean=    0.005032
+Test     :   cicen   min=    0.000002   max=    0.000306   mean=    0.000047
+Test     :   hicen   min=    0.001535   max=    0.973988   mean=    0.122935
+Test     :    socn   min=    0.000000   max=    1.308587   mean=    0.047887
+Test     :    tocn   min=    0.000000   max=    7.360339   mean=    0.202748
+Test     :    uocn   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :    vocn   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     ssh   min=    0.000000   max=    0.001096   mean=    0.000019
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     :     mld   min=    0.000000   max=4114265.322958   mean=82711.880140
-Test     : layer_depth   min=    0.000000   max=614330.851695   mean= 1633.595038
+Test     :     mld   min=    0.000000   max=4254787.447907   mean=92395.587772
+Test     : layer_depth   min=    0.000000   max=    0.000000   mean=    0.000000

--- a/test/testref/letkf_observer.test
+++ b/test/testref/letkf_observer.test
@@ -1,0 +1,64 @@
+Test     : Initial state for member 1:
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.530414
+Test     :    tocn   min=   -3.921668   max=   31.555520   mean=    6.045493
+Test     :     ssh   min=   -2.318490   max=    0.961947   mean=   -0.270186
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :     chl   min=   -0.000604   max=    4.672095   mean=    0.118477
+Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     : Initial state for member 2:
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.538916
+Test     :    tocn   min=   -3.373237   max=   31.466833   mean=    6.009999
+Test     :     ssh   min=   -1.920096   max=    0.991057   mean=   -0.280513
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :     chl   min=   -0.000741   max=    4.672040   mean=    0.118481
+Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     : Initial state for member 3:
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.571084
+Test     :    tocn   min=   -4.025426   max=   31.863681   mean=    6.030053
+Test     :     ssh   min=   -1.981225   max=    0.948331   mean=   -0.286933
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :     chl   min=   -0.000678   max=    4.672024   mean=    0.118489
+Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     : Initial state for member 4:
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.515829
+Test     :    tocn   min=   -3.777201   max=   32.054886   mean=    6.024774
+Test     :     ssh   min=   -1.878931   max=    0.946667   mean=   -0.260414
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :     chl   min=   -0.000986   max=    4.671970   mean=    0.118504
+Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     : Initial state for member 5:
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.547259
+Test     :    tocn   min=   -4.053497   max=   31.658321   mean=    6.016663
+Test     :     ssh   min=   -1.906226   max=    0.934702   mean=   -0.272621
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :     chl   min=   -0.000687   max=    4.671862   mean=    0.118466
+Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     : H(x) for member 1:
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=31.356113, RMS=24.215221
+Test     : H(x) for member 2:
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.698692, RMS=24.160496
+Test     : H(x) for member 3:
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.789898, RMS=24.315633
+Test     : H(x) for member 4:
+Test     : SeaSurfaceTemp nobs= 201 Min=-1.883003, Max=31.637488, RMS=24.153517
+Test     : H(x) for member 5:
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.611782, RMS=24.132900
+Test     : H(x) ensemble background mean: 
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.967726, RMS=24.191498
+Test     : background y - H(x): 
+Test     : SeaSurfaceTemp nobs= 201 Min=-5.273398, Max=4.326472, RMS=1.343445

--- a/test/testref/letkf_solver.test
+++ b/test/testref/letkf_solver.test
@@ -1,0 +1,114 @@
+Test     : Initial state for member 1:
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.530414
+Test     :    tocn   min=   -3.921668   max=   31.555520   mean=    6.045493
+Test     :     ssh   min=   -2.318490   max=    0.961947   mean=   -0.270186
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :     chl   min=   -0.000604   max=    4.672095   mean=    0.118477
+Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     : Initial state for member 2:
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.538916
+Test     :    tocn   min=   -3.373237   max=   31.466833   mean=    6.009999
+Test     :     ssh   min=   -1.920096   max=    0.991057   mean=   -0.280513
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :     chl   min=   -0.000741   max=    4.672040   mean=    0.118481
+Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     : Initial state for member 3:
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.571084
+Test     :    tocn   min=   -4.025426   max=   31.863681   mean=    6.030053
+Test     :     ssh   min=   -1.981225   max=    0.948331   mean=   -0.286933
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :     chl   min=   -0.000678   max=    4.672024   mean=    0.118489
+Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     : Initial state for member 4:
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.515829
+Test     :    tocn   min=   -3.777201   max=   32.054886   mean=    6.024774
+Test     :     ssh   min=   -1.878931   max=    0.946667   mean=   -0.260414
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :     chl   min=   -0.000986   max=    4.671970   mean=    0.118504
+Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     : Initial state for member 5:
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.547259
+Test     :    tocn   min=   -4.053497   max=   31.658321   mean=    6.016663
+Test     :     ssh   min=   -1.906226   max=    0.934702   mean=   -0.272621
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :     chl   min=   -0.000687   max=    4.671862   mean=    0.118466
+Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     : H(x) for member 1:
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=31.356113, RMS=24.215221
+Test     : H(x) for member 2:
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.698692, RMS=24.160496
+Test     : H(x) for member 3:
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.789898, RMS=24.315634
+Test     : H(x) for member 4:
+Test     : SeaSurfaceTemp nobs= 201 Min=-1.883003, Max=31.637487, RMS=24.153517
+Test     : H(x) for member 5:
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.611782, RMS=24.132900
+Test     : H(x) ensemble background mean: 
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.967726, RMS=24.191498
+Test     : background y - H(x): 
+Test     : SeaSurfaceTemp nobs= 201 Min=-5.273398, Max=4.326472, RMS=1.343445
+Test     : Background mean :
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.540700
+Test     :    tocn   min=   -2.719240   max=   31.710701   mean=    6.025396
+Test     :     ssh   min=   -1.898450   max=    0.956541   mean=   -0.274133
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :     chl   min=   -0.000367   max=    4.671998   mean=    0.118483
+Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     : Analysis mean :
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.537716
+Test     :    tocn   min=   -2.719240   max=   31.710701   mean=    6.028243
+Test     :     ssh   min=   -1.925407   max=    0.965278   mean=   -0.274043
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :     chl   min=   -0.000958   max=    4.671998   mean=    0.118481
+Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     : Analysis mean increment :
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    socn   min=   -1.308507   max=    0.715543   mean=   -0.002984
+Test     :    tocn   min=   -4.909225   max=    3.740613   mean=    0.002846
+Test     :     ssh   min=   -0.576840   max=    0.161442   mean=    0.000091
+Test     :    uocn   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :    vocn   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.001203   max=    0.000628   mean=   -0.000002
+Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     : Forecast variance :
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    socn   min=    0.000000   max=    1.308587   mean=    0.047659
+Test     :    tocn   min=    0.000000   max=    7.360339   mean=    0.202748
+Test     :     ssh   min=    0.000000   max=    0.088647   mean=    0.003542
+Test     :    uocn   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :    vocn   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     : Analysis variance :
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    socn   min=    0.000000   max=    2.245849   mean=    0.051704
+Test     :    tocn   min=    0.000000   max=   31.889118   mean=    0.243930
+Test     :     ssh   min=    0.000000   max=    0.468484   mean=    0.004114
+Test     :    uocn   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :    vocn   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=    0.000000   max=    0.000002   mean=    0.000000
+Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000


### PR DESCRIPTION
## Description

This PR changes the LETKF ctests to resemble the way we are actually running LETKF in soca-science, with a separate letkf observer, obs concatenation, and letkf solver series of steps. We were not catching some bugs in ioda/oops lektf-related PRs because the ctest in soca had been run as a single hofx/solver step.

Other changes that are kind of related:
- In order to actually see what is going on with the LETKF, I increased the size of the initial ensemble T perturbations.
- since anything ensemble related then had its answers changed, I took the opportunity to change all ctests to use the initial ensemble perturbation (i.e. the `PT0S` files, not the `PT6H` forecast) because the model forecast at this step has constantly been a source of rather large changes in answers on different machines. This should let me decrease some of those tolerances eventually

## Dependencies

There is a matching branch in ioda. PR will be issues once these TravisCI tests pass.
