### PR TITLE
Addition of an error trap when attempting to use SocaError with u, v

### DIFF
--- a/src/soca/Covariance/soca_covariance_mod.F90
+++ b/src/soca/Covariance/soca_covariance_mod.F90
@@ -96,6 +96,8 @@ subroutine soca_cov_setup(self, f_conf, geom, bkg, vars)
         init_seaice = .true.
      case('tocn', 'socn', 'ssh', 'chl', 'biop')
         init_ocean = .true.
+     case('uocn', 'vocn')
+        call abor1_ftn("soca_covariance: No covariance model for (u, v) yet.")
      end select
   end do
 

--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -9,7 +9,7 @@ cost function:
   cost type: 3D-Var
   window begin: 2018-04-14T00:00:00Z
   window length: P2D
-  analysis variables: &soca_vars [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us, uocn, vocn, mld, layer_depth]
+  analysis variables: &soca_vars [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us, mld, layer_depth]
   geometry:
     mom6_input_nml: ./inputnml/input.nml
     fields metadata: ./fields_metadata.yml

--- a/test/testinput/3dvarfgat_pseudo.yml
+++ b/test/testinput/3dvarfgat_pseudo.yml
@@ -9,7 +9,7 @@ cost function:
   cost type: 4D-Var
   window begin: &date_begin 2018-04-15T00:00:00Z
   window length: PT6H
-  analysis variables: &soca_vars  [socn, tocn, ssh, hocn, uocn, vocn]
+  analysis variables: &soca_vars  [socn, tocn, ssh, hocn]
   geometry:
     mom6_input_nml: ./inputnml/input.nml
     fields metadata: ./fields_metadata.yml

--- a/test/testinput/addincrement.yml
+++ b/test/testinput/addincrement.yml
@@ -21,7 +21,7 @@ increment:
   ocn_filename: ocn.3dvargodas.iter1.incr.2018-04-15T00:00:00Z.nc
   ice_filename: ice.3dvargodas.iter1.incr.2018-04-15T00:00:00Z.nc
   date: *bkg_date
-  added variables: [hsnon, socn, tocn, hocn, uocn, vocn]
+  added variables: [hsnon, socn, tocn, hocn]
 
 output:
   datadir: Data

--- a/test/testref/3dvar_godas.test
+++ b/test/testref/3dvar_godas.test
@@ -22,8 +22,6 @@ Test     :     lhf   min=  -38.137473   max=  256.595744   mean=   42.009726
 Test     :     shf   min=  -58.949303   max=  201.374228   mean=    6.075328
 Test     :      lw   min=    0.000000   max=   88.036090   mean=   31.395535
 Test     :      us   min=    0.004396   max=    0.019666   mean=    0.008686
-Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
-Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : CostJb   : Nonlinear Jb = 0.542497


### PR DESCRIPTION
closes #586 