### PR TITLE
Pass ObsTopLevelParameters instead of a Configuration to the constructor of ioda::ObsSpace

### DIFF
--- a/src/soca/GetValues/GetValues.cc
+++ b/src/soca/GetValues/GetValues.cc
@@ -90,7 +90,9 @@ void GetValues::getValuesFromFile(const ufo::Locations & locs,
 
     // Create the Atmospheric Geometry in Observation Space
     eckit::LocalConfiguration confatmobs(conf, "notocean.obs space");
-    ioda::ObsSpace atmobs(confatmobs, geom_->getComm(), bgn, end,
+    ioda::ObsTopLevelParameters paramsatmobs;
+    paramsatmobs.validateAndDeserialize(confatmobs);
+    ioda::ObsSpace atmobs(paramsatmobs, geom_->getComm(), bgn, end,
                           oops::mpi::myself());
 
     // Get GeoVaLs from file

--- a/test/testref/3dhyb.test
+++ b/test/testref/3dhyb.test
@@ -1,15 +1,15 @@
 Test     : CostJb   : Nonlinear Jb = 0
 Test     : CostJo   : Nonlinear Jo(ADT) = 224.622, nobs = 100, Jo/n = 2.24622, err = 0.1
 Test     : CostFunction: Nonlinear J = 224.622
-Test     : RPCGMinimizer: reduction in residual norm = 0.513209
+Test     : RPCGMinimizer: reduction in residual norm = 0.355527
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.000059   max=    1.000000   mean=    0.117518
+Test     :   cicen   min=   -0.000035   max=    1.000000   mean=    0.117513
 Test     :   hicen   min=    0.000000   max=    4.032667   mean=    0.471252
 Test     :   hsnon   min=    0.000000   max=    1.271283   mean=    0.088687
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.568183
-Test     :    tocn   min=   -2.226181   max=   31.700465   mean=    6.007948
-Test     :     ssh   min=   -2.358013   max=    0.926565   mean=   -0.290888
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.546154
+Test     :    tocn   min=   -2.199318   max=   31.700462   mean=    6.016047
+Test     :     ssh   min=   -2.249193   max=    0.927395   mean=   -0.277713
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
@@ -18,6 +18,6 @@ Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395529
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008644
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 6.601260
-Test     : CostJo   : Nonlinear Jo(ADT) = 150.502349, nobs = 100, Jo/n = 1.505023, err = 0.100000
-Test     : CostFunction: Nonlinear J = 157.103609
+Test     : CostJb   : Nonlinear Jb = 8.047135
+Test     : CostJo   : Nonlinear Jo(ADT) = 150.196096, nobs = 100, Jo/n = 1.501961, err = 0.100000
+Test     : CostFunction: Nonlinear J = 158.243230

--- a/test/testref/3dhybfgat.test
+++ b/test/testref/3dhybfgat.test
@@ -1,14 +1,14 @@
 Test     : CostJb   : Nonlinear Jb = 0
 Test     : CostJo   : Nonlinear Jo(ADT) = 88.4808, nobs = 31, Jo/n = 2.85422, err = 0.1
 Test     : CostFunction: Nonlinear J = 88.4808
-Test     : RPCGMinimizer: reduction in residual norm = 0.4451
+Test     : RPCGMinimizer: reduction in residual norm = 0.198545
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.000020   max=    1.000000   mean=    0.117515
+Test     :   cicen   min=   -0.000032   max=    1.000000   mean=    0.117513
 Test     :   hicen   min=    0.000000   max=    4.032667   mean=    0.471252
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.556143
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.011091
-Test     :     ssh   min=   -1.924106   max=    0.923342   mean=   -0.284703
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.545369
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017377
+Test     :     ssh   min=   -1.924485   max=    0.927398   mean=   -0.277338
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
@@ -17,6 +17,6 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 2.469505
-Test     : CostJo   : Nonlinear Jo(ADT) = 76.941568, nobs = 31, Jo/n = 2.481986, err = 0.100000
-Test     : CostFunction: Nonlinear J = 79.411072
+Test     : CostJb   : Nonlinear Jb = 2.779955
+Test     : CostJo   : Nonlinear Jo(ADT) = 77.654721, nobs = 31, Jo/n = 2.504991, err = 0.100000
+Test     : CostFunction: Nonlinear J = 80.434676

--- a/test/testref/3dvar_godas.test
+++ b/test/testref/3dvar_godas.test
@@ -7,29 +7,29 @@ Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.787, nobs = 206, Jo/
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 355.419, nobs = 218, Jo/n = 1.63036, err = 0.608197
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 679.22, nobs = 89, Jo/n = 7.63169, err = 0.1
 Test     : CostFunction: Nonlinear J = 20473.1
-Test     : RPCGMinimizer: reduction in residual norm = 0.126963
+Test     : RPCGMinimizer: reduction in residual norm = 0.218126
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.000074   max=    1.000352   mean=    0.117550
+Test     :   cicen   min=   -0.000055   max=    1.000523   mean=    0.117533
 Test     :   hicen   min=    0.000000   max=    4.032667   mean=    0.471252
 Test     :   hsnon   min=    0.000000   max=    1.271283   mean=    0.088687
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544424
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018460
-Test     :     ssh   min=   -1.924799   max=    0.927288   mean=   -0.276775
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544394
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017746
+Test     :     ssh   min=   -1.924517   max=    0.927291   mean=   -0.276784
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :      sw   min= -225.094313   max=    0.000000   mean=  -71.738347
-Test     :     lhf   min=  -38.137499   max=  256.595663   mean=   42.009714
-Test     :     shf   min=  -58.949306   max=  201.374225   mean=    6.075328
-Test     :      lw   min=    0.000000   max=   88.036091   mean=   31.395535
-Test     :      us   min=    0.004396   max=    0.019668   mean=    0.008688
+Test     :      sw   min= -225.097763   max=    0.000000   mean=  -71.739042
+Test     :     lhf   min=  -38.137398   max=  256.595617   mean=   42.009946
+Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075327
+Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395531
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008660
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 0.555610
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 16676.032947, nobs = 201, Jo/n = 82.965338, err = 0.364832
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 1597.013136, nobs = 173, Jo/n = 9.231290, err = 0.363227
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 5.519079, nobs = 28, Jo/n = 0.197110, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 212.803428, nobs = 95, Jo/n = 2.240036, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 347.131401, nobs = 206, Jo/n = 1.685104, err = 0.897281
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 353.948333, nobs = 218, Jo/n = 1.623616, err = 0.608197
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 678.166191, nobs = 89, Jo/n = 7.619845, err = 0.100000
-Test     : CostFunction: Nonlinear J = 19871.170125
+Test     : CostJb   : Nonlinear Jb = 0.646558
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 16727.144284, nobs = 201, Jo/n = 83.219623, err = 0.364832
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 1589.087911, nobs = 173, Jo/n = 9.185479, err = 0.363227
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 5.519279, nobs = 28, Jo/n = 0.197117, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 212.763541, nobs = 95, Jo/n = 2.239616, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 347.532835, nobs = 206, Jo/n = 1.687053, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 353.546345, nobs = 218, Jo/n = 1.621772, err = 0.608197
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 678.228508, nobs = 89, Jo/n = 7.620545, err = 0.100000
+Test     : CostFunction: Nonlinear J = 19914.469260

--- a/test/testref/3dvar_soca.test
+++ b/test/testref/3dvar_soca.test
@@ -10,34 +10,34 @@ Test     : CostJo   : Nonlinear Jo(SeaSurfaceChlorophyll) = 1536.63, nobs = 129,
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceBiomassP) = 395.024, nobs = 112, Jo/n = 3.527, err = 1.16926e-08
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceHS) = 983.549, nobs = 6, Jo/n = 163.925, err = 0.1
 Test     : CostFunction: Nonlinear J = 19690
