### PR TITLE
Add jedi-cmake to bundle.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@
 env:
   global:
     - MAIN_REPO=soca
-    - LIB_REPOS="jedi-cmake fckit atlas fms gsw mom6 crtm oops saber ioda ufo"
+    - LIB_REPOS="jedicmake fckit atlas fms gsw mom6 crtm oops saber ioda ufo"
     - BUILD_OPT=""
     - BUILD_OPT_fckit="-DBUILD_FCKIT=ON"
     - BUILD_OPT_atlas="-DBUILD_ATLAS=ON"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@
 env:
   global:
     - MAIN_REPO=soca
-    - LIB_REPOS="fckit atlas fms gsw mom6 crtm oops saber ioda ufo"
+    - LIB_REPOS="jedi-cmake fckit atlas fms gsw mom6 crtm oops saber ioda ufo"
     - BUILD_OPT=""
     - BUILD_OPT_fckit="-DBUILD_FCKIT=ON"
     - BUILD_OPT_atlas="-DBUILD_ATLAS=ON"

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -14,6 +14,8 @@ include( ecbuild_bundle )
 
 ecbuild_bundle_initialize()
 
+ecbuild_bundle( PROJECT jedicmake GIT "https://github.com/jcsda-internal/jedi-cmake.git" BRANCH develop UPDATE )
+include( jedicmake/cmake/Functions/git_functions.cmake  )
 
 # ECMWF repos that you probably dont need to build yourself because they
 #  should be in jedi-stack and the containers

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -14,7 +14,7 @@ include( ecbuild_bundle )
 
 ecbuild_bundle_initialize()
 
-ecbuild_bundle( PROJECT jedicmake GIT "https://github.com/jcsda-internal/jedi-cmake.git" BRANCH develop UPDATE )
+ecbuild_bundle( PROJECT jedicmake GIT "https://github.com/jcsda-internal/jedi-cmake.git" UPDATE BRANCH develop )
 include( jedicmake/cmake/Functions/git_functions.cmake  )
 
 # ECMWF repos that you probably dont need to build yourself because they


### PR DESCRIPTION
## Description

Add `jedi-cmake` to the bundle

What bug does it fix, or what feature does it add?
makes soca build with static netCDF libraries.

Is a change of answers expected from this PR?
No.

Issues:
closes #579 

## Testing

How were these changes tested?
In CI
What compilers / HPCs was it tested with?
Tested on machines with static netcdf libraries.
The changes do not impact containers or stacks built with jedi-stack.
Are the changes covered by ctests? (If not, tests should be added first.) - N/A