### PR TITLE
Use the background instead of the trajectory for some of the variable changes

### DIFF
--- a/src/soca/Transforms/BkgErr/BkgErr.cc
+++ b/src/soca/Transforms/BkgErr/BkgErr.cc
@@ -37,13 +37,13 @@ namespace soca {
                  const eckit::Configuration & conf) {
     const eckit::Configuration * configc = &conf;
 
-    // Interpolate trajectory to the geom resolution
-    State traj_at_geomres(geom, traj);
+    // Interpolate background to the geom resolution
+    State bkg_at_geomres(geom, bkg);
 
     // Read/setup the diagonal of B
     soca_bkgerr_setup_f90(keyFtnConfig_,
                           &configc,
-                          traj_at_geomres.toFortran(),
+                          bkg_at_geomres.toFortran(),
                           geom.toFortran());
   }
   // -----------------------------------------------------------------------------

--- a/src/soca/Transforms/BkgErrFilt/BkgErrFilt.cc
+++ b/src/soca/Transforms/BkgErrFilt/BkgErrFilt.cc
@@ -36,13 +36,13 @@ namespace soca {
                  const eckit::Configuration & conf) {
     const eckit::Configuration * configc = &conf;
 
-    // Interpolate trajectory to the geom resolution
-    State traj_at_geomres(geom, traj);
+    // Interpolate background to the geom resolution
+    State bkg_at_geomres(geom, bkg);
 
     // Setup background error filter
     soca_bkgerrfilt_setup_f90(keyFtnConfig_,
                               &configc,
-                              traj_at_geomres.toFortran(),
+                              bkg_at_geomres.toFortran(),
                               geom.toFortran());
   }
   // -----------------------------------------------------------------------------

--- a/src/soca/Transforms/BkgErrGodas/BkgErrGodas.cc
+++ b/src/soca/Transforms/BkgErrGodas/BkgErrGodas.cc
@@ -37,13 +37,13 @@ namespace soca {
     oops::Log::trace() << "soca::BkgErrGodas::setup " << std::endl;
     const eckit::Configuration * configc = &conf;
 
-    // Interpolate trajectory to the geom resolution
-    State traj_at_geomres(geom, traj);
+    // Interpolate background to the geom resolution
+    State bkg_at_geomres(geom, bkg);
 
     // Initialize the parametric background error variance
     soca_bkgerrgodas_setup_f90(keyFtnConfig_,
                                &configc,
-                               traj_at_geomres.toFortran(),
+                               bkg_at_geomres.toFortran(),
                                geom.toFortran());
   }
   // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Description
A bit of a C++/Fortran miss-communication. We should be passing the background, not the trajectory, to the change of variable that are used to setup the background based diagonal of B. It doesn't change the test results since we're too impatient to do outer loops in any of our ctests ... Perhaps something we should change in the future and add a second tier set of tcests.
Or not.

### Issue(s) addressed
- fixes #666 