-Test     : RPCGMinimizer: reduction in residual norm = 0.158004
+Test     : RPCGMinimizer: reduction in residual norm = 0.250019
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.000249   max=    1.000495   mean=    0.117563
+Test     :   cicen   min=   -0.000225   max=    1.000687   mean=    0.117539
 Test     :   hicen   min=    0.000000   max=    4.032667   mean=    0.471252
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544418
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.019656
-Test     :     ssh   min=   -1.924632   max=    0.927288   mean=   -0.276710
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544393
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018014
+Test     :     ssh   min=   -1.924496   max=    0.927284   mean=   -0.276771
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :      sw   min= -225.094276   max=    0.000000   mean=  -71.738228
-Test     :     lhf   min=  -38.137514   max=  256.595632   mean=   42.009666
-Test     :     shf   min=  -58.949310   max=  201.374196   mean=    6.075326
-Test     :      lw   min=    0.000000   max=   88.036092   mean=   31.395535
-Test     :      us   min=    0.004396   max=    0.019672   mean=    0.008691
-Test     :     chl   min=   -0.000013   max=    4.671990   mean=    0.118478
+Test     :      sw   min= -225.097763   max=    0.000000   mean=  -71.739018
+Test     :     lhf   min=  -38.137398   max=  256.595050   mean=   42.009935
+Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075325
+Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395531
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008661
+Test     :     chl   min=    0.000010   max=    4.671990   mean=    0.118479
 Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     :     swh   min=    0.000100   max=    6.749196   mean=    1.062151
+Test     :     swh   min=    0.000100   max=    6.749196   mean=    1.062141
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 5.399105
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 13897.616615, nobs = 173, Jo/n = 80.333044, err = 0.363227
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 782.200171, nobs = 145, Jo/n = 5.394484, err = 0.363828
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 5.519146, nobs = 28, Jo/n = 0.197112, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 159.423359, nobs = 92, Jo/n = 1.732863, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.707958, nobs = 206, Jo/n = 1.692757, err = 0.897281
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 353.937515, nobs = 218, Jo/n = 1.623567, err = 0.608197
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 677.734552, nobs = 89, Jo/n = 7.614995, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceChlorophyll) = 1516.034333, nobs = 129, Jo/n = 11.752204, err = 0.061865
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceBiomassP) = 390.929457, nobs = 112, Jo/n = 3.490442, err = 0.000000
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceHS) = 980.568210, nobs = 6, Jo/n = 163.428035, err = 0.100000
-Test     : CostFunction: Nonlinear J = 19118.070421
+Test     : CostJb   : Nonlinear Jb = 1.067706
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 13946.775040, nobs = 173, Jo/n = 80.617197, err = 0.363227
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 782.669313, nobs = 145, Jo/n = 5.397719, err = 0.363828
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 5.519368, nobs = 28, Jo/n = 0.197120, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 159.420810, nobs = 92, Jo/n = 1.732835, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.719906, nobs = 206, Jo/n = 1.692815, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 353.668262, nobs = 218, Jo/n = 1.622331, err = 0.608197
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 677.911297, nobs = 89, Jo/n = 7.616981, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceChlorophyll) = 1503.202727, nobs = 129, Jo/n = 11.652734, err = 0.061865
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceBiomassP) = 390.193480, nobs = 112, Jo/n = 3.483870, err = 0.000000
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceHS) = 979.286609, nobs = 6, Jo/n = 163.214435, err = 0.100000
+Test     : CostFunction: Nonlinear J = 19148.434516

--- a/test/testref/3dvarbump.test
+++ b/test/testref/3dvarbump.test
@@ -5,19 +5,19 @@ Test     : CostJo   : Nonlinear Jo(ADT) = 512.768, nobs = 84, Jo/n = 6.10438, er
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 450.497, nobs = 134, Jo/n = 3.36192, err = 0.913795
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 412864, nobs = 218, Jo/n = 1893.87, err = 0.608197
 Test     : CostFunction: Nonlinear J = 414470
-Test     : RPCGMinimizer: reduction in residual norm = 0.126098
+Test     : RPCGMinimizer: reduction in residual norm = 0.125609
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    hocn   min=    0.001000   max= 1297.170000   mean=  110.562284
-Test     :    socn   min=    0.000000   max=   37.417185   mean=   28.649349
-Test     :    tocn   min=   -2.144503   max=   37.739373   mean=    5.079994
-Test     :     ssh   min=   -1.979442   max=    0.875830   mean=   -0.134431
+Test     :    socn   min=    0.000000   max=   38.693888   mean=   28.614917
+Test     :    tocn   min=   -2.083797   max=   36.682774   mean=    5.091295
+Test     :     ssh   min=   -1.924809   max=    1.000102   mean=   -0.095729
 Test     :     mld   min=    0.000500   max= 3446.494302   mean=  119.933096
 Test     : layer_depth   min=    0.000500   max= 5592.096099   mean= 1053.471947
-Test     : CostJb   : Nonlinear Jb = 261.898126
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 227.597622, nobs = 80, Jo/n = 2.844970, err = 0.381671
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 28.701435, nobs = 42, Jo/n = 0.683367, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 144.169550, nobs = 84, Jo/n = 1.716304, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 223.929657, nobs = 134, Jo/n = 1.671117, err = 0.913795
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 411593.160327, nobs = 218, Jo/n = 1888.042020, err = 0.608197
-Test     : CostFunction: Nonlinear J = 412479.456718
+Test     : CostJb   : Nonlinear Jb = 845.048708
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 204.569991, nobs = 80, Jo/n = 2.557125, err = 0.381671
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 25.972696, nobs = 42, Jo/n = 0.618398, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 91.177997, nobs = 84, Jo/n = 1.085452, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 199.028552, nobs = 134, Jo/n = 1.485288, err = 0.913795
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 411440.897028, nobs = 218, Jo/n = 1887.343564, err = 0.608197
+Test     : CostFunction: Nonlinear J = 412806.694972

--- a/test/testref/3dvarfgat.test
+++ b/test/testref/3dvarfgat.test
@@ -8,7 +8,7 @@ Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.7637, nobs = 33, Jo/n = 
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 255.973, nobs = 24, Jo/n = 10.6655, err = 0.1
 Test     : CostFunction: Nonlinear J = 5975.82
 Test     : RPCGMinimizer: reduction in residual norm = 0.630139
-Test     : CostFunction::addIncrement: Analysis: 
+Test     : CostFunction::addIncrement: Analysis:
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=   -0.008690   max=    1.199182   mean=    0.122782
 Test     :   hicen   min=    0.000000   max=    4.032667   mean=    0.471252
@@ -23,12 +23,12 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 642.317086
+Test     : CostJb   : Nonlinear Jb = 642.317087
 Test     : CostJo   : Nonlinear Jo(CoolSkin) = 4341.997731, nobs = 48, Jo/n = 90.458286, err = 0.387632
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 448.178592, nobs = 43, Jo/n = 10.422758, err = 0.385815
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 448.178593, nobs = 43, Jo/n = 10.422758, err = 0.385815
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.450542, nobs = 17, Jo/n = 0.144150, err = 1.000000
 Test     : CostJo   : Nonlinear Jo(ADT) = 85.099026, nobs = 29, Jo/n = 2.934449, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 40.113982, nobs = 31, Jo/n = 1.293999, err = 0.908940
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.030525, nobs = 33, Jo/n = 0.425167, err = 0.610430
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.030524, nobs = 33, Jo/n = 0.425167, err = 0.610430
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 115.165673, nobs = 24, Jo/n = 4.798570, err = 0.100000
 Test     : CostFunction: Nonlinear J = 5689.353157

