### PR TITLE
Hard code number of pe's used in the tutorial

### DIFF
--- a/tutorial/tutorial_3dvar.sh
+++ b/tutorial/tutorial_3dvar.sh
@@ -30,7 +30,7 @@ mkdir -p 3dvar_out
 mkdir -p obs_out
 
 # 3DVAR
-OMP_NUM_THREADS=1 mpirun ../bin/soca_var.x ../config/3dvar.yaml
+OMP_NUM_THREADS=1 mpirun -np 2 ../bin/soca_var.x ../config/3dvar.yaml
 
 # Plot some diagnostics
 python -W ignore ../tutorial_plot.py '3dvar'

--- a/tutorial/tutorial_3dvarfgat.sh
+++ b/tutorial/tutorial_3dvarfgat.sh
@@ -45,7 +45,7 @@ do
     ymdh=$(date '+%Y %m %d %H' -d "$date_begin")   # change date in MOM6 namelist
     create_input_nml $ymdh                         # create input.nml valid for $date_begin
     forecast_yaml "$date_begin"                    # prepare the yaml configuration for a 24 hour forecast
-    OMP_NUM_THREADS=1 mpirun ../bin/soca_forecast.x ./forecast.yaml >> forecast.log 2>&1 # run a 24 hour forecast
+    OMP_NUM_THREADS=1 mpirun -np 2 ../bin/soca_forecast.x ./forecast.yaml >> forecast.log 2>&1 # run a 24 hour forecast
 
     # 3Dvar FGAT with a pseudo model
     # ------------------------------
@@ -59,18 +59,18 @@ do
         echo "            o 3DVAR FGAT with pseudo model"
         mkdir -p ./obs_out/outeriter_$outer_iter
         3dvarfgat_yaml "$date_begin" $outer_iter # prepare the yaml configuration
-        OMP_NUM_THREADS=1 mpirun ../bin/soca_var.x ./3dvarfgat.yaml  >> var.log 2>&1 # run 3dvar fgat for a 24 hour cycle
+        OMP_NUM_THREADS=1 mpirun -np 2 ../bin/soca_var.x ./3dvarfgat.yaml  >> var.log 2>&1 # run 3dvar fgat for a 24 hour cycle
 
         # Checkpoint analysis (write a MOM6 restart containing the analysis state variable)
         echo "            o Checkpoint analysis"
         checkpoint_yaml "$date_begin"                # prepare the yaml configuration
-        OMP_NUM_THREADS=1 mpirun ../bin/soca_checkpoint_model.x ./checkpoint.yaml  > checkpoint.log 2>&1
+        OMP_NUM_THREADS=1 mpirun -np 2 ../bin/soca_checkpoint_model.x ./checkpoint.yaml  > checkpoint.log 2>&1
 
         # Re-forecast starting from the analysis as initial conditions
         echo "            o Re-forecast from analysis"
         mv ./RESTART/MOM.res.nc ./INPUT/MOM.res.nc  # swap initial conditions with 3DVAR analysis
         forecast_yaml "$date_begin"                 # prepare the yaml configuration for a 24 hour forecast
-        OMP_NUM_THREADS=1 mpirun ../bin/soca_forecast.x ./forecast.yaml >> reforecast.log 2>&1 # run a 24 hour re-forecast
+        OMP_NUM_THREADS=1 mpirun -np 2 ../bin/soca_forecast.x ./forecast.yaml >> reforecast.log 2>&1 # run a 24 hour re-forecast
     done # outer_iter
 
     # Save some of the output

--- a/tutorial/tutorial_bump_op.sh
+++ b/tutorial/tutorial_bump_op.sh
@@ -26,7 +26,7 @@ ln -sf ../static/soca_gridspec.nc .
 
 # Create a NICAS horizontal correlation operator
 mkdir -p bump
-OMP_NUM_THREADS=1 mpirun ../bin/soca_staticbinit.x ../config/staticb.yaml
+OMP_NUM_THREADS=1 mpirun -np 2 ../bin/soca_staticbinit.x ../config/staticb.yaml
 
 # Move bump initialization files
 cp -r ./bump ../static/

--- a/tutorial/tutorial_gridgen.sh
+++ b/tutorial/tutorial_gridgen.sh
@@ -22,7 +22,7 @@ create_scratch 'scratch_gridgen'
 mom6_soca_static $PWD/..
 
 # Generate grid
-OMP_NUM_THREADS=1 mpirun ../bin/soca_gridgen.x ../config/gridgen.yaml
+OMP_NUM_THREADS=1 mpirun -np 2 ../bin/soca_gridgen.x ../config/gridgen.yaml
 
 # Save grid for later use
 mkdir -p ../static

--- a/tutorial/tutorial_make_observations.sh
+++ b/tutorial/tutorial_make_observations.sh
@@ -33,7 +33,7 @@ cp ../bkg_pert/MOM.res.nc ./INPUT/
 
 # Create synth obs by sampling the model initialized with the
 # perturbed background. This application runs MOM6 in-core.
-OMP_NUM_THREADS=1 mpirun ../bin/soca_hofx.x ../config/synthetic_obs.yaml
+OMP_NUM_THREADS=1 mpirun -np 2 ../bin/soca_hofx.x ../config/synthetic_obs.yaml
 
 # Concatenate ioda files that contain the synthetic observations
 mkdir -p ../obs

--- a/tutorial/tutorial_perturb_ic.sh
+++ b/tutorial/tutorial_perturb_ic.sh
@@ -29,7 +29,7 @@ ln -sf ../static/bump .
 
 # Generate a perturbation by randomizing a staic B-matrix
 mkdir -p out
-OMP_NUM_THREADS=1 mpirun ../bin/soca_enspert.x ../config/pert_ic.yaml
+OMP_NUM_THREADS=1 mpirun -np 2 ../bin/soca_enspert.x ../config/pert_ic.yaml
 
 # Move the perturbed restarts
 mkdir -p ../bkg_pert


### PR DESCRIPTION
## Description
Using all the cores in the node doesn't work when a node has ~20+ core, as the low resolution model used doesn't scale well beyond ~20pes. 

swapping `mpirun` with `mpirun -np 2` in the tutorial scripts.


