### PR TITLE
fix yaml schema / and obsloc test

### DIFF
--- a/test/testinput/convertstate.yml
+++ b/test/testinput/convertstate.yml
@@ -1,9 +1,8 @@
-inputVariables:
-  variables: &soca_vars [ssh, tocn, socn, uocn, vocn, hocn, cicen, layer_depth]
 input geometry:
   geom_grid_file: soca_gridspec.nc
   mom6_input_nml: ./inputnml/input.nml
   fields metadata: ./fields_metadata.yml
+
 output geometry:
   geom_grid_file: soca_gridspec.small.nc
   mom6_input_nml: ./inputnml/input_small.nml
@@ -17,7 +16,7 @@ states:
      ice_filename: cice.res.nc
      sfc_filename: sfc.res.nc
      date: &bkg_date 2018-04-15T00:00:00Z
-     state variables: *soca_vars
+     state variables: [ssh, tocn, socn, uocn, vocn, hocn, cicen, layer_depth]
   output:
      datadir: Data
      exp: remapped

--- a/test/testinput/convertstate_changevar.yml
+++ b/test/testinput/convertstate_changevar.yml
@@ -1,5 +1,7 @@
-inputVariables:
-  variables: &soca_vars [ssh, tocn, socn, uocn, vocn, hocn, cicen, chl, layer_depth]
+_: #YAML anchors to be used throughout
+  - &soca_vars [ssh, tocn, socn, uocn, vocn, hocn, cicen, chl, layer_depth]
+
+
 input geometry:
   geom_grid_file: soca_gridspec.nc
   mom6_input_nml: ./inputnml/input.nml

--- a/test/testinput/obslocalization.yml
+++ b/test/testinput/obslocalization.yml
@@ -26,7 +26,6 @@ observations:
     simulated variables: ['sea_surface_temperature']
     obsdatain:  {obsfile: ./Data/sst.nc}
   obs localization:
-    search method: kd_tree
     lengthscale: 3000e3
     localization method: Gaspari-Cohn
     reference gridpoints:
@@ -48,7 +47,7 @@ observations:
       lons: [-172.5, -192.5, -172.5, -17.5]
       lats: [  42.5,    2.5,    2.5,  22.5]
     reference local nobs: [12, 17, 21, 19]
-    reference rms: [0.188352,0.111358,0.0157477,0.0463056]
+    reference rms: [0.188375, 0.111379, 0.0158103, 0.0464027]
 
 - obs space:
     name: 'Rossby'
@@ -57,7 +56,6 @@ observations:
     obsdatain:  {obsfile: ./Data/sst.nc}
   obs localization:
     localization method: Rossby
-    search method: kd_tree
     base value: 500.0e3
     rossby mult: 2.0
     min grid mult: 1.0

--- a/test/testinput/state.yml
+++ b/test/testinput/state.yml
@@ -14,9 +14,4 @@ state test:
     remap_filename: ./INPUT/MOM.res.nc
   norm file: 387790.8913881866
   date: *date
-  StateGenerate:
-    read_from_file: 0
-    date: *date
-    variables: *soca_vars
-  norm-gen: 0.0
   tolerance: 1.0e-08


### PR DESCRIPTION
## Description
- garbage removed from the yamls so that the yaml schema checker is happy.
- update the obslocalization test rms reference values because the default search method was changed from `brute force` to `kd tree` and there were tiny differences. remove the search method in the yaml, because the default of `kd tree` is what we want.



### Issue(s) addressed

- fixes #667 