--- a/test/testref/3dvarfgat.test
+++ b/test/testref/3dvarfgat.test
@@ -7,14 +7,14 @@ Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 41.0886, nobs = 31, Jo/n
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.7637, nobs = 33, Jo/n = 0.447385, err = 0.61043
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 255.973, nobs = 24, Jo/n = 10.6655, err = 0.1
 Test     : CostFunction: Nonlinear J = 5975.82
-Test     : RPCGMinimizer: reduction in residual norm = 0.417916
+Test     : RPCGMinimizer: reduction in residual norm = 0.630139
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.007252   max=    1.315490   mean=    0.131222
+Test     :   cicen   min=   -0.008690   max=    1.199182   mean=    0.122782
 Test     :   hicen   min=    0.000000   max=    4.032667   mean=    0.471252
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.549295
-Test     :    tocn   min=   -1.888390   max=   32.060930   mean=    6.045711
-Test     :     ssh   min=   -1.923076   max=    0.927170   mean=   -0.277195
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544700
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.022463
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276684
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :      sw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     lhf   min=    0.000000   max=    0.000000   mean=    0.000000
@@ -23,12 +23,12 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 1470.746246
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 3392.873679, nobs = 48, Jo/n = 70.684868, err = 0.387632
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 763.501477, nobs = 43, Jo/n = 17.755848, err = 0.385815
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.439723, nobs = 17, Jo/n = 0.143513, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 83.752875, nobs = 29, Jo/n = 2.888030, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 39.575932, nobs = 31, Jo/n = 1.276643, err = 0.908940
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 13.644232, nobs = 33, Jo/n = 0.413462, err = 0.610430
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 101.815302, nobs = 24, Jo/n = 4.242304, err = 0.100000
-Test     : CostFunction: Nonlinear J = 5868.349466
+Test     : CostJb   : Nonlinear Jb = 642.317086
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 4341.997731, nobs = 48, Jo/n = 90.458286, err = 0.387632
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 448.178592, nobs = 43, Jo/n = 10.422758, err = 0.385815
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.450542, nobs = 17, Jo/n = 0.144150, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 85.099026, nobs = 29, Jo/n = 2.934449, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 40.113982, nobs = 31, Jo/n = 1.293999, err = 0.908940
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.030525, nobs = 33, Jo/n = 0.425167, err = 0.610430
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 115.165673, nobs = 24, Jo/n = 4.798570, err = 0.100000
+Test     : CostFunction: Nonlinear J = 5689.353157

--- a/test/testref/3dvarfgat_pseudo.test
+++ b/test/testref/3dvarfgat_pseudo.test
@@ -6,7 +6,7 @@ Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 41.0886, nobs = 31, Jo/n
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.7637, nobs = 33, Jo/n = 0.447385, err = 0.61043
 Test     : CostFunction: Nonlinear J = 452.334
 Test     : RPCGMinimizer: reduction in residual norm = 0.703085
-Test     : CostFunction::addIncrement: Analysis: 
+Test     : CostFunction::addIncrement: Analysis:
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.545563
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.016556
@@ -16,10 +16,10 @@ Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 67.514335
+Test     : CostJb   : Nonlinear Jb = 67.514331
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 306.000437, nobs = 43, Jo/n = 7.116289, err = 0.385815
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.482603, nobs = 17, Jo/n = 0.146035, err = 1.000000
 Test     : CostJo   : Nonlinear Jo(ADT) = 49.944912, nobs = 29, Jo/n = 1.722238, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 41.088638, nobs = 31, Jo/n = 1.325440, err = 0.908940
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.763692, nobs = 33, Jo/n = 0.447385, err = 0.610430
-Test     : CostFunction: Nonlinear J = 481.794617
+Test     : CostFunction: Nonlinear J = 481.794613

--- a/test/testref/3dvarfgat_pseudo.test
+++ b/test/testref/3dvarfgat_pseudo.test
@@ -5,21 +5,21 @@ Test     : CostJo   : Nonlinear Jo(ADT) = 86.7398, nobs = 29, Jo/n = 2.99103, er
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 41.0886, nobs = 31, Jo/n = 1.32544, err = 0.90894
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.7637, nobs = 33, Jo/n = 0.447385, err = 0.61043
 Test     : CostFunction: Nonlinear J = 452.334
-Test     : RPCGMinimizer: reduction in residual norm = 0.895145
+Test     : RPCGMinimizer: reduction in residual norm = 0.703085
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.555182
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.015803
-Test     :     ssh   min=   -2.001871   max=    0.848694   mean=   -0.303489
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.545563
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.016556
+Test     :     ssh   min=   -2.044691   max=    0.927283   mean=   -0.279586
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 202.421619
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 304.454960, nobs = 43, Jo/n = 7.080348, err = 0.385815
+Test     : CostJb   : Nonlinear Jb = 67.514335
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 306.000437, nobs = 43, Jo/n = 7.116289, err = 0.385815
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.482603, nobs = 17, Jo/n = 0.146035, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 52.886691, nobs = 29, Jo/n = 1.823679, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(ADT) = 49.944912, nobs = 29, Jo/n = 1.722238, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 41.088638, nobs = 31, Jo/n = 1.325440, err = 0.908940
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.763692, nobs = 33, Jo/n = 0.447385, err = 0.610430
-Test     : CostFunction: Nonlinear J = 618.098204
+Test     : CostFunction: Nonlinear J = 481.794617

--- a/test/testref/3dvarlowres_soca.test
+++ b/test/testref/3dvarlowres_soca.test
@@ -5,19 +5,19 @@ Test     : CostJo   : Nonlinear Jo(ADT) = 147.738, nobs = 87, Jo/n = 1.69814, er
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.787, nobs = 206, Jo/n = 1.69314, err = 0.897281
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 355.419, nobs = 218, Jo/n = 1.63036, err = 0.608197
 Test     : CostFunction: Nonlinear J = 1669.38
-Test     : RPCGMinimizer: reduction in residual norm = 0.122973
+Test     : RPCGMinimizer: reduction in residual norm = 0.0288511
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721046   max=   40.441679   mean=   34.544836
-Test     :    tocn   min=   -1.888701   max=   31.788334   mean=    6.030155
-Test     :     ssh   min=   -1.992878   max=    0.885148   mean=   -0.278444
+Test     :    socn   min=   10.721046   max=   40.441698   mean=   34.544495
+Test     :    tocn   min=   -1.888433   max=   31.760565   mean=    6.021551
+Test     :     ssh   min=   -1.955396   max=    0.909823   mean=   -0.276436
 Test     :    hocn   min=    0.002000   max= 2691.280000   mean=  257.256128
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 75864.647752
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 246.970336, nobs = 147, Jo/n = 1.680070, err = 0.361776
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.068261, nobs = 51, Jo/n = 0.962123, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 99.081569, nobs = 87, Jo/n = 1.138869, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 5351.013376, nobs = 206, Jo/n = 25.975793, err = 0.897281
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 540.860894, nobs = 218, Jo/n = 2.481013, err = 0.608197
-Test     : CostFunction: Nonlinear J = 82151.642188
+Test     : CostJb   : Nonlinear Jb = 73993.807328
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 330.370048, nobs = 147, Jo/n = 2.247415, err = 0.361776
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.028916, nobs = 51, Jo/n = 0.961351, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 125.450448, nobs = 87, Jo/n = 1.441959, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 4964.411496, nobs = 206, Jo/n = 24.099085, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 550.967411, nobs = 218, Jo/n = 2.527373, err = 0.608197
+Test     : CostFunction: Nonlinear J = 80014.035648

--- a/test/testref/3dvarlowres_soca.test
+++ b/test/testref/3dvarlowres_soca.test
@@ -6,7 +6,7 @@ Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.787, nobs = 206, Jo/
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 355.419, nobs = 218, Jo/n = 1.63036, err = 0.608197
 Test     : CostFunction: Nonlinear J = 1669.38
 Test     : RPCGMinimizer: reduction in residual norm = 0.0288511
