### PR TITLE
interpolation on u/v grids

### DIFF
--- a/src/soca/GetValues/soca_getvalues_mod.F90
+++ b/src/soca/GetValues/soca_getvalues_mod.F90
@@ -18,9 +18,18 @@ use iso_c_binding
 implicit none
 private
 
+!------------------------------------------------------------------------------
+! soca_getvalues
+!  forward and adjoint interpolation between the model and observation locations.
+!  Several interpolators need to be created depending on which grid is used
+!  (h, u, v) and if land masking is used. Since we do not know this information
+!  until fill_geovals() or fill_geovals_ad() is called, creation of the interp
+!  is postoned to then
 type, public :: soca_getvalues
-  type(unstrc_interp) :: horiz_interp
-  type(unstrc_interp) :: horiz_interp_masked
+  ! the interpolator, and a flag for whether or not it has been initialized yet.
+  type(unstrc_interp), allocatable :: horiz_interp(:)
+  logical,             allocatable :: horiz_interp_init(:)
+
 contains
 
   ! constructors / destructors
@@ -28,6 +37,7 @@ contains
   procedure :: delete => soca_getvalues_delete
 
   ! apply interpolation
+  procedure :: get_interp => soca_getvalues_getinterp
   procedure :: fill_geovals=> soca_getvalues_fillgeovals
   procedure :: fill_geovals_ad=> soca_getvalues_fillgeovals_ad
 
@@ -43,11 +53,66 @@ subroutine soca_getvalues_create(self, geom, locs)
   type(soca_geom),          intent(in) :: geom
   type(ufo_locations),      intent(in) :: locs
 
-  integer :: isc, iec, jsc, jec, ni, nj
-  integer :: nn, ngrid_in, ngrid_out
-  character(len=8) :: wtype = 'barycent'
-  real(kind=kind_real), allocatable :: lats_in(:), lons_in(:)
+  ! why do things crash if I don't make these allocatable??
+  allocate(self%horiz_interp(6))
+  allocate(self%horiz_interp_init(6))
+  self%horiz_interp_init = .false.
+
+end subroutine soca_getvalues_create
+
+!------------------------------------------------------------------------------
+! Get the index of the interpolator for the given grid/masking.
+! If the interpolator has not been initialized yet, it will initialize it.
+! The index of horiz_interp and horiz_interp_init map to the following
+!   1 = h, unmasked    2 = h, masked
+!   3 = u, unmasked    4 = u, masked
+!   5 = v, unmasked    6 = v, masked
+function soca_getvalues_getinterp(self, geom, grid, masked, locs) result(idx)
+  class(soca_getvalues), intent(inout) :: self
+  type(soca_geom),  target, intent(in) :: geom
+  character(len=1),         intent(in) :: grid   !< "h", "u", or "v"
+  logical,                  intent(in) :: masked
+  type(ufo_locations),      intent(in) :: locs
+  integer :: idx
+
+  integer :: isc, iec, jsc, jec
+  integer :: ngrid_in, ngrid_out
+
   real(8), allocatable, dimension(:) :: locs_lons, locs_lats
