### PR TITLE
instantiateObsLocFactory was moved from ioda to ufo

### DIFF
--- a/src/mains/LETKF.cc
+++ b/src/mains/LETKF.cc
@@ -6,15 +6,15 @@
  */
 
 #include "soca/Traits.h"
-#include "ioda/instantiateObsLocFactory.h"
 #include "oops/runs/LocalEnsembleDA.h"
 #include "oops/runs/Run.h"
 #include "ufo/instantiateObsFilterFactory.h"
+#include "ufo/instantiateObsLocFactory.h"
 #include "ufo/ObsTraits.h"
 
 int main(int argc,  char ** argv) {
   oops::Run run(argc, argv);
-  ioda::instantiateObsLocFactory<soca::Traits, ufo::ObsTraits>();
+  ufo::instantiateObsLocFactory<soca::Traits, ufo::ObsTraits>();
   ufo::instantiateObsFilterFactory<ufo::ObsTraits>();
   oops::LocalEnsembleDA<soca::Traits, ufo::ObsTraits> letkf;
   return run.execute(letkf);

--- a/test/executables/TestObsLocalization.cc
+++ b/test/executables/TestObsLocalization.cc
@@ -7,14 +7,14 @@
 
 #include "soca/Traits.h"
 
-#include "ioda/instantiateObsLocFactory.h"
 #include "oops/runs/Run.h"
 #include "test/interface/ObsLocalization.h"
+#include "ufo/instantiateObsLocFactory.h"
 #include "ufo/ObsTraits.h"
 
 int main(int argc,  char ** argv) {
   oops::Run run(argc, argv);
-  ioda::instantiateObsLocFactory<soca::Traits, ufo::ObsTraits>();
+  ufo::instantiateObsLocFactory<soca::Traits, ufo::ObsTraits>();
   test::ObsLocalization<soca::Traits, ufo::ObsTraits> tests;
   return run.execute(tests);
 }


### PR DESCRIPTION
## Description

https://github.com/JCSDA-internal/ioda/pull/221 and https://github.com/JCSDA-internal/ufo/pull/1082 move `instantiateObsLocFactory` from ioda to ufo.

## Dependencies

Waiting on the following PRs:
- [ ] waiting on https://github.com/JCSDA-internal/ioda/pull/221
- [ ] waiting on https://github.com/JCSDA-internal/ufo/pull/1082