### PR TITLE
remove OBS template parameter from instantiateObsLocFactory

### DIFF
--- a/src/mains/LETKF.cc
+++ b/src/mains/LETKF.cc
@@ -14,7 +14,7 @@
 
 int main(int argc,  char ** argv) {
   oops::Run run(argc, argv);
-  ufo::instantiateObsLocFactory<soca::Traits, ufo::ObsTraits>();
+  ufo::instantiateObsLocFactory<soca::Traits>();
   ufo::instantiateObsFilterFactory<ufo::ObsTraits>();
   oops::LocalEnsembleDA<soca::Traits, ufo::ObsTraits> letkf;
   return run.execute(letkf);

--- a/test/executables/TestObsLocalization.cc
+++ b/test/executables/TestObsLocalization.cc
@@ -14,7 +14,7 @@
 
 int main(int argc,  char ** argv) {
   oops::Run run(argc, argv);
-  ufo::instantiateObsLocFactory<soca::Traits, ufo::ObsTraits>();
+  ufo::instantiateObsLocFactory<soca::Traits>();
   test::ObsLocalization<soca::Traits, ufo::ObsTraits> tests;
   return run.execute(tests);
 }


### PR DESCRIPTION
## Description

https://github.com/JCSDA-internal/ufo/pull/1185 changes interface of `instantiateObsLocFactory` to only take one template parameter, MODEL.

This PR complies with that.

## Dependencies

- [ ] waiting on https://github.com/JCSDA-internal/oops/pull/1211
- [ ] waiting on https://github.com/JCSDA-internal/ufo/pull/1185