### PR TITLE
Generalize covariance code

### DIFF
--- a/src/soca/Covariance/soca_covariance_mod.F90
+++ b/src/soca/Covariance/soca_covariance_mod.F90
@@ -99,7 +99,7 @@ subroutine soca_cov_setup(self, f_conf, geom, bkg, vars)
   allocate(self%conv_vars(size(self%conv)))
   do i=1,size(f_conf_list)
     call f_conf_list(i)%get_or_die("name", domain)
-    call f_conf_list(i)%get_or_die("vars", domain_vars)
+    call f_conf_list(i)%get_or_die("variables", domain_vars)
     self%conv_vars(i) = oops_variables()
     call self%conv_vars(i)%push_back(domain_vars)
 

--- a/src/soca/Covariance/soca_covariance_mod.F90
+++ b/src/soca/Covariance/soca_covariance_mod.F90
@@ -165,6 +165,9 @@ subroutine soca_cov_C_mult(self, dx)
     if (.not. dx%has(self%vars%variable(i))) cycle ! why is this sometimes getting an "empty" list with "none" in it?
     call dx%get(trim(self%vars%variable(i)), field)
 
+    ! a **TEMPORARY** special exception for hocn
+    if ( field%name == "hocn" ) cycle
+
     ! determine which horizontal convolution to use
     call self%getConv(field, conv)
 
@@ -189,6 +192,9 @@ subroutine soca_cov_sqrt_C_mult(self, dx)
   do i = 1, self%vars%nvars()
     conv => null()
     call dx%get(trim(self%vars%variable(i)), field)
+
+    ! a **TEMPORARY** special exception for hocn
+    if ( field%name == "hocn" ) cycle
 
     ! find matching index in self%vars and get the perturbation scale
     if (.not. allocated(self%pert_scale)) then

--- a/test/testinput/3dhyb.yml
+++ b/test/testinput/3dhyb.yml
@@ -39,9 +39,9 @@ cost function:
           mpicom: 2
         correlation:
         - name: ocn
-          vars: [hsnon, socn, tocn, ssh]
+          variables: [hsnon, socn, tocn, ssh]
         - name: ice
-          vars: [cicen, hicen]
+          variables: [cicen, hicen]
 
         variable changes:
         - variable change: BkgErrFILT

--- a/test/testinput/3dhyb.yml
+++ b/test/testinput/3dhyb.yml
@@ -29,13 +29,20 @@ cost function:
     components:
     - covariance:
         covariance model: SocaError
-        datadir: ./bump
-        strategy: specific_univariate
-        load_nicas: 1
-        mpicom: 2
-        verbosity: main
+        analysis variables: [cicen, hicen, hsnon, socn, tocn, ssh]
         date: *bkg_date
-        analysis variables: *soca_vars
+        bump:
+          verbosity: main
+          datadir: ./bump
+          strategy: specific_univariate
+          load_nicas: 1
+          mpicom: 2
+        correlation:
+        - name: ocn
+          vars: [hsnon, socn, tocn, ssh]
+        - name: ice
+          vars: [cicen, hicen]
+
         variable changes:
         - variable change: BkgErrFILT
           ocean_depth_min: 1000 # [m]

--- a/test/testinput/3dhybfgat.yml
+++ b/test/testinput/3dhybfgat.yml
@@ -34,13 +34,20 @@ cost function:
     components:
     - covariance:
         covariance model: SocaError
-        verbosity: main
-        datadir: ./bump
-        strategy: specific_univariate
-        load_nicas: 1
-        mpicom: 2
+        analysis variables: [cicen, hicen, socn, tocn, ssh, sw, lhf, shf, lw, us]
         date: *date_begin
-        analysis variables: *soca_vars
+        bump:
+          verbosity: main
+          datadir: ./bump
+          strategy: specific_univariate
+          load_nicas: 1
+          mpicom: 2
+        correlation:
+        - name: ocn
+          vars: [socn, tocn, ssh, sw, lhf, shf, lw, us]
+        - name: ice
+          vars: [cicen, hicen]
+
         variable changes:
         - variable change: BkgErrFILT
           ocean_depth_min: 1000 # [m]

--- a/test/testinput/3dhybfgat.yml
+++ b/test/testinput/3dhybfgat.yml
@@ -44,9 +44,9 @@ cost function:
           mpicom: 2
         correlation:
         - name: ocn
-          vars: [socn, tocn, ssh, sw, lhf, shf, lw, us]
+          variables: [socn, tocn, ssh, sw, lhf, shf, lw, us]
         - name: ice
