### PR TITLE
ewok files for hofx

### DIFF
--- a/ewok/bg.yaml
+++ b/ewok/bg.yaml
@@ -1,0 +1,9 @@
+basename: $(current_dir)/
+date: '{{current_cycle}}'
+ice_filename: $(model_ice_file).$(experiment).bg.{{local_current_cycle}}.nc
+ocn_filename: $(model_ocn_file).$(experiment).bg.{{local_current_cycle}}.nc
+read_from_file: 1
+state variables: $(model_variables)
+
+# needed for GetBackground only
+filename: $(current_dir)/$(file_type).$(experiment).bg.{{local_current_cycle}}.nc

--- a/ewok/geom.yaml
+++ b/ewok/geom.yaml
@@ -1,0 +1,3 @@
+mom6_input_nml: $(stage_dir)/mom_input.nml
+fields metadata: $(stage_dir)/fields_metadata.yaml
+geom_grid_file: $(stage_dir)/soca_gridspec.nc

--- a/ewok/mom_input.nml
+++ b/ewok/mom_input.nml
@@ -1,0 +1,11 @@
+$MOM_input_nml
+      parameter_filename = '@[stage_dir]/MOM_input'
+/
+
+&fms_io_nml
+      checksum_required=.false.
+/
+
+&fms_nml
+     domains_stack_size = 2000000
+/

--- a/ewok/stage.yaml
+++ b/ewok/stage.yaml
@@ -1,0 +1,25 @@
+copy_files:
+  directories:
+  - [ $(bundle)/soca/test/Data/fields_metadata.yml,   fields_metadata.yaml]
+  - [ $(bundle)/soca/test/Data/rossrad.dat,           rossrad.dat]
+
+template_files:
+  destination: stage_dir
+  template:
+    pattern: AT_SQUARE_BRACES
+    dictionaries:
+      - $(suite_dir)/$(experiment).yaml
+  directories:
+    - [ $(bundle)/soca/ewok/mom_input.nml, mom_input.nml]
+
+
+# model specific static files
+r2d2_files:
+  - fetch:
+      resolution: $(horizontal_resolution)
+      type: static
+      model: $(model)
+      file_type:
+        - soca_gridspec.nc
+        - MOM_input
+      target_file: $(stage_dir)/$(file_type)


### PR DESCRIPTION
## Description

files needed for ewok hofx. `ewok/mom_input.nml` will be moved eventually to the static model-specific r2d2 store once we start working on actual forecasts.
See the corresponding PR at https://github.com/JCSDA-internal/experiments/pull/32 for further details.