### PR TITLE
delete old log before running test

### DIFF
--- a/test/test_wrapper.sh
+++ b/test/test_wrapper.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
+# delete the existing log file
+output_log=testoutput/${COMPARE_TESTNAME}.log
+[[ -f "$output_log" ]] && rm $output_log
+
 # run the executable
 echo ""
 echo "==============================================================================="
 echo "Running test executable"
 echo "==============================================================================="
-${MPI_CMD} $1 $2 testoutput/${COMPARE_TESTNAME}.log
+${MPI_CMD} $1 $2 $output_log
 e=$?
 if [[ $e -gt 0 ]]; then
     echo -e "Failed to run executable. Error code: $e \n"
@@ -19,7 +23,7 @@ if [[ $SKIP_COMPARE == "FALSE" ]]; then
     echo "Running compare script"
     echo "==============================================================================="
 
-    $COMPARE_SCRIPT testoutput/${COMPARE_TESTNAME}.log testref/${COMPARE_TESTNAME}.test ${COMPARE_TOL_F} ${COMPARE_TOL_I}
+    $COMPARE_SCRIPT $output_log testref/${COMPARE_TESTNAME}.test ${COMPARE_TOL_F} ${COMPARE_TOL_I}
     e=$?
     if [[ $e -gt 0 ]]; then
         echo -e "Failed in the COMPARE step. Error code: $e \n"


### PR DESCRIPTION
## Description

@mmiesch pointed out that we could be getting problems with the new eckit because of the way it handles output logs.
(see https://github.com/JCSDA-internal/oops/pull/1105)
Deleting the old log file before running the test fixes it.