-          vars: [cicen, hicen]
+          variables: [cicen, hicen]
 
         variable changes:
         - variable change: BkgErrFILT

--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -35,9 +35,9 @@ cost function:
       mpicom: 2
     correlation:
     - name: ocn
-      vars: [hsnon, socn, tocn, ssh, sw, lhf, shf, lw, us]
+      variables: [hsnon, socn, tocn, ssh, sw, lhf, shf, lw, us]
     - name: ice
-      vars: [cicen, hicen]
+      variables: [cicen, hicen]
 
     variable changes:
 

--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -24,14 +24,20 @@ cost function:
     state variables: *soca_vars
 
   background error:
-    verbosity: main
     covariance model: SocaError
-    datadir: ./bump
-    strategy: specific_univariate
-    load_nicas: 1
-    mpicom: 2
+    analysis variables: [cicen, hicen, hsnon, socn, tocn, ssh, sw, lhf, shf, lw, us]
     date: *bkg_date
-    analysis variables: *soca_vars
+    bump:
+      verbosity: main
+      datadir: ./bump
+      strategy: specific_univariate
+      load_nicas: 1
+      mpicom: 2
+    correlation:
+    - name: ocn
+      vars: [hsnon, socn, tocn, ssh, sw, lhf, shf, lw, us]
+    - name: ice
+      vars: [cicen, hicen]
 
     variable changes:
 

--- a/test/testinput/3dvar_soca.yml
+++ b/test/testinput/3dvar_soca.yml
@@ -35,9 +35,9 @@ cost function:
       mpicom: 2
     correlation:
     - name: ocn
-      vars: [socn, tocn, ssh, sw, lhf, shf, lw, us, chl, biop]
+      variables: [socn, tocn, ssh, sw, lhf, shf, lw, us, chl, biop]
     - name: ice
-      vars: [cicen, hicen]
+      variables: [cicen, hicen]
 
     variable changes:
 

--- a/test/testinput/3dvar_soca.yml
+++ b/test/testinput/3dvar_soca.yml
@@ -24,14 +24,20 @@ cost function:
     state variables: *soca_vars
 
   background error:
-    verbosity: main
     covariance model: SocaError
-    datadir: ./bump
-    strategy: specific_univariate
-    load_nicas: 1
-    mpicom: 2
+    analysis variables: [cicen, hicen, socn, tocn, ssh, sw, lhf, shf, lw, us, chl, biop]
     date: 2018-04-15T00:00:00Z
-    analysis variables: *soca_vars
+    bump:
+      verbosity: main
+      datadir: ./bump
+      strategy: specific_univariate
+      load_nicas: 1
+      mpicom: 2
+    correlation:
+    - name: ocn
+      vars: [socn, tocn, ssh, sw, lhf, shf, lw, us, chl, biop]
+    - name: ice
+      vars: [cicen, hicen]
 
     variable changes:
 

--- a/test/testinput/3dvarfgat.yml
+++ b/test/testinput/3dvarfgat.yml
@@ -40,9 +40,9 @@ cost function:
       mpicom: 2
     correlation:
     - name: ocn
-      vars: [socn, tocn, ssh, sw, lhf, shf, lw, us]
+      variables: [socn, tocn, ssh, sw, lhf, shf, lw, us]
     - name: ice
-      vars: [cicen, hicen]
+      variables: [cicen, hicen]
 
     variable changes:
 

--- a/test/testinput/3dvarfgat.yml
+++ b/test/testinput/3dvarfgat.yml
@@ -29,14 +29,20 @@ cost function:
     state variables: *model_vars
 
   background error:
-    verbosity: main
     covariance model: SocaError
-    datadir: ./bump
-    strategy: specific_univariate
-    load_nicas: 1
-    mpicom: 2
+    analysis variables: [cicen, hicen, socn, tocn, ssh, sw, lhf, shf, lw, us]
     date: 2018-04-15T00:00:00Z
-    analysis variables: *soca_vars
+    bump:
+      verbosity: main
+      datadir: ./bump
+      strategy: specific_univariate
+      load_nicas: 1
+      mpicom: 2
+    correlation:
+    - name: ocn
+      vars: [socn, tocn, ssh, sw, lhf, shf, lw, us]
+    - name: ice
+      vars: [cicen, hicen]
 
     variable changes:
 