-Test     : CostFunction::addIncrement: Analysis: 
+Test     : CostFunction::addIncrement: Analysis:
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    socn   min=   10.721046   max=   40.441698   mean=   34.544495
 Test     :    tocn   min=   -1.888433   max=   31.760565   mean=    6.021551
@@ -14,10 +14,10 @@ Test     :     ssh   min=   -1.955396   max=    0.909823   mean=   -0.276436
 Test     :    hocn   min=    0.002000   max= 2691.280000   mean=  257.256128
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 73993.807328
+Test     : CostJb   : Nonlinear Jb = 73993.984567
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 330.370048, nobs = 147, Jo/n = 2.247415, err = 0.361776
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.028916, nobs = 51, Jo/n = 0.961351, err = 1.000000
 Test     : CostJo   : Nonlinear Jo(ADT) = 125.450448, nobs = 87, Jo/n = 1.441959, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 4964.411496, nobs = 206, Jo/n = 24.099085, err = 0.897281
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 550.967411, nobs = 218, Jo/n = 2.527373, err = 0.608197
-Test     : CostFunction: Nonlinear J = 80014.035648
+Test     : CostFunction: Nonlinear J = 80014.212887

--- a/test/testref/balance_mask.test
+++ b/test/testref/balance_mask.test
@@ -12,5 +12,5 @@ Test     :   cicen   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :   hicen   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :    socn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :    tocn   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     :     ssh   min=    0.000000   max=    1.000000   mean=    0.074100
+Test     :     ssh   min=    0.000000   max=    1.000000   mean=    0.021958
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000

--- a/test/testref/checkpointmodel.test
+++ b/test/testref/checkpointmodel.test
@@ -5,11 +5,11 @@ Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544424
-Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.018460
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544394
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017746
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : output background: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721046   max=   38.000000   mean=   34.539804
-Test     :    tocn   min=   -1.800000   max=   31.700465   mean=    6.018598
+Test     :    socn   min=   10.721046   max=   38.000000   mean=   34.539775
+Test     :    tocn   min=   -1.800000   max=   31.700465   mean=    6.017885
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064

--- a/test/testref/dirac_soca_cov.test
+++ b/test/testref/dirac_soca_cov.test
@@ -10,11 +10,11 @@ Test     :     mld   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : layer_depth   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : B * Increment: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.003559   max=    0.000000   mean=   -0.000023
-Test     :   hicen   min=    0.000000   max=  100.000000   mean=    0.810989
-Test     :    socn   min=   -0.044238   max=    0.285489   mean=    0.000313
-Test     :    tocn   min=    0.000000   max=    5.268716   mean=    0.021451
-Test     :     ssh   min=   -0.001965   max=    0.056011   mean=    0.000800
+Test     :   cicen   min=   -0.000828   max=    0.000000   mean=   -0.000001
+Test     :   hicen   min=    0.000000   max=  100.000000   mean=    0.060864
+Test     :    socn   min=   -0.016775   max=    0.103294   mean=    0.000295
+Test     :    tocn   min=    0.000000   max=    5.268716   mean=    0.001606
+Test     :     ssh   min=   -0.001965   max=    0.056011   mean=    0.000052
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : layer_depth   min=    0.000000   max=    0.000000   mean=    0.000000

--- a/test/testref/dirac_socahyb_cov.test
+++ b/test/testref/dirac_socahyb_cov.test
@@ -10,11 +10,11 @@ Test     :     mld   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : layer_depth   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : B * Increment: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.001779   max=    0.000000   mean=   -0.000010
-Test     :   hicen   min=    0.000000   max=   50.103093   mean=    0.405557
-Test     :    socn   min=   -0.219024   max=    0.030206   mean=   -0.000869
-Test     :    tocn   min=   -0.056974   max=    2.860168   mean=    0.011124
-Test     :     ssh   min=   -0.005017   max=    0.052044   mean=    0.000651
+Test     :   cicen   min=   -0.000414   max=    0.000000   mean=   -0.000000
+Test     :   hicen   min=    0.000000   max=   50.021187   mean=    0.030445
+Test     :    socn   min=   -0.043347   max=    0.046872   mean=   -0.000043
+Test     :    tocn   min=   -0.048798   max=    2.856185   mean=    0.001077
+Test     :     ssh   min=   -0.005701   max=    0.025578   mean=    0.000071
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : layer_depth   min=    0.000000   max=    0.000000   mean=    0.000000

--- a/test/testref/enspert.test
+++ b/test/testref/enspert.test
@@ -20,16 +20,16 @@ Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 0 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=   -0.017581   max=    1.020651   mean=    0.116650
-Test     :   hicen   min=   -1.179959   max=    4.254068   mean=    0.482225
+Test     :   cicen   min=   -0.011680   max=    1.020651   mean=    0.117571
+Test     :   hicen   min=   -0.658897   max=    4.254068   mean=    0.472863
 Test     :   hsnon   min=    0.000000   max=    1.271283   mean=    0.088687
-Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.525630
-Test     :    tocn   min=   -1.899104   max=   31.638666   mean=    6.028334
-Test     :    uocn   min=   -0.855045   max=    0.695355   mean=   -0.000291
-Test     :    vocn   min=   -0.796646   max=    1.223441   mean=    0.002085
-Test     :     ssh   min=   -1.881588   max=    0.917256   mean=   -0.276753
-Test     :    hocn   min=    0.001000   max= 1341.250000   mean=  128.628070
-Test     :     chl   min=   -0.032499   max=    4.686284   mean=    0.118486
+Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.541285
+Test     :    tocn   min=   -1.889974   max=   31.413425   mean=    6.026585
+Test     :    uocn   min=   -0.854941   max=    0.695162   mean=   -0.000304
+Test     :    vocn   min=   -0.794045   max=    1.223441   mean=    0.002032
+Test     :     ssh   min=   -1.906402   max=    0.914749   mean=   -0.276794
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :     chl   min=   -0.015046   max=    4.685795   mean=    0.118498
 Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
@@ -40,16 +40,16 @@ Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 1 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=   -0.026392   max=    1.006613   mean=    0.115638
-Test     :   hicen   min=   -1.051775   max=    3.938621   mean=    0.451004
+Test     :   cicen   min=   -0.016644   max=    1.006613   mean=    0.116383
+Test     :   hicen   min=   -0.506534   max=    3.938621   mean=    0.468198
 Test     :   hsnon   min=    0.000000   max=    1.271283   mean=    0.088687
-Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.545467
-Test     :    tocn   min=   -1.909555   max=   31.633334   mean=    6.002741
-Test     :    uocn   min=   -0.854705   max=    0.695640   mean=   -0.000138
-Test     :    vocn   min=   -0.755494   max=    1.208656   mean=    0.002041
-Test     :     ssh   min=   -1.886916   max=    0.913904   mean=   -0.276648
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628080
-Test     :     chl   min=   -0.041446   max=    4.675899   mean=    0.118537
+Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.544519
+Test     :    tocn   min=   -1.891514   max=   31.919727   mean=    6.012472
+Test     :    uocn   min=   -0.854646   max=    0.700629   mean=   -0.000304
+Test     :    vocn   min=   -0.700577   max=    1.208656   mean=    0.002151
+Test     :     ssh   min=   -1.913965   max=    0.909525   mean=   -0.276763
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628072
+Test     :     chl   min=   -0.031893   max=    4.687582   mean=    0.118507
 Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
@@ -60,16 +60,16 @@ Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 2 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=   -0.022499   max=    1.019549   mean=    0.118433
-Test     :   hicen   min=   -1.092589   max=    4.592419   mean=    0.442531
+Test     :   cicen   min=   -0.019120   max=    1.019549   mean=    0.118259
+Test     :   hicen   min=   -0.510803   max=    4.592419   mean=    0.458152
 Test     :   hsnon   min=    0.000000   max=    1.271283   mean=    0.088687
-Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.577775
-Test     :    tocn   min=   -1.939834   max=   31.987083   mean=    6.044769
-Test     :    uocn   min=   -0.857626   max=    0.669150   mean=   -0.000277
-Test     :    vocn   min=   -0.765791   max=    1.350246   mean=    0.001887
-Test     :     ssh   min=   -1.936310   max=    0.906278   mean=   -0.276586
-Test     :    hocn   min=    0.001000   max= 1341.250000   mean=  128.628076
-Test     :     chl   min=   -0.022928   max=    4.677805   mean=    0.118461
+Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.550461
+Test     :    tocn   min=   -1.899377   max=   31.604019   mean=    6.022802
+Test     :    uocn   min=   -0.855571   max=    0.649389   mean=   -0.000177
+Test     :    vocn   min=   -0.805753   max=    1.350246   mean=    0.002078
+Test     :     ssh   min=   -1.918574   max=    0.906906   mean=   -0.276676
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628083
+Test     :     chl   min=   -0.018535   max=    4.683831   mean=    0.118515
 Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
@@ -80,16 +80,16 @@ Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 3 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=   -0.020000   max=    1.014924   mean=    0.117130
-Test     :   hicen   min=   -1.115286   max=    4.224135   mean=    0.487186
+Test     :   cicen   min=   -0.016171   max=    1.014925   mean=    0.117372
+Test     :   hicen   min=   -0.644214   max=    4.224135   mean=    0.484478
 Test     :   hsnon   min=    0.000000   max=    1.271283   mean=    0.088687
-Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.531120
-Test     :    tocn   min=   -1.905177   max=   31.734106   mean=    6.054228
-Test     :    uocn   min=   -0.855890   max=    0.621920   mean=    0.000150
-Test     :    vocn   min=   -0.777995   max=    1.359538   mean=    0.002074
-Test     :     ssh   min=   -1.890098   max=    0.903739   mean=   -0.276528
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628095
-Test     :     chl   min=   -0.029007   max=    4.694876   mean=    0.118490
+Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.535502
+Test     :    tocn   min=   -1.903993   max=   31.858499   mean=    6.023081
+Test     :    uocn   min=   -0.854556   max=    0.705483   mean=   -0.000134
+Test     :    vocn   min=   -0.780169   max=    1.359537   mean=    0.002210
+Test     :     ssh   min=   -1.874035   max=    0.907889   mean=   -0.276589
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628087
+Test     :     chl   min=   -0.019906   max=    4.691876   mean=    0.118501
 Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
@@ -100,16 +100,16 @@ Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
 Test     : Member 4 final state: 
 Test     :   Valid time: 2018-04-15T06:00:00Z
-Test     :   cicen   min=   -0.018480   max=    1.007767   mean=    0.117177
-Test     :   hicen   min=   -1.191411   max=    4.752283   mean=    0.467455
+Test     :   cicen   min=   -0.011796   max=    1.007731   mean=    0.116978
+Test     :   hicen   min=   -0.725586   max=    4.752283   mean=    0.470088
 Test     :   hsnon   min=    0.000000   max=    1.271283   mean=    0.088687
-Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.543139
-Test     :    tocn   min=   -1.898822   max=   31.870497   mean=    5.904390
-Test     :    uocn   min=   -0.854023   max=    0.699338   mean=   -0.000087
-Test     :    vocn   min=   -0.815297   max=    1.398405   mean=    0.002040
-Test     :     ssh   min=   -1.919603   max=    0.904074   mean=   -0.276385
-Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628123
-Test     :     chl   min=   -0.032003   max=    4.640356   mean=    0.118547
+Test     :    socn   min=   10.720395   max=   40.441655   mean=   34.552325
+Test     :    tocn   min=   -1.901608   max=   31.890562   mean=    5.981426
+Test     :    uocn   min=   -0.853870   max=    0.710781   mean=    0.000040
+Test     :    vocn   min=   -0.809385   max=    1.398404   mean=    0.002047
+Test     :     ssh   min=   -1.921112   max=    0.907241   mean=   -0.276518
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628091
+Test     :     chl   min=   -0.042834   max=    4.632736   mean=    0.118517
 Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
 Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040

--- a/test/testref/ensrecenter.test
+++ b/test/testref/ensrecenter.test
@@ -1,88 +1,88 @@
 Test     : Original member 0 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.017581   max=    1.020651   mean=    0.116650
