### PR TITLE
remove hardcoded masked interp for atmospheric flux fields

### DIFF
--- a/src/soca/GetValues/soca_getvalues_mod.F90
+++ b/src/soca/GetValues/soca_getvalues_mod.F90
@@ -140,13 +140,6 @@ subroutine soca_getvalues_fillgeovals(self, geom, fld, t1, t2, locs, geovals)
     allocate(fld3d(isc:iec,jsc:jec,1:nval))
 
     masked = fldptr%metadata%masked
-    ! TODO, the following is an override to keep same answers during a PR,
-    ! it should be removed in its own PR
-    select case (fldptr%metadata%name)
-    case ('sw', 'lw', 'lhf', 'shf', 'us')          
-      masked = .true.
-    end select
-
     fld3d = fldptr%val(isc:iec,jsc:jec,1:nval)
 
     ! Apply forward interpolation: Model ---> Obs
@@ -225,12 +218,6 @@ subroutine soca_getvalues_fillgeovals_ad(self, geom, incr, t1, t2, locs, geovals
 
     ! determine if this variable should use the masked grid
     masked = field%metadata%masked
-    ! TODO, the following is an override to keep same answers during a PR,
-    ! it should be removed in its own PR
-    select case (field%metadata%name)
-    case ('sw', 'lw', 'lhf', 'shf', 'us')          
-      masked = .true.
-    end select
 
     ! Apply backward interpolation: Obs ---> Model
     if (masked) then

--- a/test/testref/3dvar_godas.test
+++ b/test/testref/3dvar_godas.test
@@ -1,35 +1,35 @@
 Test     : CostJb   : Nonlinear Jb = 0
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 17276.6, nobs = 201, Jo/n = 85.9534, err = 0.364832
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 17245.8, nobs = 201, Jo/n = 85.7998, err = 0.364832
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 1625.53, nobs = 173, Jo/n = 9.39612, err = 0.363227
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 5.51964, nobs = 28, Jo/n = 0.19713, err = 1
 Test     : CostJo   : Nonlinear Jo(ADT) = 212.909, nobs = 95, Jo/n = 2.24115, err = 0.1
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.787, nobs = 206, Jo/n = 1.69314, err = 0.897281
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 355.419, nobs = 218, Jo/n = 1.63036, err = 0.608197
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 679.22, nobs = 89, Jo/n = 7.63169, err = 0.1
-Test     : CostFunction: Nonlinear J = 20504
-Test     : RPCGMinimizer: reduction in residual norm = 0.130615
+Test     : CostFunction: Nonlinear J = 20473.1
+Test     : RPCGMinimizer: reduction in residual norm = 0.128721
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.000065   max=    1.000293   mean=    0.117547
+Test     :   cicen   min=   -0.000068   max=    1.000288   mean=    0.117546
 Test     :   hicen   min=    0.000000   max=    4.032667   mean=    0.471252
 Test     :   hsnon   min=    0.000000   max=    1.271283   mean=    0.088687
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544421
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018368
-Test     :     ssh   min=   -1.924827   max=    0.927291   mean=   -0.276777
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018375
+Test     :     ssh   min=   -1.924822   max=    0.927291   mean=   -0.276777
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :      sw   min= -225.094437   max=    0.000000   mean=  -71.738390
-Test     :     lhf   min=  -38.137473   max=  256.595744   mean=   42.009726
-Test     :     shf   min=  -58.949303   max=  201.374228   mean=    6.075328
-Test     :      lw   min=    0.000000   max=   88.036090   mean=   31.395535
-Test     :      us   min=    0.004396   max=    0.019666   mean=    0.008686
+Test     :      sw   min= -225.094293   max=    0.000000   mean=  -71.738419
+Test     :     lhf   min=  -38.137473   max=  256.595741   mean=   42.009738
+Test     :     shf   min=  -58.949303   max=  201.374229   mean=    6.075328
+Test     :      lw   min=    0.000000   max=   88.036090   mean=   31.395534
+Test     :      us   min=    0.004396   max=    0.019666   mean=    0.008685
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 0.542497
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 16675.539789, nobs = 201, Jo/n = 82.962885, err = 0.364832
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 1595.789091, nobs = 173, Jo/n = 9.224214, err = 0.363227
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 5.519040, nobs = 28, Jo/n = 0.197109, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 212.797249, nobs = 95, Jo/n = 2.239971, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 347.108080, nobs = 206, Jo/n = 1.684991, err = 0.897281
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 353.875424, nobs = 218, Jo/n = 1.623282, err = 0.608197
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 678.155755, nobs = 89, Jo/n = 7.619728, err = 0.100000
-Test     : CostFunction: Nonlinear J = 19869.326924
+Test     : CostJb   : Nonlinear Jb = 0.543267
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 16678.877306, nobs = 201, Jo/n = 82.979489, err = 0.364832
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 1595.820536, nobs = 173, Jo/n = 9.224396, err = 0.363227
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 5.519048, nobs = 28, Jo/n = 0.197109, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 212.798602, nobs = 95, Jo/n = 2.239985, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 347.132403, nobs = 206, Jo/n = 1.685109, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 353.897484, nobs = 218, Jo/n = 1.623383, err = 0.608197
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 678.170989, nobs = 89, Jo/n = 7.619899, err = 0.100000
+Test     : CostFunction: Nonlinear J = 19872.759635

--- a/test/testref/3dvar_soca.test
+++ b/test/testref/3dvar_soca.test
@@ -1,5 +1,5 @@
 Test     : CostJb   : Nonlinear Jb = 0
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 14473.8, nobs = 173, Jo/n = 83.6638, err = 0.363227
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 14435.1, nobs = 173, Jo/n = 83.4402, err = 0.363227
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 791.222, nobs = 145, Jo/n = 5.4567, err = 0.363828
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 5.51964, nobs = 28, Jo/n = 0.19713, err = 1
 Test     : CostJo   : Nonlinear Jo(ADT) = 159.451, nobs = 92, Jo/n = 1.73316, err = 0.1
@@ -8,33 +8,33 @@ Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 355.419, nobs = 218, Jo/n =
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 679.22, nobs = 89, Jo/n = 7.63169, err = 0.1
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceChlorophyll) = 1536.63, nobs = 129, Jo/n = 11.9119, err = 0.061865
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceBiomassP) = 395.024, nobs = 112, Jo/n = 3.527, err = 1.16926e-08
-Test     : CostFunction: Nonlinear J = 18745.1
-Test     : RPCGMinimizer: reduction in residual norm = 0.168004
+Test     : CostFunction: Nonlinear J = 18706.4
+Test     : RPCGMinimizer: reduction in residual norm = 0.166869
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.000281   max=    1.000450   mean=    0.117563
+Test     :   cicen   min=   -0.000276   max=    1.000441   mean=    0.117562
 Test     :   hicen   min=    0.000000   max=    4.032667   mean=    0.471252
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544418
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.019727
-Test     :     ssh   min=   -1.924660   max=    0.927288   mean=   -0.276707
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544417
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.019676
+Test     :     ssh   min=   -1.924656   max=    0.927288   mean=   -0.276709
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :      sw   min= -225.095244   max=    0.000000   mean=  -71.738250
-Test     :     lhf   min=  -38.137485   max=  256.595671   mean=   42.009667
-Test     :     shf   min=  -58.949307   max=  201.374190   mean=    6.075326
+Test     :      sw   min= -225.094275   max=    0.000000   mean=  -71.738263
+Test     :     lhf   min=  -38.137485   max=  256.595648   mean=   42.009673
+Test     :     shf   min=  -58.949307   max=  201.374192   mean=    6.075326
 Test     :      lw   min=    0.000000   max=   88.036092   mean=   31.395535