--- a/test/testinput/3dvarfgat_pseudo.yml
+++ b/test/testinput/3dvarfgat_pseudo.yml
@@ -63,7 +63,7 @@ cost function:
       mpicom: 2
     correlation:
     - name: ocn
-      vars: [socn, tocn, ssh]
+      variables: [socn, tocn, ssh]
 
     variable changes:
 

--- a/test/testinput/3dvarfgat_pseudo.yml
+++ b/test/testinput/3dvarfgat_pseudo.yml
@@ -52,14 +52,18 @@ cost function:
     state variables: *model_vars
 
   background error:
-    verbosity: main
     covariance model: SocaError
-    datadir: ./bump
-    strategy: specific_univariate
-    load_nicas: 1
-    mpicom: 2
+    analysis variables: [socn, tocn, ssh]
     date: 2018-04-15T00:00:00Z
-    analysis variables: *soca_vars
+    bump:
+      verbosity: main
+      datadir: ./bump
+      strategy: specific_univariate
+      load_nicas: 1
+      mpicom: 2
+    correlation:
+    - name: ocn
+      vars: [socn, tocn, ssh]
 
     variable changes:
 

--- a/test/testinput/3dvarlowres_soca.yml
+++ b/test/testinput/3dvarlowres_soca.yml
@@ -34,7 +34,7 @@ cost function:
       mpicom: 2
     correlation:
     - name: ocn
-      vars: [socn, tocn, ssh]
+      variables: [socn, tocn, ssh]
 
 
     variable changes:

--- a/test/testinput/3dvarlowres_soca.yml
+++ b/test/testinput/3dvarlowres_soca.yml
@@ -23,14 +23,19 @@ cost function:
     state variables: [socn, tocn, ssh, hocn, mld, layer_depth]
 
   background error:
-    verbosity: main
     covariance model: SocaError
-    datadir: ./bump_lowres
-    strategy: specific_univariate
-    load_nicas: 1
-    mpicom: 2
-    date: 2018-04-15T00:00:00Z
     analysis variables: [tocn, socn, ssh]
+    date: 2018-04-15T00:00:00Z
+    bump:
+      verbosity: main
+      datadir: ./bump_lowres
+      strategy: specific_univariate
+      load_nicas: 1
+      mpicom: 2
+    correlation:
+    - name: ocn
+      vars: [socn, tocn, ssh]
+
 
     variable changes:
 

--- a/test/testinput/balance_mask.yml
+++ b/test/testinput/balance_mask.yml
@@ -23,7 +23,7 @@ background error:
     strategy: specific_univariate
   correlation:
   - name: ocn
-    vars: [ssh]
+    variables: [ssh]
 
 dirac:
   # NOTE ice (ifdir=4) was not being correctly tested, need to fix

--- a/test/testinput/balance_mask.yml
+++ b/test/testinput/balance_mask.yml
@@ -14,12 +14,16 @@ variables: *soca_vars
 
 background error:
   covariance model: SocaError
-  datadir: ./bump
-  load_nicas: 1
-  mpicom: 2
-  strategy: specific_univariate
-  date: *date
   analysis variables: [ssh]
+  date: *date
+  bump:
+    datadir: ./bump
+    load_nicas: 1
+    mpicom: 2
+    strategy: specific_univariate
+  correlation:
+  - name: ocn
+    vars: [ssh]
 
 dirac:
   # NOTE ice (ifdir=4) was not being correctly tested, need to fix

--- a/test/testinput/dirac_horizfilt.yml
+++ b/test/testinput/dirac_horizfilt.yml
@@ -22,9 +22,9 @@ background error:
     strategy: specific_univariate
   correlation:
   - name: ocn
-    vars: []
+    variables: []
   - name: ice
-    vars: []
+    variables: []
 
   variable changes:
 

--- a/test/testinput/dirac_horizfilt.yml
+++ b/test/testinput/dirac_horizfilt.yml
@@ -11,14 +11,20 @@ initial condition:
   state variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn, mld, layer_depth]
 
 background error:
-  verbosity: main
   covariance model: SocaError
-  datadir: ./bump
-  load_nicas: 1
-  mpicom: 2
-  strategy: specific_univariate
-  date: *date
   analysis variables: [none]
+  date: *date
+  bump:
+    verbosity: main
+    datadir: ./bump
+    load_nicas: 1
+    mpicom: 2
+    strategy: specific_univariate
+  correlation:
+  - name: ocn
+    vars: []
+  - name: ice
+    vars: []
 
   variable changes:
 

