### PR TITLE
Fixes for tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -450,11 +450,13 @@ soca_add_test( NAME forecast_pseudo
 soca_add_test( NAME static_socaerror_init
                EXE  soca_staticbinit.x
                NOCOMPARE
+               NOTRAPFPE
                TEST_DEPENDS test_soca_gridgen )
 
 soca_add_test( NAME static_socaerrorlowres_init
                EXE  soca_staticbinit.x
                NOCOMPARE
+               NOTRAPFPE
                TEST_DEPENDS test_soca_gridgen )
 
 # Use the soca_dirac.x application to create a mask for the dynamic height Jacobians
@@ -464,7 +466,7 @@ soca_add_test( NAME balance_mask
 
 # Create dc/dt file for ocean/ice balance and convert dirac file into a mask
 add_test ( test_soca_create_kmask
-           python
+           python3
            ${CMAKE_CURRENT_SOURCE_DIR}/Data/create_kmask.py
            TEST_DEPENDS test_static_socaerror_init
                         test_balance_mask )
@@ -615,6 +617,7 @@ soca_add_test( NAME hybridgain
 #                EXE  soca_dirac.x )
 
 soca_add_test( NAME parameters_bump_cor_nicas
+               NOTRAPFPE
                EXE  soca_parameters.x
                TEST_DEPENDS test_soca_gridgen_small
                             test_soca_convertstate)

--- a/test/Data/create_kmask.py
+++ b/test/Data/create_kmask.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import netCDF4
 import numpy as np
 


### PR DESCRIPTION
## Description

I needed to add NOTRAPFPE to several tests in soca for them to pass on my machine (on Mac with clang + gfortran). Doesn't seem like  a good idea to ignore divisions by 0 for tests but ocean dwellers are a different breed ;-) Adding Benjamin since it looks like it's happening in BUMP. 

I also needed to explicitly call python3 in two places.

I hope all that works on all platforms (or there is a better solution).

## Dependencies

None.