-Test     :   hicen   min=   -1.179959   max=    4.254068   mean=    0.482225
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.526983
-Test     :    tocn   min=   -3.525179   max=   31.713250   mean=    6.033070
-Test     :     ssh   min=   -1.887364   max=    0.907733   mean=   -0.269837
+Test     :   cicen   min=   -0.011680   max=    1.020651   mean=    0.117571
+Test     :   hicen   min=   -0.658897   max=    4.254068   mean=    0.472863
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.542736
+Test     :    tocn   min=   -2.900711   max=   31.401339   mean=    6.029450
+Test     :     ssh   min=   -1.907243   max=    0.908127   mean=   -0.275046
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Original member 1 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.026392   max=    1.006613   mean=    0.115638
-Test     :   hicen   min=   -1.051775   max=    3.938621   mean=    0.451004
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.547289
-Test     :    tocn   min=   -3.188436   max=   31.792663   mean=    6.009795
-Test     :     ssh   min=   -1.901868   max=    0.931464   mean=   -0.277311
+Test     :   cicen   min=   -0.016644   max=    1.006613   mean=    0.116383
+Test     :   hicen   min=   -0.506534   max=    3.938621   mean=    0.468198
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.545526
+Test     :    tocn   min=   -3.191891   max=   31.908549   mean=    6.012457
+Test     :     ssh   min=   -1.914232   max=    0.918997   mean=   -0.277593
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Original member 2 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.022499   max=    1.019549   mean=    0.118433
-Test     :   hicen   min=   -1.092589   max=    4.592419   mean=    0.442531
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.579870
-Test     :    tocn   min=   -4.897355   max=   31.975624   mean=    6.034572
-Test     :     ssh   min=   -1.984895   max=    0.902055   mean=   -0.289881
+Test     :   cicen   min=   -0.019120   max=    1.019549   mean=    0.118259
+Test     :   hicen   min=   -0.510803   max=    4.592419   mean=    0.458152
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.551847
+Test     :    tocn   min=   -3.507859   max=   31.592360   mean=    6.019790
+Test     :     ssh   min=   -1.966098   max=    0.917253   mean=   -0.279473
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Original member 3 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.020000   max=    1.014924   mean=    0.117130
-Test     :   hicen   min=   -1.115286   max=    4.224135   mean=    0.487186
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.532636
-Test     :    tocn   min=   -5.859760   max=   31.722738   mean=    6.048271
-Test     :     ssh   min=   -2.056795   max=    0.903968   mean=   -0.269574
+Test     :   cicen   min=   -0.016171   max=    1.014925   mean=    0.117372
+Test     :   hicen   min=   -0.644214   max=    4.224135   mean=    0.484478
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.536414
+Test     :    tocn   min=   -3.358337   max=   31.847385   mean=    6.024412
+Test     :     ssh   min=   -2.004855   max=    0.923682   mean=   -0.274211
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Original member 4 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.018480   max=    1.007767   mean=    0.117177
-Test     :   hicen   min=   -1.191411   max=    4.752283   mean=    0.467455
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.545644
-Test     :    tocn   min=   -4.036815   max=   32.044480   mean=    5.876109
-Test     :     ssh   min=   -1.881227   max=    0.899457   mean=   -0.282054
+Test     :   cicen   min=   -0.011796   max=    1.007731   mean=    0.116978
+Test     :   hicen   min=   -0.725586   max=    4.752283   mean=    0.470088
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.553650
+Test     :    tocn   min=   -3.597628   max=   31.879189   mean=    5.972634
+Test     :     ssh   min=   -1.895779   max=    0.922762   mean=   -0.279440
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Ensemble mean: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.009269   max=    1.009244   mean=    0.117006
-Test     :   hicen   min=   -0.528634   max=    3.998698   mean=    0.466080
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.546484
-Test     :    tocn   min=   -3.641211   max=   31.761192   mean=    6.000363
-Test     :     ssh   min=   -1.892620   max=    0.907471   mean=   -0.277731
+Test     :   cicen   min=   -0.006949   max=    1.009244   mean=    0.117313
+Test     :   hicen   min=   -0.286329   max=    3.998698   mean=    0.470756
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.546035
+Test     :    tocn   min=   -2.602939   max=   31.725764   mean=    6.011749
+Test     :     ssh   min=   -1.884998   max=    0.918164   mean=   -0.277153
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 0 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.017199   max=    1.017826   mean=    0.117157
-Test     :   hicen   min=   -1.072217   max=    4.069692   mean=    0.487396
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.524888
-Test     :    tocn   min=   -3.049545   max=   31.638535   mean=    6.050271
-Test     :     ssh   min=   -1.849272   max=    0.927545   mean=   -0.268896
+Test     :   cicen   min=   -0.009164   max=    1.017826   mean=    0.117771
+Test     :   hicen   min=   -0.601419   max=    4.069409   mean=    0.473359
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.541091
+Test     :    tocn   min=   -3.018438   max=   31.376039   mean=    6.035267
+Test     :     ssh   min=   -1.919518   max=    0.917246   mean=   -0.274684
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 1 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.018447   max=    1.009323   mean=    0.116145
-Test     :   hicen   min=   -1.022436   max=    3.966602   mean=    0.456175
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.545195
-Test     :    tocn   min=   -2.899840   max=   31.764359   mean=    6.026997
-Test     :     ssh   min=   -2.000403   max=    0.951275   mean=   -0.276370
+Test     :   cicen   min=   -0.011329   max=    1.008235   mean=    0.116583
+Test     :   hicen   min=   -0.486297   max=    3.966602   mean=    0.468694
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.543881
+Test     :    tocn   min=   -2.741248   max=   31.883249   mean=    6.018273
+Test     :     ssh   min=   -1.936962   max=    0.928115   mean=   -0.277231
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 2 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.021282   max=    1.015963   mean=    0.118940
-Test     :   hicen   min=   -0.979535   max=    4.544395   mean=    0.447703
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.577775
-Test     :    tocn   min=   -3.864815   max=   31.914897   mean=    6.051773
-Test     :     ssh   min=   -1.940641   max=    0.914545   mean=   -0.288940
+Test     :   cicen   min=   -0.014562   max=    1.015963   mean=    0.118459
+Test     :   hicen   min=   -0.493177   max=    4.544395   mean=    0.458648
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.550202
+Test     :    tocn   min=   -2.825613   max=   31.567060   mean=    6.025606
+Test     :     ssh   min=   -1.956610   max=    0.926372   mean=   -0.279111
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 3 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.018888   max=    1.009704   mean=    0.117637
-Test     :   hicen   min=   -0.979981   max=    4.306970   mean=    0.492358
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.530542
-Test     :    tocn   min=   -4.005697   max=   31.708586   mean=    6.065473
-Test     :     ssh   min=   -2.165066   max=    0.923780   mean=   -0.268633
+Test     :   cicen   min=   -0.014954   max=    1.009704   mean=    0.117572
+Test     :   hicen   min=   -0.556154   max=    4.306970   mean=    0.484974
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.534769
+Test     :    tocn   min=   -2.808559   max=   31.822085   mean=    6.030228
+Test     :     ssh   min=   -2.041148   max=    0.932800   mean=   -0.273849
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 4 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.015713   max=    1.007956   mean=    0.117684
-Test     :   hicen   min=   -1.161915   max=    4.599739   mean=    0.472626
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.543549
-Test     :    tocn   min=   -3.578535   max=   31.798181   mean=    5.893311
-Test     :     ssh   min=   -1.918873   max=    0.919269   mean=   -0.281113
+Test     :   cicen   min=   -0.009124   max=    1.007274   mean=    0.117178
+Test     :   hicen   min=   -0.748005   max=    4.599739   mean=    0.470584
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.552005
+Test     :    tocn   min=   -3.224584   max=   31.853890   mean=    5.978451
+Test     :     ssh   min=   -1.900900   max=    0.931880   mean=   -0.279078
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064

--- a/test/testref/ensvariance.test
+++ b/test/testref/ensvariance.test
@@ -1,12 +1,12 @@
 Test     : Variance: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=    0.000001   max=    0.000241   mean=    0.000050
-Test     :   hicen   min=    0.001124   max=    0.901982   mean=    0.135079
-Test     :    socn   min=    0.000000   max=    1.621284   mean=    0.057181
-Test     :    tocn   min=    0.000000   max=    9.939211   mean=    0.250615
+Test     :   cicen   min=    0.000000   max=    0.000231   mean=    0.000021
+Test     :   hicen   min=    0.000100   max=    0.901982   mean=    0.053978
+Test     :    socn   min=    0.000000   max=    0.594241   mean=    0.014839
+Test     :    tocn   min=    0.000000   max=    2.316193   mean=    0.064064
 Test     :    uocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :    vocn   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     :     ssh   min=    0.000000   max=    0.000858   mean=    0.000017
+Test     :     ssh   min=    0.000000   max=    0.000283   mean=    0.000006
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     :     mld   min=    0.000000   max=4212320.923603   mean=89558.031202
+Test     :     mld   min=    0.000000   max=5177843.328106   mean=84322.479603
 Test     : layer_depth   min=    0.000000   max=    0.000000   mean=    0.000000