--- a/test/testinput/dirac_soca_cov.yml
+++ b/test/testinput/dirac_soca_cov.yml
@@ -22,9 +22,9 @@ background error:
     strategy: specific_univariate
   correlation:
   - name: ocn
-    vars: [socn, tocn, ssh]
+    variables: [socn, tocn, ssh]
   - name: ice
-    vars: [cicen, hicen]
+    variables: [cicen, hicen]
 
   variable changes:
 

--- a/test/testinput/dirac_soca_cov.yml
+++ b/test/testinput/dirac_soca_cov.yml
@@ -11,14 +11,20 @@ initial condition:
   state variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn, mld, layer_depth]
 
 background error:
-  verbosity: main
   covariance model: SocaError
-  datadir: ./bump
-  load_nicas: 1
-  mpicom: 2
-  strategy: specific_univariate
+  analysis variables: [cicen, hicen, socn, tocn, ssh]
   date: *date
-  analysis variables: [cicen, hicen, socn, tocn, ssh, hocn]
+  bump:
+    verbosity: main
+    datadir: ./bump
+    load_nicas: 1
+    mpicom: 2
+    strategy: specific_univariate
+  correlation:
+  - name: ocn
+    vars: [socn, tocn, ssh]
+  - name: ice
+    vars: [cicen, hicen]
 
   variable changes:
 

--- a/test/testinput/dirac_socahyb_cov.yml
+++ b/test/testinput/dirac_socahyb_cov.yml
@@ -22,13 +22,20 @@ background error:
   components:
   - covariance:
       covariance model: SocaError
-      datadir: ./bump
-      strategy: specific_univariate
-      load_nicas: 1
-      mpicom: 2
-      verbosity: main
+      analysis variables: [cicen, hicen, socn, tocn, ssh]
       date: *date
-      analysis variables: [cicen, hicen, socn, tocn, ssh, hocn]
+      bump:
+        datadir: ./bump
+        strategy: specific_univariate
+        load_nicas: 1
+        mpicom: 2
+        verbosity: main
+      correlation:
+      - name: ocn
+        vars: [socn, tocn, ssh]
+      - name: ice
+        vars: [cicen, hicen]
+
       variable changes:
       - variable change: BkgErrFILT
         ocean_depth_min: 1000 # [m]

--- a/test/testinput/dirac_socahyb_cov.yml
+++ b/test/testinput/dirac_socahyb_cov.yml
@@ -32,9 +32,9 @@ background error:
         verbosity: main
       correlation:
       - name: ocn
-        vars: [socn, tocn, ssh]
+        variables: [socn, tocn, ssh]
       - name: ice
-        vars: [cicen, hicen]
+        variables: [cicen, hicen]
 
       variable changes:
       - variable change: BkgErrFILT

--- a/test/testinput/enspert.yml
+++ b/test/testinput/enspert.yml
@@ -24,13 +24,14 @@ background error:
   load_nicas: 1
   mpicom: 2
   date: *date
-  pert_T: 1.0
-  pert_S: 1.0
-  pert_SSH: 0.0
-  pert_AICE: 0.1
-  pert_HICE: 0.05
-  pert_CHL: 0.1
-  pert_BIOP: 0.1
+  perturbation scales:
+    tocn:  1.0
+    socn:  1.0
+    ssh:   0.0
+    cicen: 0.1
+    hicen: 0.05
+    chl:   0.1
+    biop:  0.1
   analysis variables: &soca_vars [ssh, cicen, hicen, tocn, socn, chl, biop]
 
   variable changes:

--- a/test/testinput/enspert.yml
+++ b/test/testinput/enspert.yml
@@ -17,13 +17,15 @@ initial condition:
   state variables: *model_vars
 
 background error:
-  verbosity: main
   covariance model: SocaError
-  datadir: ./bump
-  strategy: specific_univariate
-  load_nicas: 1
-  mpicom: 2
   date: *date
+  analysis variables: &soca_vars [ssh, cicen, hicen, tocn, socn, chl, biop]
+  bump:
+    verbosity: main
+    datadir: ./bump
+    strategy: specific_univariate
+    load_nicas: 1
+    mpicom: 2
   perturbation scales:
     tocn:  1.0
     socn:  1.0
@@ -32,7 +34,12 @@ background error:
     hicen: 0.05
     chl:   0.1
     biop:  0.1