+  real(kind=kind_real), allocatable :: lats_in(:), lons_in(:)
+
+  real(kind=kind_real),     pointer :: mask(:,:) => null() !< field mask
+  real(kind=kind_real),     pointer :: lon(:,:) => null()  !< field lon
+  real(kind=kind_real),     pointer :: lat(:,:) => null()  !< field lat
+
+  ! interpolation parameters
+  integer :: nn = 3
+  character(len=8) :: wtype = 'barycent'
+
+  ! get the model lat/lon/interpolator depending on grid type
+  select case(grid)
+  case ('h')
+    idx = 1
+    lon => geom%lon
+    lat => geom%lat
+    mask => geom%mask2d
+  case ('u')
+    idx = 3
+    lon => geom%lonu
+    lat => geom%latu
+    mask => geom%mask2du
+  case ('v')
+    idx = 5
+    lon => geom%lonv
+    lat => geom%latv
+    mask => geom%mask2dv
+  case default
+    call abor1_ftn('error in soca_getvalues_setupinterp. grid: '//grid)
+  end select
+  if (masked) idx = idx + 1
+
+  ! has interpolation already been initialized? if so return.
+  if (self%horiz_interp_init(idx)) return
 
   ! Indices for compute domain (no halo)
   isc = geom%isc ; iec = geom%iec
@@ -59,36 +124,33 @@ subroutine soca_getvalues_create(self, geom, locs)
   call locs%get_lons(locs_lons)
   call locs%get_lats(locs_lats)
 
-  ! create interpolation weights for fields that do NOT use the land mask
-  nn = 3
-  ni = iec - isc + 1
-  nj = jec - jsc + 1
-  ngrid_in = ni * nj
-  allocate(lats_in(ngrid_in), lons_in(ngrid_in))
+  if ( .not. masked ) then
+    ! create interpolation weights for fields that do NOT use the land mask
+    ngrid_in = (iec - isc + 1) * (jec - jsc + 1)
+    allocate(lats_in(ngrid_in), lons_in(ngrid_in))
+    lons_in = reshape(lon(isc:iec,jsc:jec), (/ngrid_in/))
+    lats_in = reshape(lat(isc:iec,jsc:jec), (/ngrid_in/))
+  else
+    ! create interpolation weights for fields that DO use the land mask
+    ngrid_in = count(mask(isc:iec,jsc:jec) > 0)
+    allocate(lats_in(ngrid_in), lons_in(ngrid_in))
+    lons_in = pack(lon(isc:iec,jsc:jec), mask=mask(isc:iec,jsc:jec) > 0)
+    lats_in = pack(lat(isc:iec,jsc:jec), mask=mask(isc:iec,jsc:jec) > 0)
+  end if
 
-  lons_in = reshape(geom%lon(isc:iec,jsc:jec), (/ngrid_in/))
-  lats_in = reshape(geom%lat(isc:iec,jsc:jec), (/ngrid_in/))
-  call self%horiz_interp%create(geom%f_comm, nn, wtype, &
-                           ngrid_in, lats_in, lons_in, &
-                           ngrid_out, locs_lats, locs_lons)
+  call self%horiz_interp(idx)%create(geom%f_comm, nn, wtype, &
+                     ngrid_in, lats_in, lons_in, &
+                     ngrid_out, locs_lats, locs_lons)
+  self%horiz_interp_init(idx) = .true.
 
-  ! create interpolation weights for fields that DO use the land mask
-  deallocate(lats_in, lons_in)
-  ngrid_in = count(geom%mask2d(isc:iec,jsc:jec) > 0)
-  lons_in = pack(geom%lon(isc:iec,jsc:jec), mask=geom%mask2d(isc:iec,jsc:jec) > 0)
-  lats_in = pack(geom%lat(isc:iec,jsc:jec), mask=geom%mask2d(isc:iec,jsc:jec) > 0)
-  call self%horiz_interp_masked%create(geom%f_comm, nn, wtype, &
-                           ngrid_in, lats_in, lons_in, &
-                           ngrid_out, locs_lats, locs_lons)
-end subroutine soca_getvalues_create
+end function
 
 !------------------------------------------------------------------------------
 subroutine soca_getvalues_delete(self)
   class(soca_getvalues), intent(inout) :: self
 
-  call self%horiz_interp%delete()
-  call self%horiz_interp_masked%delete()
-
+  deallocate(self%horiz_interp)
+  deallocate(self%horiz_interp_init)
 end subroutine soca_getvalues_delete
 
 !------------------------------------------------------------------------------
@@ -110,6 +172,7 @@ subroutine soca_getvalues_fillgeovals(self, geom, fld, t1, t2, locs, geovals)
   real(kind=kind_real), allocatable :: gom_window(:)
   real(kind=kind_real), allocatable :: fld3d(:,:,:), fld3d_un(:)
   type(soca_field), pointer :: fldptr
+  integer :: interp_idx = -1
 
   ! Indices for compute domain (no halo)
   isc = geom%isc ; iec = geom%iec
@@ -143,18 +206,19 @@ subroutine soca_getvalues_fillgeovals(self, geom, fld, t1, t2, locs, geovals)
     fld3d = fldptr%val(isc:iec,jsc:jec,1:nval)
 
     ! Apply forward interpolation: Model ---> Obs
+    interp_idx = self%get_interp(geom, fldptr%metadata%grid, masked, locs)
     do ival = 1, nval
+
       if (masked) then
-        ns = count(fld%geom%mask2d(isc:iec,jsc:jec) > 0 )
+        ns = count(fldptr%mask(isc:iec,jsc:jec) > 0 )
         if (.not. allocated(fld3d_un)) allocate(fld3d_un(ns))
-        fld3d_un = pack(fld3d(isc:iec,jsc:jec,ival), mask=fld%geom%mask2d(isc:iec,jsc:jec) > 0)
-        call self%horiz_interp_masked%apply(fld3d_un, gom_window)
+        fld3d_un = pack(fld3d(isc:iec,jsc:jec,ival), mask=fldptr%mask(isc:iec,jsc:jec) > 0)
       else
         ns = (iec - isc + 1) * (jec - jsc + 1)
         if (.not. allocated(fld3d_un)) allocate(fld3d_un(ns))
         fld3d_un = reshape(fld3d(isc:iec,jsc:jec,ival), (/ns/))
-        call self%horiz_interp%apply(fld3d_un(1:ns), gom_window)
       end if
+      call self%horiz_interp(interp_idx)%apply(fld3d_un(1:ns), gom_window)
 
       ! Fill proper geoval according to time window
       do indx = 1, locs%nlocs()
@@ -196,6 +260,7 @@ subroutine soca_getvalues_fillgeovals_ad(self, geom, incr, t1, t2, locs, geovals
   real(kind=kind_real), allocatable :: incr3d(:,:,:), incr3d_un(:)
   type(soca_field), pointer :: field
     logical :: found
+  integer :: interp_idx = -1
 
   ! Indices for compute domain (no halo)
   isc = geom%isc ; iec = geom%iec
@@ -221,7 +286,7 @@ subroutine soca_getvalues_fillgeovals_ad(self, geom, incr, t1, t2, locs, geovals
 
     ! Apply backward interpolation: Obs ---> Model
     if (masked) then
-      ns = count(incr%geom%mask2d(isc:iec,jsc:jec) > 0)
+      ns = count(field%mask(isc:iec,jsc:jec) > 0)
     else
       ni = iec - isc + 1
       nj = jec - jsc + 1
@@ -229,6 +294,7 @@ subroutine soca_getvalues_fillgeovals_ad(self, geom, incr, t1, t2, locs, geovals
     end if
     if (.not.allocated(incr3d_un)) allocate(incr3d_un(ns))
 
+    interp_idx = self%get_interp(geom, field%metadata%grid, masked, locs)
     do ival = 1, nval
       ! Fill proper geoval according to time window
       do indx = 1, locs%nlocs()
@@ -239,14 +305,14 @@ subroutine soca_getvalues_fillgeovals_ad(self, geom, incr, t1, t2, locs, geovals
       gom_window_ival = gom_window(ival,1:locs%nlocs())
 
       if (masked) then
-        incr3d_un = pack(incr3d(isc:iec,jsc:jec,ival), mask = incr%geom%mask2d(isc:iec,jsc:jec) >0)
-        call self%horiz_interp_masked%apply_ad(incr3d_un, gom_window_ival)
+        incr3d_un = pack(incr3d(isc:iec,jsc:jec,ival), mask = field%mask(isc:iec,jsc:jec) >0)
+        call self%horiz_interp(interp_idx)%apply_ad(incr3d_un, gom_window_ival)
         incr3d(isc:iec,jsc:jec,ival) = unpack(incr3d_un, &
-              mask = incr%geom%mask2d(isc:iec,jsc:jec) >0, &
+              mask = field%mask(isc:iec,jsc:jec) >0, &
               field = incr3d(isc:iec,jsc:jec,ival))
       else
         incr3d_un = reshape(incr3d(isc:iec,jsc:jec,ival), (/ns/))
-        call self%horiz_interp%apply_ad(incr3d_un(1:ns), gom_window_ival)
+        call self%horiz_interp(interp_idx)%apply_ad(incr3d_un(1:ns), gom_window_ival)
         incr3d(isc:iec,jsc:jec,ival) = reshape(incr3d_un(1:ns),(/ni,nj/))
       end if
     end do

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -141,15 +141,17 @@ set( soca_model_restarts
 
 set( soca_obs
   Data/Obs/adt.nc
+  Data/Obs/biomass_p.nc
+  Data/Obs/chl.nc
+  Data/Obs/gmi_gpm_geoval.nc
+  Data/Obs/gmi_gpm_obs.nc
   Data/Obs/icec.nc
   Data/Obs/icefb.nc
   Data/Obs/prof.nc
   Data/Obs/sss.nc
   Data/Obs/sst.nc
-  Data/Obs/chl.nc
-  Data/Obs/biomass_p.nc
-  Data/Obs/gmi_gpm_geoval.nc
-  Data/Obs/gmi_gpm_obs.nc
+  Data/Obs/uocn_surface.nc
+  Data/Obs/vocn_surface.nc
 )
 
 # Create Data directory for test input/output and symlink all files

--- a/test/Data/Obs/uocn_surface.nc
+++ b/test/Data/Obs/uocn_surface.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9753ea23c02c231c6ad83287a25993ffebb7477dc991a6c45c3ea48051d8bb05
+size 73824

--- a/test/Data/Obs/vocn_surface.nc
+++ b/test/Data/Obs/vocn_surface.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca55bd3c3bf2f005522e6d1435015661f49a253ef37adcf227b9e930402c487a
+size 73824

--- a/test/testinput/getvalues.yml
+++ b/test/testinput/getvalues.yml
@@ -14,7 +14,11 @@ state variables: &geovals [sea_water_potential_temperature,
                            upward_latent_heat_flux_in_air,
                            upward_sensible_heat_flux_in_air,
                            net_downwelling_longwave_radiation,
-                           friction_velocity_over_water]
+                           friction_velocity_over_water,
+                           surface_eastward_sea_water_velocity,
+                           eastward_sea_water_velocity,
+                           surface_northward_sea_water_velocity,
+                           northward_sea_water_velocity]
 
 getvalues test:
   interpolation tolerance: 1.0e-2
@@ -27,7 +31,7 @@ getvalues test:
     ocn_filename: MOM.res.nc
     ice_filename: cice.res.nc
     sfc_filename: sfc.res.nc
-    state variables: [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
+    state variables: [cicen, hicen, socn, tocn, ssh, hocn, uocn, vocn, sw, lhf, shf, lw, us]
 
 geovals:
   state variables: *geovals
@@ -45,4 +49,4 @@ locations:
         lat2: 90
         lon1: 0
         lon2: 360
-      obs errors: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+      obs errors: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]

--- a/test/testinput/hofx_3d.yml
+++ b/test/testinput/hofx_3d.yml
@@ -9,7 +9,7 @@ state:
     ocn_filename: MOM.res.nc
     ice_filename: cice.res.nc
     sfc_filename: sfc.res.nc
-    state variables: [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us, chl]
+    state variables: [cicen, hicen, hsnon, socn, tocn, ssh, hocn, uocn, vocn, sw, lhf, shf, lw, us, chl]
 
 window begin: 2018-04-14T00:00:00Z
 window length: P2D
@@ -111,3 +111,19 @@ observations:
       action:
         name: inflate error
         inflation factor: 2.0
+
+  - obs space:
+      name: SurfaceU
+      obsdataout: {obsfile: ./Data/uocn_surface.out.nc}
+      obsdatain:  {obsfile: ./Data/uocn_surface.nc}
+      simulated variables: [surface_eastward_sea_water_velocity]
+    obs operator:
+      name: Identity
+
+  - obs space:
+      name: SurfaceV
+      obsdataout: {obsfile: ./Data/vocn_surface.out.nc}
+      obsdatain:  {obsfile: ./Data/vocn_surface.nc}
+      simulated variables: [surface_northward_sea_water_velocity]
+    obs operator:
+      name: Identity

--- a/test/testinput/hofx_4d.yml
+++ b/test/testinput/hofx_4d.yml
@@ -6,7 +6,7 @@ model:
   name: SOCA
   tstep: PT1H
   advance_mom6: 1
-  model variables: [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
+  model variables: [cicen, hicen, socn, tocn, ssh, hocn, uocn, vocn, sw, lhf, shf, lw, us]
 
 initial condition:
   read_from_file: 1
@@ -14,7 +14,7 @@ initial condition:
   basename: ./INPUT/
   ocn_filename: MOM.res.nc
   ice_filename: cice.res.nc
-  state variables: [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
+  state variables: [cicen, hicen, socn, tocn, ssh, hocn, uocn, vocn, sw, lhf, shf, lw, us]
 
 window begin: 2018-04-15T00:00:00Z
 window length: PT3H
@@ -76,3 +76,19 @@ observations:
       simulated variables: [sea_ice_area_fraction]
     obs operator:
       name: SeaIceFraction
+
+  - obs space:
+      name: SurfaceU
+      obsdataout: {obsfile: ./Data/uocn_surface.out.nc}
+      obsdatain:  {obsfile: ./Data/uocn_surface.nc}
+      simulated variables: [surface_eastward_sea_water_velocity]
+    obs operator:
+      name: Identity
+
+  - obs space:
+      name: SurfaceV
+      obsdataout: {obsfile: ./Data/vocn_surface.out.nc}
+      obsdatain:  {obsfile: ./Data/vocn_surface.nc}
+      simulated variables: [surface_northward_sea_water_velocity]
+    obs operator:
+      name: Identity

--- a/test/testref/hofx_3d.test
+++ b/test/testref/hofx_3d.test
@@ -1,4 +1,4 @@
-Test     : State:
+Test     : State: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.117513
 Test     :   hicen   min=    0.000000   max=    4.032667   mean=    0.471252
@@ -7,13 +7,15 @@ Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
 Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
 Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395529
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008644
 Test     :     chl   min=    0.000010   max=    4.671990   mean=    0.118483
-Test     : H(x):
+Test     : H(x): 
 Test     : CoolSkin nobs= 201 Min=-4.375751, Max=25.239587, RMS=20.071725
 Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.649473, RMS=24.170310
 Test     : SeaSurfaceSalinity nobs= 100 Min=31.245713, Max=37.087544, RMS=34.753009
@@ -23,4 +25,6 @@ Test     : InsituSalinity nobs= 218 Min=34.160244, Max=35.992907, RMS=35.036438
 Test     : SeaIceFraction nobs= 100 Min=0.000000, Max=1.000000, RMS=0.694504
 Test     : SeaIceFreeboard nobs= 376 Min=-0.071509, Max=0.255906, RMS=0.054232
 Test     : Chlorophyll nobs= 137 Min=0.001273, Max=2.410599, RMS=0.357860
+Test     : SurfaceU nobs= 201 Min=-0.668706, Max=0.342825, RMS=0.176726
+Test     : SurfaceV nobs= 201 Min=-0.345640, Max=0.399404, RMS=0.114036
 Test     : End H(x)

--- a/test/testref/hofx_4d.test
+++ b/test/testref/hofx_4d.test
@@ -6,6 +6,8 @@ Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
 Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
+Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     shf   min=    0.000000   max=    0.000000   mean=    0.000000
@@ -15,10 +17,12 @@ Test     : Final state:
 Test     :   Valid time: 2018-04-15T03:00:00Z
 Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.117513
 Test     :   hicen   min=    0.000000   max=    4.032667   mean=    0.471252
-Test     :    socn   min=   10.719095   max=   40.441647   mean=   34.544480
-Test     :    tocn   min=   -1.888585   max=   31.734800   mean=    6.015852
+Test     :    socn   min=   10.719095   max=   40.441647   mean=   34.544484
+Test     :    tocn   min=   -1.888585   max=   31.734800   mean=    6.015855
 Test     :     ssh   min=   -1.908095   max=    0.909066   mean=   -0.276583
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628088
+Test     :    uocn   min=   -0.848361   max=    0.700808   mean=    0.000089
+Test     :    vocn   min=   -0.834645   max=    0.944534   mean=    0.001772
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
 Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
@@ -32,4 +36,6 @@ Test     : ADT nobs= 14 Min=-0.712935, Max=1.495782, RMS=1.001838
 Test     : InsituTemperature nobs= 10 Min=8.008760, Max=30.381888, RMS=23.736167
 Test     : InsituSalinity nobs= 10 Min=34.155913, Max=35.701557, RMS=35.026605
 Test     : SeaIceFraction nobs= 14 Min=0.000004, Max=0.999981, RMS=0.683195
+Test     : SurfaceU nobs= 21 Min=-0.506909, Max=0.153542, RMS=0.267933
+Test     : SurfaceV nobs= 21 Min=-0.345640, Max=0.175382, RMS=0.145807
 Test     : End H(x)


### PR DESCRIPTION
## Description

Interpolation of variables on the u/v grid now use the correct lat/lon/mask for those grids.

The creation of the interpolator objects was moved out of `soca_getvalues_create()` and are instead created when they are first required by `fill_geovals()` and `fill_geovals_ad()`. This is because: 
1) I don't want to incur the cost of creating all 6 combinations of u/v/h mask/nomask interpolators if they are not all needed, but 
2) we don't know which interpolators are needed until those `fill_` subroutines.

Note: u/v hofx should be correct now **IF** no u/v rotations are required (regional domain only?)

### Issue(s) addressed
closes #575 

## Testing

- `GetValues` test updated to test u/v grids.
- surface u/v obs are added to `hofx` tests

## Dependencies

requires OOPS branch with same name (to fix bug in the unstructured interpolation)
- waiting on https://github.com/JCSDA-internal/oops/pull/1247