-Test     :      us   min=    0.004396   max=    0.019671   mean=    0.008690
-Test     :     chl   min=   -0.000018   max=    4.671970   mean=    0.118371
+Test     :      us   min=    0.004396   max=    0.019670   mean=    0.008690
+Test     :     chl   min=   -0.000017   max=    4.671970   mean=    0.118373
 Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 6.215209
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 13921.101924, nobs = 173, Jo/n = 80.468797, err = 0.363227
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 781.278325, nobs = 145, Jo/n = 5.388126, err = 0.363828
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 5.519078, nobs = 28, Jo/n = 0.197110, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 159.420734, nobs = 92, Jo/n = 1.732834, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.699884, nobs = 206, Jo/n = 1.692718, err = 0.897281
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 353.723800, nobs = 218, Jo/n = 1.622586, err = 0.608197
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 677.582985, nobs = 89, Jo/n = 7.613292, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceChlorophyll) = 1488.455367, nobs = 129, Jo/n = 11.538414, err = 0.061865
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceBiomassP) = 362.270963, nobs = 112, Jo/n = 3.234562, err = 0.000000
-Test     : CostFunction: Nonlinear J = 18104.268269
+Test     : CostJb   : Nonlinear Jb = 5.962082
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 13890.695761, nobs = 173, Jo/n = 80.293039, err = 0.363227
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 781.433693, nobs = 145, Jo/n = 5.389198, err = 0.363828
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 5.519089, nobs = 28, Jo/n = 0.197110, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 159.421116, nobs = 92, Jo/n = 1.732838, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.701625, nobs = 206, Jo/n = 1.692726, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 353.755838, nobs = 218, Jo/n = 1.622733, err = 0.608197
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 677.613987, nobs = 89, Jo/n = 7.613640, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceChlorophyll) = 1489.343966, nobs = 129, Jo/n = 11.545302, err = 0.061865
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceBiomassP) = 362.866609, nobs = 112, Jo/n = 3.239880, err = 0.000000
+Test     : CostFunction: Nonlinear J = 18075.313766