-  analysis variables: &soca_vars [ssh, cicen, hicen, tocn, socn, chl, biop]
+  correlation:
+  - name: ocn
+    vars: [tocn, ssh, socn, chl, biop]
+  - name: ice
+    vars: [cicen, hicen]
+
 
   variable changes:
 

--- a/test/testinput/enspert.yml
+++ b/test/testinput/enspert.yml
@@ -36,9 +36,9 @@ background error:
     biop:  0.1
   correlation:
   - name: ocn
-    vars: [tocn, ssh, socn, chl, biop]
+    variables: [tocn, ssh, socn, chl, biop]
   - name: ice
-    vars: [cicen, hicen]
+    variables: [cicen, hicen]
 
 
   variable changes:

--- a/test/testinput/linearmodel.yml
+++ b/test/testinput/linearmodel.yml
@@ -36,9 +36,15 @@ linear model test:
 
 background error:
   covariance model: SocaError
-  datadir: ./bump
-  strategy: specific_univariate
-  load_nicas: 1
-  mpicom: 2
-  date: *date
   analysis variables: *soca_vars
+  date: *date
+  bump:
+    datadir: ./bump
+    strategy: specific_univariate
+    load_nicas: 1
+    mpicom: 2
+  correlation:
+  - name: ocn
+    vars: [socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
+  - name: ice
+    vars: [cicen, hicen]

--- a/test/testinput/linearmodel.yml
+++ b/test/testinput/linearmodel.yml
@@ -45,6 +45,6 @@ background error:
     mpicom: 2
   correlation:
   - name: ocn
-    vars: [socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
+    variables: [socn, tocn, ssh, hocn, sw, lhf, shf, lw, us]
   - name: ice
-    vars: [cicen, hicen]
+    variables: [cicen, hicen]

--- a/test/testinput/static_socaerror_init.yml
+++ b/test/testinput/static_socaerror_init.yml
@@ -2,7 +2,7 @@ geometry:
   mom6_input_nml: ./inputnml/input.nml
   fields metadata: ./fields_metadata.yml
 
-analysis variables: [cicen, hicen, hocn, socn, tocn, ssh]
+analysis variables: &ana_vars [cicen, hicen, socn, tocn, ssh]
 
 background:
   read_from_file: 1
@@ -13,24 +13,28 @@ background:
   state variables: [cicen, hicen, hocn, socn, tocn, ssh]
 
 background error:
-  verbosity: main
   covariance model: SocaError
-  datadir: ./bump
-  method: cor
-  strategy: specific_univariate
-  new_nicas: 1
-  interp_type: mesh_based
-  mask_check: 1
-  ntry: 3
-  nrep:  2
-  resol: 6.0
-  network: 1
-  mpicom: 2
+  analysis variables: *ana_vars
   date: *date
-  corr_scales:
-    ocn:
-      base value: 840336.134453782
-      rossby mult: 0.280112045
-    ice:
-      base value: 560224.089635854
-  analysis variables: [cicen, hicen, hocn, socn, tocn, ssh]
+  bump:
+    verbosity: main
+    datadir: ./bump
+    method: cor
+    strategy: specific_univariate
+    new_nicas: 1
+    interp_type: mesh_based
+    mask_check: 1
+    ntry: 3
+    nrep:  2
+    resol: 6.0
+    network: 1
+    mpicom: 2
+  correlation:
+  - name: ocn
+    base value: 840336.134453782
+    rossby mult: 0.280112045
+    vars: [tocn, socn, ssh]
+  - name: ice
+    base value: 560224.089635854
+    vars: [cicen, hicen]
+

--- a/test/testinput/static_socaerror_init.yml
+++ b/test/testinput/static_socaerror_init.yml
@@ -33,8 +33,9 @@ background error:
   - name: ocn
     base value: 840336.134453782
     rossby mult: 0.280112045
-    vars: [tocn, socn, ssh]
+    variables: [tocn, socn, ssh] # I don't think variable names actually matter
+                                 # here, it just needs something
   - name: ice
     base value: 560224.089635854
-    vars: [cicen, hicen]
+    variables: [cicen, hicen]
 

--- a/test/testinput/static_socaerror_test.yml
+++ b/test/testinput/static_socaerror_test.yml
@@ -2,7 +2,7 @@ geometry:
   mom6_input_nml: ./inputnml/input.nml
   fields metadata: ./fields_metadata.yml
 
-analysis variables: &soca_vars [cicen, hicen, hocn, socn, tocn, ssh]
+analysis variables: &soca_vars [cicen, hicen, socn, tocn, ssh]
 
 background:
   read_from_file: 1
@@ -10,16 +10,22 @@ background:
   basename: ./INPUT/
   ocn_filename: MOM.res.nc
   ice_filename: cice.res.nc
-  state variables: *soca_vars
+  state variables: [cicen, hicen, socn, tocn, ssh, hocn]
 
 background error:
   covariance model: SocaError
-  datadir: ./bump
-  strategy: specific_univariate
-  load_nicas: 1
-  mpicom: 2
-  date: *date
   analysis variables: *soca_vars
+  date: *date
+  bump:
+    datadir: ./bump
+    strategy: specific_univariate
+    load_nicas: 1
+    mpicom: 2
+  correlation:
+  - name: ocn
+    vars: [socn, tocn, ssh]
+  - name: ice
+    vars: [cicen, hicen]
 
 covariance test:
   tolerance: 1e-10

--- a/test/testinput/static_socaerror_test.yml
+++ b/test/testinput/static_socaerror_test.yml
@@ -23,9 +23,9 @@ background error:
     mpicom: 2
   correlation:
   - name: ocn
-    vars: [socn, tocn, ssh]
+    variables: [socn, tocn, ssh]
   - name: ice
-    vars: [cicen, hicen]
+    variables: [cicen, hicen]
 
 covariance test:
   tolerance: 1e-10

--- a/test/testinput/static_socaerrorlowres_init.yml
+++ b/test/testinput/static_socaerrorlowres_init.yml
@@ -34,8 +34,8 @@ background error:
   - name: ocn
     base value: 840336.134453782
     rossby mult: 0.280112045
-    vars: [tocn, socn, ssh]
+    variables: [tocn, socn, ssh]
   - name: ice
     base value: 560224.089635854
-    vars: [cicen, hicen]
+    variables: [cicen, hicen]
 

--- a/test/testinput/static_socaerrorlowres_init.yml
+++ b/test/testinput/static_socaerrorlowres_init.yml
@@ -3,7 +3,7 @@ geometry:
   mom6_input_nml: ./inputnml/input_small.nml
   fields metadata: ./fields_metadata.yml
 
-analysis variables: [cicen, hicen, hocn, socn, tocn, ssh]
+analysis variables: &ana_vars [cicen, hicen, socn, tocn, ssh]
 
 background:
   read_from_file: 1
@@ -14,24 +14,28 @@ background:
   state variables: [cicen, hicen, hocn, socn, tocn, ssh]
 
 background error:
-  verbosity: main
   covariance model: SocaError
-  datadir: ./bump_lowres
-  method: cor
-  strategy: specific_univariate
-  new_nicas: 1
-  interp_type: mesh_based
-  mask_check: 1
-  ntry: 3
-  nrep:  2
-  resol: 6.0
-  network: 1
-  mpicom: 2
+  analysis variables: *ana_vars
   date: *date
-  corr_scales:
-    ocn:
-      base value: 840336.134453782
-      rossby mult: 0.280112045
-    ice:
-      base value: 560224.089635854
-  analysis variables: [cicen, hicen, hocn, socn, tocn, ssh]
+  bump:
+    verbosity: main
+    datadir: ./bump_lowres
+    method: cor
+    strategy: specific_univariate
+    new_nicas: 1
+    interp_type: mesh_based
+    mask_check: 1
+    ntry: 3
+    nrep:  2
+    resol: 6.0
+    network: 1
+    mpicom: 2
+  correlation:
+  - name: ocn
+    base value: 840336.134453782
+    rossby mult: 0.280112045
+    vars: [tocn, socn, ssh]
+  - name: ice
+    base value: 560224.089635854
+    vars: [cicen, hicen]
+


### PR DESCRIPTION
## Description

_**do not merge until soca-science PR is ready**_

Generalizes the background error covariance code to remove hardcoded variable names. All information is obtained from the yaml files.

- all the bump related yaml for `SocaError` covariance has been moved under a `bump:` section to make it cleaner (and consistent with `BUMP` covariance class)
- the `correlation` section is required to inform which variables belong to which correlation lengths generated by socaerror_init.
- As a fun side effect of the generalization, we can have any number of correlation lengths now. So we could setup different lengths for ssh, or various tracers.
- `Covariance` checks to make sure all variables are on the h grid, so u/v are still rejected for now.

I might do a followup PR to generalize the error variance transform, I think it is the last remaining place with hardcoded variable names preventing us from being able to add new tracers simply by changing yaml files.



### Issue(s) addressed

- closes #602 


