### PR TITLE
invent bkg error for chl and biop

### DIFF
--- a/src/soca/Transforms/BkgErr/soca_bkgerr_mod.F90
+++ b/src/soca/Transforms/BkgErr/soca_bkgerr_mod.F90
@@ -88,6 +88,9 @@ subroutine soca_bkgerr_setup(f_conf, self, bkg, geom)
     case ('sw','lw','lhf','shf','us')
       call bkg%get(field%name, field_bkg)
       field%val = abs(field_bkg%val) * 0.1_kind_real
+    case ('chl','biop')
+      call bkg%get(field%name, field_bkg)
+      field%val = abs(field_bkg%val) * 0.2_kind_real
     end select
   end do
 

--- a/src/soca/Transforms/BkgErr/soca_bkgerr_mod.F90
+++ b/src/soca/Transforms/BkgErr/soca_bkgerr_mod.F90
@@ -79,9 +79,10 @@ subroutine soca_bkgerr_setup(f_conf, self, bkg, geom)
       field%val(:,:,1) = self%std_sss
   end if
 
-  ! Invent background error for ocnsfc fields: set it
-  ! to 10% of the background for now ...
-  ! TODO: Read background error for ocnsfc from file
+  ! Invent background error for ocnsfc and ocn_bgc fields: 
+  ! set it to 10% or 20% of the background for now ...
+  ! TODO: Read background error for ocnsfc and ocn_bgc from 
+  ! files
   do i=1,size(self%std_bkgerr%fields)
     field => self%std_bkgerr%fields(i)
     select case(field%name)

--- a/src/soca/Transforms/BkgErrGodas/soca_bkgerrgodas_mod.F90
+++ b/src/soca/Transforms/BkgErrGodas/soca_bkgerrgodas_mod.F90
@@ -78,8 +78,8 @@ subroutine soca_bkgerrgodas_setup(f_conf, self, bkg, geom)
   call soca_bkgerrgodas_socn(self)
   call soca_bkgerrgodas_ssh(self)
 
-  ! Invent background error for ocnsfc fields: set it
-  ! to 10% of the background for now ...
+  ! Invent background error for ocnsfc and ocn_bgc fields: set 
+  ! it to 10% or 20% of the background for now ...
   do i=1,size(self%std_bkgerr%fields)
     field => self%std_bkgerr%fields(i)
     select case(field%name)

--- a/src/soca/Transforms/BkgErrGodas/soca_bkgerrgodas_mod.F90
+++ b/src/soca/Transforms/BkgErrGodas/soca_bkgerrgodas_mod.F90
@@ -87,6 +87,9 @@ subroutine soca_bkgerrgodas_setup(f_conf, self, bkg, geom)
       call bkg%get(field%name, field_bkg)
       field%val = abs(field_bkg%val)
       field%val = 0.1_kind_real * field%val
+    case ('chl','biop')
+      call bkg%get(field%name, field_bkg)
+      field%val = abs(field_bkg%val) * 0.2_kind_real
     end select
   end do
 

--- a/test/testref/3dvar_soca.test
+++ b/test/testref/3dvar_soca.test
@@ -9,32 +9,32 @@ Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 679.22, nobs = 89, Jo/n = 7
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceChlorophyll) = 1536.63, nobs = 129, Jo/n = 11.9119, err = 0.061865
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceBiomassP) = 395.024, nobs = 112, Jo/n = 3.527, err = 1.16926e-08
 Test     : CostFunction: Nonlinear J = 18745.1