--- a/test/testref/3dvarfgat.test
+++ b/test/testref/3dvarfgat.test
@@ -1,20 +1,20 @@
 Test     : CostJb   : Nonlinear Jb = 0
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 5270.89, nobs = 48, Jo/n = 109.81, err = 0.387632
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 5267.52, nobs = 48, Jo/n = 109.74, err = 0.387632
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 307.259, nobs = 43, Jo/n = 7.14556, err = 0.385815
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.4826, nobs = 17, Jo/n = 0.146035, err = 1
 Test     : CostJo   : Nonlinear Jo(ADT) = 86.7398, nobs = 29, Jo/n = 2.99103, err = 0.1
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 41.0886, nobs = 31, Jo/n = 1.32544, err = 0.90894
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.7637, nobs = 33, Jo/n = 0.447385, err = 0.61043
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 255.973, nobs = 24, Jo/n = 10.6655, err = 0.1
-Test     : CostFunction: Nonlinear J = 5979.2
-Test     : RPCGMinimizer: reduction in residual norm = 0.44451
+Test     : CostFunction: Nonlinear J = 5975.82
+Test     : RPCGMinimizer: reduction in residual norm = 0.444368
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.007489   max=    1.239763   mean=    0.129424
+Test     :   cicen   min=   -0.007474   max=    1.239947   mean=    0.129433
 Test     :   hicen   min=    0.000000   max=    4.032667   mean=    0.471252
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.548590
-Test     :    tocn   min=   -1.888390   max=   31.920138   mean=    6.041353
-Test     :     ssh   min=   -1.923527   max=    0.927135   mean=   -0.277137
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.548593
+Test     :    tocn   min=   -1.888390   max=   31.921784   mean=    6.041329
+Test     :     ssh   min=   -1.923526   max=    0.927135   mean=   -0.277139
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
@@ -23,12 +23,12 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 1284.472933
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 3470.792632, nobs = 48, Jo/n = 72.308180, err = 0.387632
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 733.656828, nobs = 43, Jo/n = 17.061787, err = 0.385815
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.439776, nobs = 17, Jo/n = 0.143516, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 83.638224, nobs = 29, Jo/n = 2.884077, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 39.661420, nobs = 31, Jo/n = 1.279401, err = 0.908940
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 13.672151, nobs = 33, Jo/n = 0.414308, err = 0.610430
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 101.413503, nobs = 24, Jo/n = 4.225563, err = 0.100000
-Test     : CostFunction: Nonlinear J = 5729.747467
+Test     : CostJb   : Nonlinear Jb = 1283.647477
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 3467.832944, nobs = 48, Jo/n = 72.246520, err = 0.387632
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 733.494978, nobs = 43, Jo/n = 17.058023, err = 0.385815
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.439744, nobs = 17, Jo/n = 0.143514, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 83.639182, nobs = 29, Jo/n = 2.884110, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 39.660595, nobs = 31, Jo/n = 1.279374, err = 0.908940
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 13.671412, nobs = 33, Jo/n = 0.414285, err = 0.610430
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 101.345890, nobs = 24, Jo/n = 4.222745, err = 0.100000
+Test     : CostFunction: Nonlinear J = 5725.732222

