### PR TITLE
Adjust indentation when saving increments to match changes in oops

### DIFF
--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -206,11 +206,11 @@ variational:
       departures: ombg
     online diagnostics:
       write increment: true
-    increment:
-      datadir: Data
-      date: *bkg_date
-      exp: 3dvargodas.iter1
-      type: incr
+      increment:
+        datadir: Data
+        date: *bkg_date
+        exp: 3dvargodas.iter1
+        type: incr
 
 output:
   datadir: Data

--- a/test/testinput/3dvar_soca.yml
+++ b/test/testinput/3dvar_soca.yml
@@ -263,11 +263,11 @@ variational:
       departures: ombg
     online diagnostics:
       write increment: true
-    increment:
-      datadir: Data
-      date: *bkg_date
-      exp: 3dvarsoca.iter1
-      type: incr
+      increment:
+        datadir: Data
+        date: *bkg_date
+        exp: 3dvarsoca.iter1
+        type: incr
 
 output:
   datadir: Data


### PR DESCRIPTION
## Description

I changed the indentation that `write increment` needs to have, it is now under `online diagnostics`.

## Dependencies
- waiting on JCSDA-internal/oops/pull/1276

