### PR TITLE
add "irr_mix" to MOM.res.nc

### DIFF
--- a/test/Data/72x35x25/INPUT/MOM.res.nc
+++ b/test/Data/72x35x25/INPUT/MOM.res.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92c142af8de5666ed596a0cbd55fdedc3acccd438e06896967024e8e9060e168
-size 7945856
+oid sha256:d4b96d2855decb6eeb05705ee01cd51db35529d969c3050601f98c4b12582c36
+size 8456693


### PR DESCRIPTION
## Description

Add `irr_mix` to `MOM.res.nc` which is required for BGC [checkpoint applications](https://github.com/JCSDA-internal/soca-science/blob/bgc_ckpts_bugfix/tools/ocn_bgc/soca_ocn_bgc.py) in `soca-science` workflow.



### Issue(s) addressed

- fixes JCSDA-internal/soca-science/issues/300 (it is not directly related to this issue but is required by the [PR](https://github.com/JCSDA-internal/soca-science/pull/303) that fixes this issue)



## Testing

Hera, intel