-Test     : RPCGMinimizer: reduction in residual norm = 0.17909
+Test     : RPCGMinimizer: reduction in residual norm = 0.168004
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.000290   max=    1.000464   mean=    0.117564
+Test     :   cicen   min=   -0.000281   max=    1.000450   mean=    0.117563
 Test     :   hicen   min=    0.000000   max=    4.032667   mean=    0.471252
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544419
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.019790
-Test     :     ssh   min=   -1.924665   max=    0.927289   mean=   -0.276705
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544418
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.019727
+Test     :     ssh   min=   -1.924660   max=    0.927288   mean=   -0.276707
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :      sw   min= -225.095245   max=    0.000000   mean=  -71.738229
-Test     :     lhf   min=  -38.137487   max=  256.595650   mean=   42.009658
-Test     :     shf   min=  -58.949308   max=  201.374187   mean=    6.075326
+Test     :      sw   min= -225.095244   max=    0.000000   mean=  -71.738250
+Test     :     lhf   min=  -38.137485   max=  256.595671   mean=   42.009667
+Test     :     shf   min=  -58.949307   max=  201.374190   mean=    6.075326
 Test     :      lw   min=    0.000000   max=   88.036092   mean=   31.395535
-Test     :      us   min=    0.004396   max=    0.019671   mean=    0.008691
-Test     :     chl   min=   -0.000061   max=    4.671862   mean=    0.117818
+Test     :      us   min=    0.004396   max=    0.019671   mean=    0.008690
+Test     :     chl   min=   -0.000018   max=    4.671970   mean=    0.118371
 Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 10.168308
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 13914.356020, nobs = 173, Jo/n = 80.429804, err = 0.363227
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 781.041043, nobs = 145, Jo/n = 5.386490, err = 0.363828
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 5.519061, nobs = 28, Jo/n = 0.197109, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 159.419831, nobs = 92, Jo/n = 1.732824, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.697028, nobs = 206, Jo/n = 1.692704, err = 0.897281
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 353.672413, nobs = 218, Jo/n = 1.622351, err = 0.608197
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 677.533257, nobs = 89, Jo/n = 7.612733, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceChlorophyll) = 1272.786018, nobs = 129, Jo/n = 9.866558, err = 0.061865
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceBiomassP) = 361.314325, nobs = 112, Jo/n = 3.226021, err = 0.000000
-Test     : CostFunction: Nonlinear J = 17884.507304
+Test     : CostJb   : Nonlinear Jb = 6.215209
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 13921.101923, nobs = 173, Jo/n = 80.468797, err = 0.363227
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 781.278326, nobs = 145, Jo/n = 5.388126, err = 0.363828
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 5.519078, nobs = 28, Jo/n = 0.197110, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 159.420734, nobs = 92, Jo/n = 1.732834, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.699884, nobs = 206, Jo/n = 1.692718, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 353.723800, nobs = 218, Jo/n = 1.622586, err = 0.608197
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 677.582985, nobs = 89, Jo/n = 7.613292, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceChlorophyll) = 1488.455367, nobs = 129, Jo/n = 11.538414, err = 0.061865
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceBiomassP) = 362.270963, nobs = 112, Jo/n = 3.234562, err = 0.000000
+Test     : CostFunction: Nonlinear J = 18104.268268

--- a/test/testref/3dvar_soca.test
+++ b/test/testref/3dvar_soca.test
@@ -28,8 +28,8 @@ Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : CostJb   : Nonlinear Jb = 6.215209
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 13921.101923, nobs = 173, Jo/n = 80.468797, err = 0.363227
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 781.278326, nobs = 145, Jo/n = 5.388126, err = 0.363828
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 13921.101924, nobs = 173, Jo/n = 80.468797, err = 0.363227
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 781.278325, nobs = 145, Jo/n = 5.388126, err = 0.363828
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 5.519078, nobs = 28, Jo/n = 0.197110, err = 1.000000
 Test     : CostJo   : Nonlinear Jo(ADT) = 159.420734, nobs = 92, Jo/n = 1.732834, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.699884, nobs = 206, Jo/n = 1.692718, err = 0.897281
@@ -37,4 +37,4 @@ Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 353.723800, nobs = 218, Jo/
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 677.582985, nobs = 89, Jo/n = 7.613292, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceChlorophyll) = 1488.455367, nobs = 129, Jo/n = 11.538414, err = 0.061865
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceBiomassP) = 362.270963, nobs = 112, Jo/n = 3.234562, err = 0.000000
-Test     : CostFunction: Nonlinear J = 18104.268268
+Test     : CostFunction: Nonlinear J = 18104.268269

