### PR TITLE
Implement analytic init, and handle upcoming OOPS chvar_tlad PR

### DIFF
--- a/src/soca/AnalyticInit/AnalyticInit.cc
+++ b/src/soca/AnalyticInit/AnalyticInit.cc
@@ -1,0 +1,20 @@
+/*
+ * (C) Copyright 2021-2021 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#include "soca/AnalyticInit/AnalyticInit.h"
+#include "soca/AnalyticInit/AnalyticInitFortran.h"
+
+namespace soca {
+
+  static oops::AnalyticInitMaker<ufo::ObsTraits, AnalyticInit>
+    makerAnalyticInit_("soca_ana_init");
+
+  void AnalyticInit::fillGeoVaLs(const ufo::Locations & locs,
+                                 ufo::GeoVaLs & geovals) const {
+    soca_analytic_geovals_f90(geovals.toFortran(), locs);
+  };
+}  // namespace soca

--- a/src/soca/AnalyticInit/AnalyticInit.cc
+++ b/src/soca/AnalyticInit/AnalyticInit.cc
@@ -16,5 +16,5 @@ namespace soca {
   void AnalyticInit::fillGeoVaLs(const ufo::Locations & locs,
                                  ufo::GeoVaLs & geovals) const {
     soca_analytic_geovals_f90(geovals.toFortran(), locs);
-  };
+  }
 }  // namespace soca

--- a/src/soca/AnalyticInit/AnalyticInit.h
+++ b/src/soca/AnalyticInit/AnalyticInit.h
@@ -1,0 +1,35 @@
+/*
+ * (C) Copyright 2021-2021 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef SOCA_ANALYTICINIT_ANALYTICINIT_H_
+#define SOCA_ANALYTICINIT_ANALYTICINIT_H_
+
+#include "oops/interface/AnalyticInitBase.h"
+#include "ufo/ObsTraits.h"
+
+namespace soca {
+
+  class AnalyticInitParameters : public oops::AnalyticInitParametersBase {
+   OOPS_CONCRETE_PARAMETERS(AnalyticInitParameters, AnalyticInitParametersBase)
+   public:
+    // No parameters, for now
+  };
+
+// -----------------------------------------------------------------------------
+
+
+  class AnalyticInit : public oops::interface::AnalyticInitBase<ufo::ObsTraits> {
+
+   public:
+    typedef AnalyticInitParameters Parameters_;
+
+    explicit AnalyticInit(const Parameters_ &) {}
+    void fillGeoVaLs(const ufo::Locations &, ufo::GeoVaLs &) const override;
+  };
+
+}  // namespace soca
+#endif  // SOCA_ANALYTICINIT_ANALYTICINIT_H_

--- a/src/soca/AnalyticInit/AnalyticInit.h
+++ b/src/soca/AnalyticInit/AnalyticInit.h
@@ -14,7 +14,7 @@
 namespace soca {
 
   class AnalyticInitParameters : public oops::AnalyticInitParametersBase {
-   OOPS_CONCRETE_PARAMETERS(AnalyticInitParameters, AnalyticInitParametersBase)
+    OOPS_CONCRETE_PARAMETERS(AnalyticInitParameters, AnalyticInitParametersBase)
    public:
     // No parameters, for now
   };
@@ -22,8 +22,8 @@ namespace soca {
 // -----------------------------------------------------------------------------
 
 
-  class AnalyticInit : public oops::interface::AnalyticInitBase<ufo::ObsTraits> {
-
+  class AnalyticInit :
+    public oops::interface::AnalyticInitBase<ufo::ObsTraits> {
    public:
     typedef AnalyticInitParameters Parameters_;
 

--- a/src/soca/AnalyticInit/AnalyticInitFortran.h
+++ b/src/soca/AnalyticInit/AnalyticInitFortran.h
@@ -1,0 +1,24 @@
+/*
+ * (C) Copyright 2021-2021 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef SOCA_ANALYTICINIT_ANALYTICINITFORTRAN_H_
+#define SOCA_ANALYTICINIT_ANALYTICINITFORTRAN_H_
+
+#include "soca/Fortran.h"
+
+// Forward declarations
+namespace ufo {
+  class Locations;
+}
+
+namespace soca {
+
+  extern "C" {
+    void soca_analytic_geovals_f90(F90goms &, const ufo::Locations &);
+  }
+}  // namespace soca
+#endif  // SOCA_ANALYTICINIT_ANALYTICINITFORTRAN_H_

--- a/src/soca/AnalyticInit/CMakeLists.txt
+++ b/src/soca/AnalyticInit/CMakeLists.txt
@@ -1,0 +1,7 @@
+soca_target_sources(
+  AnalyticInit.cc
+  AnalyticInit.h
+  AnalyticInitFortran.h
+  soca_analytic_mod.F90
+  soca_analytic.interface.F90
+)

--- a/src/soca/AnalyticInit/soca_analytic.interface.F90
+++ b/src/soca/AnalyticInit/soca_analytic.interface.F90
@@ -1,0 +1,37 @@
+! (C) Copyright 2021-2021 UCAR.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+module soca_analytic_mod_c
+
+use iso_c_binding
+
+USE ufo_geovals_mod,            ONLY : ufo_geovals
+USE ufo_geovals_mod_c,          ONLY : ufo_geovals_registry
+USE ufo_locations_mod,          ONLY : ufo_locations
+
+use soca_analytic_mod
+
+implicit none
+private
+
+contains
+
+subroutine soca_analytic_geovals_c(c_key_geovals, c_locs) &
+        bind (c,name='soca_analytic_geovals_f90')
+
+    integer(c_int),  intent(inout) :: c_key_geovals
+    type(c_ptr), value, intent(in) :: c_locs
+
+    type(ufo_geovals), pointer :: geovals
+    type(ufo_locations) :: locs
+
+    call ufo_geovals_registry%get(c_key_geovals, geovals)
+    locs = ufo_locations(c_locs)
+
+    call soca_analytic_geovals(geovals, locs)
+
+end subroutine
+
+end module

--- a/src/soca/AnalyticInit/soca_analytic.interface.F90
+++ b/src/soca/AnalyticInit/soca_analytic.interface.F90
@@ -3,6 +3,8 @@
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 
+
+!> C++ interfaces for soca_analytic_mod
 module soca_analytic_mod_c
 
 use iso_c_binding
@@ -18,6 +20,7 @@ private
 
 contains
 
+!> C++ interface for soca_analytic_mod::soca_analytic_geovals()
 subroutine soca_analytic_geovals_c(c_key_geovals, c_locs) &
         bind (c,name='soca_analytic_geovals_f90')
 

--- a/src/soca/AnalyticInit/soca_analytic_mod.F90
+++ b/src/soca/AnalyticInit/soca_analytic_mod.F90
@@ -3,6 +3,7 @@
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 
+!> Analytic state/geoval initialization module used for testing only
 module soca_analytic_mod
 
 use kinds, only : kind_real
@@ -19,9 +20,13 @@ public :: soca_analytic_state
 
 contains
 
+! ------------------------------------------------------------------------------
+!> fill geovals using the analytic solution
+!!
+!! \see soca_analytic_val
 subroutine soca_analytic_geovals(geovals, locs)
-    type(ufo_geovals), intent(inout) :: geovals
-    type(ufo_locations),  intent(in) :: locs
+    type(ufo_geovals), intent(inout) :: geovals  !< output geovals
+    type(ufo_locations),  intent(in) :: locs !< input locations
 
     real(kind=kind_real), allocatable :: lons(:), lats(:)
     integer :: ivar, iloc, ival
@@ -46,6 +51,11 @@ subroutine soca_analytic_geovals(geovals, locs)
 
 end subroutine
 
+
+! ------------------------------------------------------------------------------
+!> Create a state from the analytic solution
+!!
+!! \see soca_analytic_val
 subroutine soca_analytic_state(state)
     class(soca_state), intent(inout) :: state
 
@@ -66,6 +76,12 @@ subroutine soca_analytic_state(state)
     end do
 end subroutine
 
+
+! ------------------------------------------------------------------------------
+!> Create an analytic value for a given location/variable
+!!
+!! A completely non-physical result. But used for testing the accuracy of the
+!! interpolation used in soca.
 function soca_analytic_val(var, lat, lon, depth) result(val)
     character(len=:), allocatable, intent(inout) :: var
     real(kind=kind_real), intent(in) :: lat, lon, depth
@@ -84,8 +100,6 @@ function soca_analytic_val(var, lat, lon, depth) result(val)
     rvar = mod(abs(ieor(ivar, z'5D7A9F43')), 1000) / 1000.0
 
     val = (sin(lon*3.14158/180.0) + cos(lat*3.14158/180.0)) * (0.5/depth) + rvar
-
-
 end function
 
 

--- a/src/soca/AnalyticInit/soca_analytic_mod.F90
+++ b/src/soca/AnalyticInit/soca_analytic_mod.F90
@@ -1,0 +1,91 @@
+! (C) Copyright 2021-2021 UCAR.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+module soca_analytic_mod
+
+use kinds, only : kind_real
+use ufo_geovals_mod, only : ufo_geovals
+use ufo_locations_mod, only : ufo_locations
+use soca_state_mod, only : soca_state
+
+
+implicit none
+private
+
+public :: soca_analytic_geovals
+public :: soca_analytic_state
+
+contains
+
+subroutine soca_analytic_geovals(geovals, locs)
+    type(ufo_geovals), intent(inout) :: geovals
+    type(ufo_locations),  intent(in) :: locs
+
+    real(kind=kind_real), allocatable :: lons(:), lats(:)
+    integer :: ivar, iloc, ival
+    real(kind=kind_real) :: val
+    character(len=:), allocatable :: name
+
+    allocate(lons(locs%nlocs()))
+    allocate(lats(locs%nlocs()))
+    call locs%get_lons(lons)
+    call locs%get_lats(lats)
+
+    do ivar = 1, geovals%nvar
+        name = geovals%variables(ivar)
+        do iloc = 1, geovals%geovals(ivar)%nlocs
+            do ival = 1, geovals%geovals(ivar)%nval
+                val = soca_analytic_val(&
+                    name, lats(iloc), lons(iloc), ival*1.0_kind_real)
+                geovals%geovals(ivar)%vals(ival, iloc) = val
+            end do
+        end do
+    end do
+
+end subroutine
+
+subroutine soca_analytic_state(state)
+    class(soca_state), intent(inout) :: state
+
+    integer :: i, j, f, k
+    real(kind=kind_real) :: val
+
+    do f = 1, size(state%fields)
+        do i = state%geom%isc, state%geom%iec
+            do j = state%geom%jsc, state%geom%jec
+                do k = 1, state%fields(f)%nz
+                ! TODO use the depth instead of the depth level
+                    val = soca_analytic_val(&
+                        state%fields(f)%name, state%fields(f)%lat(i,j), &
+                        state%fields(f)%lon(i,j), k*1.0_kind_real)
+                    state%fields(f)%val(i,j,k) = val
+                end do
+            end do
+        end do
+    end do
+end subroutine
+
+function soca_analytic_val(var, lat, lon, depth) result(val)
+    character(len=:), allocatable, intent(inout) :: var
+    real(kind=kind_real), intent(in) :: lat, lon, depth
+    real(kind=kind_real) :: val
+
+    integer :: i, j
+    real(kind=kind_real) :: rvar
+    integer :: ivar
+
+    ! create hash from string
+    ivar = 0
+    do i=1,len(var)
+        ivar = ieor(ivar, ishft(ichar(var(i:i)), mod(i-1,4)*8))
+    end do
+    rvar = mod(abs(ieor(ivar, z'5D7A9F43')), 1000) / 1000.0
+
+    val = (sind(lon) + lat/90.0) * (0.5/depth) + rvar
+
+end function
+
+
+end module

--- a/src/soca/AnalyticInit/soca_analytic_mod.F90
+++ b/src/soca/AnalyticInit/soca_analytic_mod.F90
@@ -53,10 +53,9 @@ subroutine soca_analytic_state(state)
     real(kind=kind_real) :: val
 
     do f = 1, size(state%fields)
-        do i = state%geom%isc, state%geom%iec
-            do j = state%geom%jsc, state%geom%jec
+        do i = state%geom%isd, state%geom%ied
+            do j = state%geom%jsd, state%geom%jed
                 do k = 1, state%fields(f)%nz
-                ! TODO use the depth instead of the depth level
                     val = soca_analytic_val(&
                         state%fields(f)%name, state%fields(f)%lat(i,j), &
                         state%fields(f)%lon(i,j), k*1.0_kind_real)
@@ -76,14 +75,16 @@ function soca_analytic_val(var, lat, lon, depth) result(val)
     real(kind=kind_real) :: rvar
     integer :: ivar
 
+
     ! create hash from string
     ivar = 0
-    do i=1,len(var)
+    do i=1,len(trim(var))
         ivar = ieor(ivar, ishft(ichar(var(i:i)), mod(i-1,4)*8))
     end do
     rvar = mod(abs(ieor(ivar, z'5D7A9F43')), 1000) / 1000.0
 
-    val = (sind(lon) + lat/90.0) * (0.5/depth) + rvar
+    val = (sin(lon*3.14158/180.0) + cos(lat*3.14158/180.0)) * (0.5/depth) + rvar
+
 
 end function
 

--- a/src/soca/CMakeLists.txt
+++ b/src/soca/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries( soca PUBLIC ioda )
 target_link_libraries( soca PUBLIC ufo )
 
 # Add source code in the subdirectories
+add_subdirectory(AnalyticInit)
 add_subdirectory(Covariance)
 add_subdirectory(Fields)
 add_subdirectory(Geometry)

--- a/src/soca/GetValues/GetValues.cc
+++ b/src/soca/GetValues/GetValues.cc
@@ -16,7 +16,6 @@
 #include "soca/GetValues/GetValues.h"
 #include "soca/GetValues/GetValuesFortran.h"
 #include "soca/State/State.h"
-#include "soca/Transforms/Model2GeoVaLs/Model2GeoVaLs.h"
 
 #include "ufo/GeoVaLs.h"
 #include "ufo/Locations.h"
@@ -29,8 +28,7 @@ namespace soca {
 GetValues::GetValues(const Geometry & geom,
                      const ufo::Locations & locs,
                      const eckit::Configuration & config)
-  : locs_(locs), geom_(new Geometry(geom)),
-    model2geovals_(new Model2GeoVaLs(geom, config)) {
+  : locs_(locs), geom_(new Geometry(geom)) {
   soca_getvalues_create_f90(keyGetValues_, geom.toFortran(), locs);
 }
 // -----------------------------------------------------------------------------
@@ -55,22 +53,10 @@ void GetValues::fillGeoVaLs(const State & state,
     getValuesFromFile(locs_, geovals.getVars(), geovals);
   }
 
-  // Do variable change if it has not already been done.
-  // TODO(travis): remove this once Yannick is done rearranging things in oops.
-  std::unique_ptr<State> varChangeState;
-  const State * state_ptr;
-  if (geovals.getVars() <= state.variables()) {
-    state_ptr = &state;
-  } else {
-    varChangeState.reset(new State(*geom_, geovals.getVars(),
-                                   state.validTime()));
-    model2geovals_->changeVar(state, *varChangeState);
-    state_ptr = varChangeState.get();
-  }
   // Get ocean geovals
   soca_getvalues_fill_geovals_f90(keyGetValues_,
                                   geom_->toFortran(),
-                                  state_ptr->toFortran(),
+                                  state.toFortran(),
                                   t1, t2, locs_,
                                   geovals.toFortran());
 }

--- a/src/soca/GetValues/GetValues.h
+++ b/src/soca/GetValues/GetValues.h
@@ -30,7 +30,6 @@ namespace ufo {
 namespace soca {
   class Geometry;
   class State;
-  class Model2GeoVaLs;
 }
 
 //-----------------------------------------------------------------------------
@@ -68,7 +67,6 @@ class GetValues : public util::Printable,
   F90getval keyGetValues_;
   ufo::Locations locs_;
   std::shared_ptr<const Geometry> geom_;
-  std::unique_ptr<Model2GeoVaLs> model2geovals_;
 };
 // -----------------------------------------------------------------------------
 

--- a/src/soca/GetValues/LinearGetValues.cc
+++ b/src/soca/GetValues/LinearGetValues.cc
@@ -12,8 +12,6 @@
 #include "soca/GetValues/LinearGetValues.h"
 #include "soca/Increment/Increment.h"
 #include "soca/State/State.h"
-#include "soca/Transforms/Model2GeoVaLs/LinearModel2GeoVaLs.h"
-#include "soca/Transforms/Model2GeoVaLs/Model2GeoVaLs.h"
 
 #include "ufo/GeoVaLs.h"
 #include "ufo/Locations.h"
@@ -26,8 +24,7 @@ namespace soca {
 LinearGetValues::LinearGetValues(const Geometry & geom,
                                  const ufo::Locations & locs,
                                  const eckit::Configuration &config)
-  : locs_(locs), geom_(new Geometry(geom)),
-    model2geovals_(new Model2GeoVaLs(geom, config))
+  : locs_(locs), geom_(new Geometry(geom))
 {
   soca_getvalues_create_f90(keyLinearGetValues_,
                             geom.toFortran(),
@@ -45,28 +42,9 @@ void LinearGetValues::setTrajectory(const State & state,
                                     const util::DateTime & t1,
                                     const util::DateTime & t2,
                                     ufo::GeoVaLs & geovals) {
-  std::unique_ptr<State> varChangeState;
-  const State * state_ptr;
-
-  // Do variable change if it has not already been done.
-  // TODO(travis): remove this once Yannick is done rearranging things in oops.
-  if ( geovals.getVars() <= state.variables() ) {
-    state_ptr = &state;
-  } else {
-    varChangeState.reset(new State(*geom_, geovals.getVars(),
-                         state.validTime()));
-    model2geovals_->changeVar(state, *varChangeState);
-    state_ptr = varChangeState.get();
-  }
-
-  // TODO(travis) : change to a map to store multiple time slices?
-  eckit::LocalConfiguration conf;
-  linearmodel2geovals_.reset(new LinearModel2GeoVaLs(state, state,
-                                                     *geom_, conf));
-
   soca_getvalues_fill_geovals_f90(keyLinearGetValues_,
                                   geom_->toFortran(),
-                                  state_ptr->toFortran(),
+                                  state.toFortran(),
                                   t1, t2, locs_,
                                   geovals.toFortran());
 }
@@ -75,11 +53,9 @@ void LinearGetValues::fillGeoVaLsTL(const Increment & incr,
                                     const util::DateTime & t1,
                                     const util::DateTime & t2,
                                     ufo::GeoVaLs & geovals) const {
-  Increment incrGeovals(*geom_, geovals.getVars(), incr.validTime());
-  linearmodel2geovals_->multiply(incr, incrGeovals);
   soca_getvalues_fill_geovals_tl_f90(keyLinearGetValues_,
                                      geom_->toFortran(),
-                                     incrGeovals.toFortran(),
+                                     incr.toFortran(),
                                      t1, t2, locs_,
                                      geovals.toFortran());
 }
@@ -88,13 +64,11 @@ void LinearGetValues::fillGeoVaLsAD(Increment & incr,
                                     const util::DateTime & t1,
                                     const util::DateTime & t2,
                                     const ufo::GeoVaLs & geovals) const {
-  Increment incrGeovals(*geom_, geovals.getVars(), incr.validTime());
-  soca_getvalues_fill_geovals_ad_f90(keyLinearGetValues_,
+    soca_getvalues_fill_geovals_ad_f90(keyLinearGetValues_,
                                      geom_->toFortran(),
-                                     incrGeovals.toFortran(),
+                                     incr.toFortran(),
                                      t1, t2, locs_,
                                      geovals.toFortran());
-  linearmodel2geovals_->multiplyAD(incrGeovals, incr);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/soca/GetValues/LinearGetValues.h
+++ b/src/soca/GetValues/LinearGetValues.h
@@ -23,8 +23,6 @@
 namespace soca {
   class Increment;
   class State;
-  class Model2GeoVaLs;
-  class LinearModel2GeoVaLs;
 }
 namespace ufo {
   class GeoVaLs;
@@ -69,8 +67,6 @@ class LinearGetValues : public util::Printable,
   F90getval keyLinearGetValues_;
   ufo::Locations locs_;
   std::shared_ptr<const Geometry> geom_;
-  std::unique_ptr<Model2GeoVaLs> model2geovals_;
-  std::unique_ptr<LinearModel2GeoVaLs> linearmodel2geovals_;
 };
 // -----------------------------------------------------------------------------
 

--- a/src/soca/State/State.cc
+++ b/src/soca/State/State.cc
@@ -48,6 +48,9 @@ namespace soca {
     soca_state_create_f90(keyFlds_, geom_->toFortran(), vars);
 
     if (conf.has("analytic init")) {
+      std::string dt;
+      conf.get("date", dt);
+      time_ = util::DateTime(dt);
       soca_state_analytic_f90(toFortran(), &conf, &dtp);
     } else {
       soca_state_read_file_f90(toFortran(), &conf, &dtp);

--- a/src/soca/State/State.cc
+++ b/src/soca/State/State.cc
@@ -38,15 +38,20 @@ namespace soca {
     Log::trace() << "State::State created." << std::endl;
   }
   // -----------------------------------------------------------------------------
-  State::State(const Geometry & geom, const eckit::Configuration & file)
+  State::State(const Geometry & geom, const eckit::Configuration & conf)
     : time_(),
-      vars_(file, "state variables"),
+      vars_(conf, "state variables"),
       geom_(new Geometry(geom))
   {
     util::DateTime * dtp = &time_;
     oops::Variables vars(vars_);
     soca_state_create_f90(keyFlds_, geom_->toFortran(), vars);
-    soca_state_read_file_f90(toFortran(), &file, &dtp);
+
+    if (conf.has("analytic init")) {
+      soca_state_analytic_f90(toFortran(), &conf, &dtp);
+    } else {
+      soca_state_read_file_f90(toFortran(), &conf, &dtp);
+    }
     Log::trace() << "State::State created and read in." << std::endl;
   }
   // -----------------------------------------------------------------------------

--- a/src/soca/State/StateFortran.h
+++ b/src/soca/State/StateFortran.h
@@ -62,6 +62,9 @@ namespace soca {
                                     const size_t &,
                                     const double[],
                                     size_t &);
+    void soca_state_analytic_f90(const F90flds &,
+                                 const eckit::Configuration * const &,
+                                 util::DateTime * const *);
   }
 }  // namespace soca
 #endif  // SOCA_STATE_STATEFORTRAN_H_

--- a/src/soca/State/soca_state.interface.F90
+++ b/src/soca/State/soca_state.interface.F90
@@ -19,6 +19,7 @@ use soca_increment_mod, only: soca_increment
 use soca_increment_reg, only: soca_increment_registry
 use soca_state_mod, only: soca_state
 use soca_state_reg, only: soca_state_registry
+use soca_analytic_mod, only: soca_analytic_state
 
 implicit none
 private
@@ -401,5 +402,25 @@ subroutine soca_state_expontrans_c(c_key_self, c_trvars) bind(c,name='soca_state
   call self%logexpon(transfunc="expon", trvars=trvars)
 
 end subroutine soca_state_expontrans_c
+
+
+! ------------------------------------------------------------------------------
+subroutine scoa_state_analytic_c(c_key_self, c_conf, c_dt) &
+    bind(c,name='soca_state_analytic_f90')
+  integer (c_int),     intent(in   ) :: c_key_self
+  TYPE (c_ptr), value, intent(in   ) :: c_conf
+  TYPE (c_ptr),        intent(inout) :: c_dt
+
+  type(soca_state), pointer :: self
+  type(datetime) :: fdate
+
+  call soca_state_registry%get(c_key_self,self)
+  call c_f_datetime (c_dt, fdate)
+  call soca_analytic_state(self)
+end subroutine scoa_state_analytic_c
+
+
+
+
 
 end module soca_state_mod_c

--- a/src/soca/State/soca_state.interface.F90
+++ b/src/soca/State/soca_state.interface.F90
@@ -417,10 +417,8 @@ subroutine scoa_state_analytic_c(c_key_self, c_conf, c_dt) &
   call soca_state_registry%get(c_key_self,self)
   call c_f_datetime (c_dt, fdate)
   call soca_analytic_state(self)
+
 end subroutine scoa_state_analytic_c
-
-
-
 
 
 end module soca_state_mod_c

--- a/src/soca/State/soca_state_mod.F90
+++ b/src/soca/State/soca_state_mod.F90
@@ -44,7 +44,7 @@ contains
   !> \name misc
   !! \{
 
-  !> \copybrief soca_state_rotate \see soca_state_rotate
+    !> \copybrief soca_state_rotate \see soca_state_rotate
   procedure :: rotate => soca_state_rotate
 
   !> \copybrief soca_state_convert \see soca_state_convert

--- a/src/soca/Transforms/Model2GeoVaLs/LinearModel2GeoVaLs.cc
+++ b/src/soca/Transforms/Model2GeoVaLs/LinearModel2GeoVaLs.cc
@@ -24,6 +24,10 @@ static oops::LinearVariableChangeMaker<Traits,
        oops::LinearVariableChange<Traits, LinearModel2GeoVaLs> >
        makerLinearVariableChangeModel2GeoVaLs_("Model2GeoVaLs");
 
+static oops::LinearVariableChangeMaker<Traits,
+       oops::LinearVariableChange<Traits, LinearModel2GeoVaLs> >
+       makerLinearVariableChangeModel2GeoVaLsDefault_("default");
+
 // -----------------------------------------------------------------------------
 
 LinearModel2GeoVaLs::LinearModel2GeoVaLs(const State & bg, const State &fg,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -508,10 +508,9 @@ soca_add_test( NAME state
                SRC  TestState.cc
                TEST_DEPENDS test_soca_gridgen )
 
-# Temporarily disable until it can be fixed.
-# soca_add_test( NAME getvalues
-#                SRC  TestGetValues.cc
-#                TEST_DEPENDS test_soca_gridgen )
+soca_add_test( NAME getvalues
+               SRC  TestGetValues.cc
+               TEST_DEPENDS test_soca_gridgen )
 
 soca_add_test( NAME model
                SRC  TestModel.cc

--- a/test/testinput/getvalues.yml
+++ b/test/testinput/getvalues.yml
@@ -37,6 +37,7 @@ locations:
     simulated variables: *geovals
     generate:
       random:
+        random seed: 0
         nobs: 1000
         lat1: -32
         lat2: 37.5

--- a/test/testinput/getvalues.yml
+++ b/test/testinput/getvalues.yml
@@ -3,7 +3,6 @@ geometry:
   fields metadata: ./fields_metadata.yml
 
 state variables: &geovals [sea_water_potential_temperature,
-                           sea_water_potential_temperature,
                            sea_water_salinity,
                            sea_water_cell_thickness,
                            sea_surface_height_above_geoid,
@@ -22,21 +21,13 @@ state variables: &geovals [sea_water_potential_temperature,
                            northward_sea_water_velocity]
 
 getvalues test:
-  interpolation tolerance: 1.0e-2
-  state variables: *geovals
+  interpolation tolerance: 1.5e-2
 
   state generate:
-    read_from_file: 1
+    analytic init:
+      method: soca_ana_init
     date: &date 2018-04-15T00:00:00Z
-    basename: ./INPUT/
-    ocn_filename: MOM.res.nc
-    ice_filename: cice.res.nc
-    sfc_filename: sfc.res.nc
-    wav_filename: wav.res.nc
-    state variables: [cicen, hicen, socn, tocn, ssh, hocn, uocn, vocn, sw, lhf, shf, lw, us, swh]
-
-geovals:
-  state variables: *geovals
+    state variables: *geovals
 
 locations:
   window begin: 2018-04-15T00:00:00Z
@@ -47,8 +38,9 @@ locations:
     generate:
       random:
         nobs: 1000
-        lat1: -75
-        lat2: 90
-        lon1: 0
-        lon2: 360
-      obs errors: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+        lat1: -32
+        lat2: 37.5
+        lon1: -192.5
+        lon2: -57
+      obs errors: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+

--- a/test/testinput/lineargetvalues.yml
+++ b/test/testinput/lineargetvalues.yml
@@ -2,12 +2,7 @@ geometry:
   mom6_input_nml: ./inputnml/input.nml
   fields metadata: ./fields_metadata.yml
 
-state variables: &geovals [sea_water_potential_temperature,
-                           sea_water_salinity,
-                           sea_surface_temperature,
-                           sea_surface_height_above_geoid,
-                           sea_ice_category_area_fraction,
-                           sea_ice_category_thickness]
+state variables: &geovals [cicen, hicen, socn, tocn, ssh, hocn]
 
 linear getvalues test:
   tolerance linearity: 1.0e-11
@@ -24,9 +19,6 @@ background:
   ocn_filename: MOM.res.nc
   ice_filename: cice.res.nc
   sfc_filename: sfc.res.nc
-  state variables: [cicen, hicen, socn, tocn, ssh, hocn]
-
-geovals:
   state variables: *geovals
 
 locations:

--- a/test/testinput/state.yml
+++ b/test/testinput/state.yml
@@ -12,6 +12,16 @@ state test:
     sfc_filename: sfc.res.nc
     state variables: &soca_vars [cicen, hicen, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us, mld, layer_depth]
     remap_filename: ./INPUT/MOM.res.nc
+
+  state generate:
+    analytic init:
+      method: 'soca_ana_init'
+
+    date: *date
+    state variables: *soca_vars
+
   norm file: 387790.8913881866
+  norm generated state: 397.84702625989928
+
   date: *date
   tolerance: 1.0e-08


### PR DESCRIPTION
## Description

- Analytic init class is added to generate an analytic state and analytic geovals.
- GetValues test has been re-enabled
- remove change of variables that were done in getval and lineargetval (since these are/will be done in oops instead)

### Issue(s) addressed
- fixes #608
- fixes #639
- ready for pending oops PR


## Dependencies

requires oops branch of matching name
- waiting on https://github.com/JCSDA-internal/oops/pull/1424