--- a/test/testref/checkpointmodel.test
+++ b/test/testref/checkpointmodel.test
@@ -6,10 +6,10 @@ Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544421
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018368
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018375
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : output background: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721046   max=   38.000000   mean=   34.539802
-Test     :    tocn   min=   -1.800000   max=   31.700465   mean=    6.018507
+Test     :    socn   min=   10.721046   max=   38.000000   mean=   34.539801
+Test     :    tocn   min=   -1.800000   max=   31.700465   mean=    6.018514
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064

--- a/test/testref/hofx_3d.test
+++ b/test/testref/hofx_3d.test
@@ -14,7 +14,7 @@ Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395529
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008644
 Test     :     chl   min=    0.000010   max=    4.671990   mean=    0.118483
 Test     : H(x):
-Test     : CoolSkin nobs= 201 Min=-4.375751, Max=25.239587, RMS=20.067013
+Test     : CoolSkin nobs= 201 Min=-4.375751, Max=25.239587, RMS=20.071725
 Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.649473, RMS=24.170310
 Test     : SeaSurfaceSalinity nobs= 100 Min=31.245713, Max=37.087544, RMS=34.753009
 Test     : ADT nobs= 100 Min=-1.250816, Max=1.421506, RMS=0.757217

--- a/test/testref/hofx_4d.test
+++ b/test/testref/hofx_4d.test
@@ -25,7 +25,7 @@ Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
 Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395529
 Test     :      us   min=    0.000000   max=    0.019160   mean=    0.007202
 Test     : H(x): 
-Test     : CoolSkin nobs= 21 Min=1.468919, Max=24.080512, RMS=19.629699
+Test     : CoolSkin nobs= 21 Min=1.468919, Max=24.080512, RMS=19.630416
 Test     : SeaSurfaceTemp nobs= 21 Min=5.775514, Max=29.800003, RMS=26.110537
 Test     : SeaSurfaceSalinity nobs= 9 Min=33.357075, Max=35.661567, RMS=34.492963
 Test     : ADT nobs= 14 Min=-0.712935, Max=1.495782, RMS=1.001838


### PR DESCRIPTION
## Description

PR #553 cleaned up a lot of the hardcoded variable names in `GetValues`, but one small section for atmospheric fluxes remained because it would cause a change in answers. (There was an inconsistency in masking for these fields: they were masked for interpolation, but not masked for the `gpnorm` prints ).

This removes that exception and forces those variables to use the masked configuration in the metadata file. Answers have changed anywhere the `coolskin` operator was used.