--- a/test/testref/3dvarbump.test
+++ b/test/testref/3dvarbump.test
@@ -9,15 +9,15 @@ Test     : RPCGMinimizer: reduction in residual norm = 0.124916
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    hocn   min=    0.001000   max= 1297.170000   mean=  110.562284
-Test     :    socn   min=    0.000000   max=   37.222572   mean=   28.647745
-Test     :    tocn   min=   -2.450407   max=   38.306498   mean=    5.053292
-Test     :     ssh   min=   -2.012003   max=    0.971214   mean=   -0.142469
+Test     :    socn   min=    0.000000   max=   37.222565   mean=   28.647745
+Test     :    tocn   min=   -2.450406   max=   38.306614   mean=    5.053292
+Test     :     ssh   min=   -2.012002   max=    0.971216   mean=   -0.142469
 Test     :     mld   min=    0.000500   max= 3446.494302   mean=  119.933096
 Test     : layer_depth   min=    0.000500   max= 5592.096099   mean= 1053.471947
-Test     : CostJb   : Nonlinear Jb = 159.765938
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 201.891150, nobs = 80, Jo/n = 2.523639, err = 0.381671
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 28.908745, nobs = 42, Jo/n = 0.688303, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 136.925218, nobs = 84, Jo/n = 1.630062, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 210.580264, nobs = 134, Jo/n = 1.571495, err = 0.913795
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 411581.213634, nobs = 218, Jo/n = 1887.987219, err = 0.608197
-Test     : CostFunction: Nonlinear J = 412319.284951
+Test     : CostJb   : Nonlinear Jb = 159.767446
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 201.891297, nobs = 80, Jo/n = 2.523641, err = 0.381671
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 28.908698, nobs = 42, Jo/n = 0.688302, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 136.925639, nobs = 84, Jo/n = 1.630067, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 210.580556, nobs = 134, Jo/n = 1.571497, err = 0.913795
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 411581.214746, nobs = 218, Jo/n = 1887.987224, err = 0.608197
+Test     : CostFunction: Nonlinear J = 412319.288382

--- a/test/testref/3dvarbump.test
+++ b/test/testref/3dvarbump.test
@@ -9,15 +9,15 @@ Test     : RPCGMinimizer: reduction in residual norm = 0.124916
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    hocn   min=    0.001000   max= 1297.170000   mean=  110.562284
-Test     :    socn   min=    0.000000   max=   37.222565   mean=   28.647745
-Test     :    tocn   min=   -2.450406   max=   38.306614   mean=    5.053292
-Test     :     ssh   min=   -2.012002   max=    0.971216   mean=   -0.142469
+Test     :    socn   min=    0.000000   max=   37.222572   mean=   28.647745
+Test     :    tocn   min=   -2.450407   max=   38.306498   mean=    5.053292
+Test     :     ssh   min=   -2.012003   max=    0.971214   mean=   -0.142469
 Test     :     mld   min=    0.000500   max= 3446.494302   mean=  119.933096
 Test     : layer_depth   min=    0.000500   max= 5592.096099   mean= 1053.471947
-Test     : CostJb   : Nonlinear Jb = 159.767446
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 201.891297, nobs = 80, Jo/n = 2.523641, err = 0.381671
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 28.908698, nobs = 42, Jo/n = 0.688302, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 136.925639, nobs = 84, Jo/n = 1.630067, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 210.580556, nobs = 134, Jo/n = 1.571497, err = 0.913795
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 411581.214746, nobs = 218, Jo/n = 1887.987224, err = 0.608197
-Test     : CostFunction: Nonlinear J = 412319.288382
+Test     : CostJb   : Nonlinear Jb = 159.765938
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 201.891150, nobs = 80, Jo/n = 2.523639, err = 0.381671
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 28.908745, nobs = 42, Jo/n = 0.688303, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 136.925218, nobs = 84, Jo/n = 1.630062, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 210.580264, nobs = 134, Jo/n = 1.571495, err = 0.913795
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 411581.213634, nobs = 218, Jo/n = 1887.987219, err = 0.608197
+Test     : CostFunction: Nonlinear J = 412319.284951