--- a/test/testref/hybridgain.test
+++ b/test/testref/hybridgain.test
@@ -8,57 +8,57 @@ Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Ensemble mean posterior: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.017581   max=    1.020651   mean=    0.116650
-Test     :   hicen   min=   -1.179959   max=    4.254068   mean=    0.482225
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.526983
-Test     :    tocn   min=   -3.525179   max=   31.713250   mean=    6.033070
-Test     :     ssh   min=   -1.887364   max=    0.907733   mean=   -0.269837
+Test     :   cicen   min=   -0.011680   max=    1.020651   mean=    0.117571
+Test     :   hicen   min=   -0.658897   max=    4.254068   mean=    0.472863
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.542736
+Test     :    tocn   min=   -2.900711   max=   31.401339   mean=    6.029450
+Test     :     ssh   min=   -1.907243   max=    0.908127   mean=   -0.275046
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : new center : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.014040   max=    1.016341   mean=    0.116823
-Test     :   hicen   min=   -0.943967   max=    4.041328   mean=    0.480030
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.530464
-Test     :    tocn   min=   -3.094445   max=   31.641688   mean=    6.029969
-Test     :     ssh   min=   -1.875944   max=    0.911643   mean=   -0.271228
+Test     :   cicen   min=   -0.008862   max=    1.016341   mean=    0.117559
+Test     :   hicen   min=   -0.527117   max=    4.041328   mean=    0.472540
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.543067
+Test     :    tocn   min=   -2.646302   max=   31.461164   mean=    6.027073
+Test     :     ssh   min=   -1.895125   max=    0.911958   mean=   -0.275395
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 0 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.014040   max=    1.016341   mean=    0.116823
-Test     :   hicen   min=   -0.943967   max=    4.041328   mean=    0.480030
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.530464
-Test     :    tocn   min=   -3.094445   max=   31.641688   mean=    6.029969
-Test     :     ssh   min=   -1.875944   max=    0.911643   mean=   -0.271228
+Test     :   cicen   min=   -0.008862   max=    1.016341   mean=    0.117559
+Test     :   hicen   min=   -0.527117   max=    4.041328   mean=    0.472540
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.543067
+Test     :    tocn   min=   -2.646302   max=   31.461164   mean=    6.027073
+Test     :     ssh   min=   -1.895125   max=    0.911958   mean=   -0.275395
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 1 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.024971   max=    1.007737   mean=    0.115810
-Test     :   hicen   min=   -0.919933   max=    3.975201   mean=    0.448809
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.550770
-Test     :    tocn   min=   -3.296322   max=   31.965040   mean=    6.006694
-Test     :     ssh   min=   -1.960886   max=    0.935373   mean=   -0.278702
+Test     :   cicen   min=   -0.017286   max=    1.006181   mean=    0.116371
+Test     :   hicen   min=   -0.521867   max=    3.975201   mean=    0.467876
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.545857
+Test     :    tocn   min=   -3.244963   max=   31.968374   mean=    6.010080
+Test     :     ssh   min=   -1.924147   max=    0.922828   mean=   -0.277942
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 2 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.024462   max=    1.015574   mean=    0.118606
-Test     :   hicen   min=   -1.102013   max=    4.809731   mean=    0.440337
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.583351
-Test     :    tocn   min=   -4.967108   max=   31.990318   mean=    6.031471
-Test     :     ssh   min=   -1.977572   max=    0.902549   mean=   -0.291271
+Test     :   cicen   min=   -0.018059   max=    1.015574   mean=    0.118247
+Test     :   hicen   min=   -0.508316   max=    4.809731   mean=    0.457830
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.552178
+Test     :    tocn   min=   -3.530332   max=   31.652185   mean=    6.017413
+Test     :     ssh   min=   -1.961378   max=    0.921084   mean=   -0.279822
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 3 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.023337   max=    1.013278   mean=    0.117303
-Test     :   hicen   min=   -1.175621   max=    4.340951   mean=    0.484992
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.536117
-Test     :    tocn   min=   -5.692164   max=   31.814422   mean=    6.045170
-Test     :     ssh   min=   -2.139454   max=    0.907878   mean=   -0.270965
+Test     :   cicen   min=   -0.018472   max=    1.013279   mean=    0.117360
+Test     :   hicen   min=   -0.705428   max=    4.340951   mean=    0.484155
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.536745
+Test     :    tocn   min=   -3.368794   max=   31.907210   mean=    6.022035
+Test     :     ssh   min=   -2.038683   max=    0.927513   mean=   -0.274560
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
 Test     : Recentered member 4 : 
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :   cicen   min=   -0.019709   max=    1.006606   mean=    0.117349
-Test     :   hicen   min=   -1.204428   max=    4.865075   mean=    0.465260
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.549125
-Test     :    tocn   min=   -3.936867   max=   32.110421   mean=    5.873008
-Test     :     ssh   min=   -1.892750   max=    0.903367   mean=   -0.283445
+Test     :   cicen   min=   -0.011845   max=    1.006581   mean=    0.116967
+Test     :   hicen   min=   -0.762670   max=    4.865075   mean=    0.469765
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.553981
+Test     :    tocn   min=   -3.725178   max=   31.939015   mean=    5.970257
+Test     :     ssh   min=   -1.902828   max=    0.926593   mean=   -0.279789
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064

--- a/test/testref/letkf_observer.test
+++ b/test/testref/letkf_observer.test
@@ -1,64 +1,64 @@
 Test     : Initial state for member 1:
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.526983
-Test     :    tocn   min=   -3.525179   max=   31.713250   mean=    6.033070
-Test     :     ssh   min=   -1.887364   max=    0.907733   mean=   -0.269837
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.542736
+Test     :    tocn   min=   -2.900711   max=   31.401339   mean=    6.029450
+Test     :     ssh   min=   -1.907243   max=    0.908127   mean=   -0.275046
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.032499   max=    4.686284   mean=    0.118486
+Test     :     chl   min=   -0.015046   max=    4.685795   mean=    0.118498
 Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Initial state for member 2:
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.547289
-Test     :    tocn   min=   -3.188436   max=   31.792663   mean=    6.009795
-Test     :     ssh   min=   -1.901868   max=    0.931464   mean=   -0.277311
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.545526
+Test     :    tocn   min=   -3.191891   max=   31.908549   mean=    6.012457
+Test     :     ssh   min=   -1.914232   max=    0.918997   mean=   -0.277593
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.041446   max=    4.675899   mean=    0.118537
+Test     :     chl   min=   -0.031893   max=    4.687582   mean=    0.118507
 Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Initial state for member 3:
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.579870
-Test     :    tocn   min=   -4.897355   max=   31.975624   mean=    6.034572
-Test     :     ssh   min=   -1.984895   max=    0.902055   mean=   -0.289881
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.551847
+Test     :    tocn   min=   -3.507859   max=   31.592360   mean=    6.019790
+Test     :     ssh   min=   -1.966098   max=    0.917253   mean=   -0.279473
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.022928   max=    4.677805   mean=    0.118461
+Test     :     chl   min=   -0.018535   max=    4.683831   mean=    0.118515
 Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Initial state for member 4:
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.532636
-Test     :    tocn   min=   -5.859760   max=   31.722738   mean=    6.048271
-Test     :     ssh   min=   -2.056795   max=    0.903968   mean=   -0.269574
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.536414
+Test     :    tocn   min=   -3.358337   max=   31.847385   mean=    6.024412
+Test     :     ssh   min=   -2.004855   max=    0.923682   mean=   -0.274211
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.029007   max=    4.694876   mean=    0.118490
+Test     :     chl   min=   -0.019906   max=    4.691876   mean=    0.118501
 Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Initial state for member 5:
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.545644
-Test     :    tocn   min=   -4.036815   max=   32.044480   mean=    5.876109
-Test     :     ssh   min=   -1.881227   max=    0.899457   mean=   -0.282054
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.553650
+Test     :    tocn   min=   -3.597628   max=   31.879189   mean=    5.972634
+Test     :     ssh   min=   -1.895779   max=    0.922762   mean=   -0.279440
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.032003   max=    4.640356   mean=    0.118547
+Test     :     chl   min=   -0.042834   max=    4.632736   mean=    0.118517
 Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : H(x) for member 1:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.267384, RMS=24.117335
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.531129, RMS=24.159996
 Test     : H(x) for member 2:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=31.010689, RMS=24.302676
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.711987, RMS=24.213240
 Test     : H(x) for member 3:
-Test     : SeaSurfaceTemp nobs= 201 Min=-1.496698, Max=30.806034, RMS=24.239685
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.617450, RMS=24.189397
 Test     : H(x) for member 4:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.984012, RMS=24.218160
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.724905, RMS=24.204410
 Test     : H(x) for member 5:
-Test     : SeaSurfaceTemp nobs= 201 Min=-1.449325, Max=30.942135, RMS=24.027520
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.707510, RMS=24.123505
 Test     : H(x) ensemble background mean: 
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.694238, RMS=24.176122
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.658596, RMS=24.176943
 Test     : background y - H(x): 
-Test     : SeaSurfaceTemp nobs= 201 Min=-4.752540, Max=4.101972, RMS=1.368966
+Test     : SeaSurfaceTemp nobs= 201 Min=-5.004539, Max=4.137680, RMS=1.346655