--- a/test/testref/enspert.test
+++ b/test/testref/enspert.test
@@ -29,8 +29,8 @@ Test     :    uocn   min=   -0.854580   max=    0.695502   mean=   -0.000320
 Test     :    vocn   min=   -0.800340   max=    1.220078   mean=    0.001958
 Test     :     ssh   min=   -1.915334   max=    0.925063   mean=   -0.276765
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628068
-Test     :     chl   min=   -0.000604   max=    4.672095   mean=    0.118477
-Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.051729   max=    4.700469   mean=    0.117903
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
@@ -49,8 +49,8 @@ Test     :    uocn   min=   -0.853313   max=    0.699470   mean=   -0.000116
 Test     :    vocn   min=   -0.746604   max=    1.263707   mean=    0.002166
 Test     :     ssh   min=   -2.134823   max=    0.923897   mean=   -0.276818
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628054
-Test     :     chl   min=   -0.000741   max=    4.672040   mean=    0.118481
-Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.081377   max=    4.681366   mean=    0.118773
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
@@ -69,8 +69,8 @@ Test     :    uocn   min=   -0.853151   max=    0.633003   mean=   -0.000101
 Test     :    vocn   min=   -0.771857   max=    1.196984   mean=    0.001925
 Test     :     ssh   min=   -2.146851   max=    0.924332   mean=   -0.276873
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628062
-Test     :     chl   min=   -0.000678   max=    4.672024   mean=    0.118489
-Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.044430   max=    4.690656   mean=    0.119621
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
@@ -89,8 +89,8 @@ Test     :    uocn   min=   -0.851368   max=    0.688408   mean=   -0.000218
 Test     :    vocn   min=   -0.658992   max=    1.185960   mean=    0.001827
 Test     :     ssh   min=   -2.129719   max=    0.929467   mean=   -0.276830
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628084
-Test     :     chl   min=   -0.000986   max=    4.671970   mean=    0.118504
-Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.109219   max=    4.665663   mean=    0.119050
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
@@ -109,8 +109,8 @@ Test     :    uocn   min=   -0.846680   max=    0.713136   mean=    0.000045
 Test     :    vocn   min=   -0.820975   max=    1.280726   mean=    0.001942
 Test     :     ssh   min=   -2.113567   max=    0.931606   mean=   -0.276670
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628111
-Test     :     chl   min=   -0.000687   max=    4.671862   mean=    0.118466
-Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.042475   max=    4.643249   mean=    0.117869
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334

--- a/test/testref/letkf_observer.test
+++ b/test/testref/letkf_observer.test
@@ -6,8 +6,8 @@ Test     :     ssh   min=   -2.318490   max=    0.961947   mean=   -0.270186
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.000604   max=    4.672095   mean=    0.118477
-Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.051729   max=    4.700469   mean=    0.117903
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Initial state for member 2:
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.538916
@@ -16,8 +16,8 @@ Test     :     ssh   min=   -1.920096   max=    0.991057   mean=   -0.280513
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.000741   max=    4.672040   mean=    0.118481
-Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.081377   max=    4.681366   mean=    0.118773
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Initial state for member 3:
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.571084
@@ -26,8 +26,8 @@ Test     :     ssh   min=   -1.981225   max=    0.948331   mean=   -0.286933
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.000678   max=    4.672024   mean=    0.118489
-Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.044430   max=    4.690656   mean=    0.119621
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Initial state for member 4:
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.515829
@@ -36,8 +36,8 @@ Test     :     ssh   min=   -1.878931   max=    0.946667   mean=   -0.260414
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.000986   max=    4.671970   mean=    0.118504
-Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.109219   max=    4.665663   mean=    0.119050
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Initial state for member 5:
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.547259
@@ -46,8 +46,8 @@ Test     :     ssh   min=   -1.906226   max=    0.934702   mean=   -0.272621
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.000687   max=    4.671862   mean=    0.118466
-Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.042475   max=    4.643249   mean=    0.117869
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : H(x) for member 1:
 Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=31.356113, RMS=24.215221
 Test     : H(x) for member 2:

--- a/test/testref/letkf_solver.test
+++ b/test/testref/letkf_solver.test
@@ -6,8 +6,8 @@ Test     :     ssh   min=   -2.318490   max=    0.961947   mean=   -0.270186
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.000604   max=    4.672095   mean=    0.118477
-Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.051729   max=    4.700469   mean=    0.117903
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Initial state for member 2:
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.538916
@@ -16,8 +16,8 @@ Test     :     ssh   min=   -1.920096   max=    0.991057   mean=   -0.280513
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.000741   max=    4.672040   mean=    0.118481
-Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.081377   max=    4.681366   mean=    0.118773
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Initial state for member 3:
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.571084
@@ -26,8 +26,8 @@ Test     :     ssh   min=   -1.981225   max=    0.948331   mean=   -0.286933
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.000678   max=    4.672024   mean=    0.118489
-Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.044430   max=    4.690656   mean=    0.119621
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Initial state for member 4:
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.515829
@@ -36,8 +36,8 @@ Test     :     ssh   min=   -1.878931   max=    0.946667   mean=   -0.260414
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.000986   max=    4.671970   mean=    0.118504
-Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.109219   max=    4.665663   mean=    0.119050
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Initial state for member 5:
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.547259
@@ -46,8 +46,8 @@ Test     :     ssh   min=   -1.906226   max=    0.934702   mean=   -0.272621
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.000687   max=    4.671862   mean=    0.118466
-Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.042475   max=    4.643249   mean=    0.117869
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : H(x) for member 1:
 Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=31.356113, RMS=24.215221
 Test     : H(x) for member 2:
@@ -70,8 +70,8 @@ Test     :     ssh   min=   -1.898450   max=    0.956541   mean=   -0.274133
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.000367   max=    4.671998   mean=    0.118483
-Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.023688   max=    4.676281   mean=    0.118643
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Analysis mean :
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.537716
@@ -80,8 +80,8 @@ Test     :     ssh   min=   -1.925407   max=    0.965278   mean=   -0.274043
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.000958   max=    4.671998   mean=    0.118481
-Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.023718   max=    4.676281   mean=    0.118721
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Analysis mean increment :
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    socn   min=   -1.308507   max=    0.715543   mean=   -0.002984
@@ -90,8 +90,8 @@ Test     :     ssh   min=   -0.576840   max=    0.161442   mean=    0.000091
 Test     :    uocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :    vocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     :     chl   min=   -0.001203   max=    0.000628   mean=   -0.000002
-Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=   -0.032841   max=    0.084797   mean=    0.000078
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=   -0.000000
 Test     : Forecast variance :
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    socn   min=    0.000000   max=    1.308587   mean=    0.047659
@@ -100,7 +100,7 @@ Test     :     ssh   min=    0.000000   max=    0.088647   mean=    0.003542
 Test     :    uocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :    vocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     :     chl   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     :     chl   min=    0.000000   max=    0.032514   mean=    0.000086
 Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : Analysis variance :
 Test     :   Valid time: 2018-04-15T00:00:00Z
@@ -110,5 +110,5 @@ Test     :     ssh   min=    0.000000   max=    0.468484   mean=    0.004114
 Test     :    uocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :    vocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     :     chl   min=    0.000000   max=    0.000002   mean=    0.000000
+Test     :     chl   min=    0.000000   max=    0.032514   mean=    0.000095
 Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000


### PR DESCRIPTION
## Description

Invent `bkgerr` for chl and biop = 20% x `bkg` if static values are not provided.

### Issue(s) addressed

- fixes #588 


## Testing

Hera, Orion, w/ Intel