--- a/test/testref/letkf_solver.test
+++ b/test/testref/letkf_solver.test
@@ -1,114 +1,114 @@
 Test     : Initial state for member 1:
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.526983
-Test     :    tocn   min=   -3.525179   max=   31.713250   mean=    6.033070
-Test     :     ssh   min=   -1.887364   max=    0.907733   mean=   -0.269837
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.542736
+Test     :    tocn   min=   -2.900711   max=   31.401339   mean=    6.029450
+Test     :     ssh   min=   -1.907243   max=    0.908127   mean=   -0.275046
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.032499   max=    4.686284   mean=    0.118486
+Test     :     chl   min=   -0.015046   max=    4.685795   mean=    0.118498
 Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Initial state for member 2:
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.547289
-Test     :    tocn   min=   -3.188436   max=   31.792663   mean=    6.009795
-Test     :     ssh   min=   -1.901868   max=    0.931464   mean=   -0.277311
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.545526
+Test     :    tocn   min=   -3.191891   max=   31.908549   mean=    6.012457
+Test     :     ssh   min=   -1.914232   max=    0.918997   mean=   -0.277593
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.041446   max=    4.675899   mean=    0.118537
+Test     :     chl   min=   -0.031893   max=    4.687582   mean=    0.118507
 Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Initial state for member 3:
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.579870
-Test     :    tocn   min=   -4.897355   max=   31.975624   mean=    6.034572
-Test     :     ssh   min=   -1.984895   max=    0.902055   mean=   -0.289881
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.551847
+Test     :    tocn   min=   -3.507859   max=   31.592360   mean=    6.019790
+Test     :     ssh   min=   -1.966098   max=    0.917253   mean=   -0.279473
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.022928   max=    4.677805   mean=    0.118461
+Test     :     chl   min=   -0.018535   max=    4.683831   mean=    0.118515
 Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Initial state for member 4:
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.532636
-Test     :    tocn   min=   -5.859760   max=   31.722738   mean=    6.048271
-Test     :     ssh   min=   -2.056795   max=    0.903968   mean=   -0.269574
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.536414
+Test     :    tocn   min=   -3.358337   max=   31.847385   mean=    6.024412
+Test     :     ssh   min=   -2.004855   max=    0.923682   mean=   -0.274211
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.029007   max=    4.694876   mean=    0.118490
+Test     :     chl   min=   -0.019906   max=    4.691876   mean=    0.118501
 Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Initial state for member 5:
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.545644
-Test     :    tocn   min=   -4.036815   max=   32.044480   mean=    5.876109
-Test     :     ssh   min=   -1.881227   max=    0.899457   mean=   -0.282054
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.553650
+Test     :    tocn   min=   -3.597628   max=   31.879189   mean=    5.972634
+Test     :     ssh   min=   -1.895779   max=    0.922762   mean=   -0.279440
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.032003   max=    4.640356   mean=    0.118547
+Test     :     chl   min=   -0.042834   max=    4.632736   mean=    0.118517
 Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : H(x) for member 1:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.267384, RMS=24.117335
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.531128, RMS=24.159996
 Test     : H(x) for member 2:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=31.010689, RMS=24.302676
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.711987, RMS=24.213240
 Test     : H(x) for member 3:
-Test     : SeaSurfaceTemp nobs= 201 Min=-1.496698, Max=30.806034, RMS=24.239685
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.617451, RMS=24.189397
 Test     : H(x) for member 4:
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.984013, RMS=24.218160
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.724905, RMS=24.204410
 Test     : H(x) for member 5:
-Test     : SeaSurfaceTemp nobs= 201 Min=-1.449325, Max=30.942135, RMS=24.027520
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.707510, RMS=24.123505
 Test     : H(x) ensemble background mean: 
-Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.694238, RMS=24.176122
+Test     : SeaSurfaceTemp nobs= 201 Min=-0.992614, Max=30.658596, RMS=24.176943
 Test     : background y - H(x): 
-Test     : SeaSurfaceTemp nobs= 201 Min=-4.752541, Max=4.101972, RMS=1.368966
+Test     : SeaSurfaceTemp nobs= 201 Min=-5.004539, Max=4.137680, RMS=1.346655
 Test     : Background mean :
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.546484
-Test     :    tocn   min=   -3.641211   max=   31.761192   mean=    6.000363
-Test     :     ssh   min=   -1.892620   max=    0.907471   mean=   -0.277731
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.546035
+Test     :    tocn   min=   -2.602939   max=   31.725764   mean=    6.011749
+Test     :     ssh   min=   -1.884998   max=    0.918164   mean=   -0.277153
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.015374   max=    4.675044   mean=    0.118504
+Test     :     chl   min=   -0.010402   max=    4.676364   mean=    0.118507
 Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Analysis mean :
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.545738
-Test     :    tocn   min=   -3.641211   max=   31.761192   mean=    6.002885
-Test     :     ssh   min=   -1.891237   max=    0.900363   mean=   -0.277573
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.545584
+Test     :    tocn   min=   -2.602939   max=   31.725764   mean=    6.012098
+Test     :     ssh   min=   -1.885080   max=    0.916566   mean=   -0.276991
 Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
-Test     :     chl   min=   -0.015374   max=    4.675044   mean=    0.118524
+Test     :     chl   min=   -0.010402   max=    4.676364   mean=    0.118509
 Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Analysis mean increment :
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=   -1.418167   max=    1.295860   mean=   -0.000746
-Test     :    tocn   min=   -4.644024   max=    2.879731   mean=    0.002521
-Test     :     ssh   min=   -0.226146   max=    0.121828   mean=    0.000159
+Test     :    socn   min=   -0.997549   max=    1.133388   mean=   -0.000450
+Test     :    tocn   min=   -3.140294   max=    1.769686   mean=    0.000349
+Test     :     ssh   min=   -0.230411   max=    0.175834   mean=    0.000161
 Test     :    uocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :    vocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     :     chl   min=   -0.041939   max=    0.036757   mean=    0.000021
-Test     :    biop   min=   -0.000000   max=    0.000000   mean=   -0.000000
+Test     :     chl   min=   -0.032794   max=    0.035362   mean=    0.000002
+Test     :    biop   min=   -0.000000   max=    0.000000   mean=    0.000000
 Test     : Forecast variance :
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=    0.000000   max=    1.621284   mean=    0.057040
-Test     :    tocn   min=    0.000000   max=    9.939211   mean=    0.250615
-Test     :     ssh   min=    0.000000   max=    0.090577   mean=    0.003627
+Test     :    socn   min=    0.000000   max=    0.594241   mean=    0.014716
+Test     :    tocn   min=    0.000000   max=    2.316193   mean=    0.064064
+Test     :     ssh   min=    0.000000   max=    0.027930   mean=    0.000897
 Test     :    uocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :    vocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     :     chl   min=    0.000000   max=    0.001985   mean=    0.000013
+Test     :     chl   min=    0.000000   max=    0.001146   mean=    0.000005
 Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     : Analysis variance :
 Test     :   Valid time: 2018-04-15T00:00:00Z
-Test     :    socn   min=    0.000000   max=    2.788627   mean=    0.061761
-Test     :    tocn   min=    0.000000   max=   28.143836   mean=    0.307207
-Test     :     ssh   min=    0.000000   max=    0.091343   mean=    0.003981
+Test     :    socn   min=    0.000000   max=    1.647260   mean=    0.016723
+Test     :    tocn   min=    0.000000   max=   12.512573   mean=    0.081252
+Test     :     ssh   min=    0.000000   max=    0.067908   mean=    0.001083
 Test     :    uocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :    vocn   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
-Test     :     chl   min=    0.000000   max=    0.002731   mean=    0.000015
+Test     :     chl   min=    0.000000   max=    0.001624   mean=    0.000006
 Test     :    biop   min=    0.000000   max=    0.000000   mean=    0.000000


### PR DESCRIPTION
## Description

The aim of this PR is to fix the build error reported in #625.

### Issue(s) addressed

- fixes #625
- fixes #628 

## Testing

I tried to test them using Travis CI. However, CMake fails with the following error:
```
CMake Error at src/CMakeLists.txt:561 (set_property):

  set_property given TEST names that do not exist:

    test_util_signal_trap
```

I don't think it's related to this PR, though.

## Dependencies

None
