### PR TITLE
Use Parameters in ObsLocRossby

### DIFF
--- a/src/soca/ObsLocalization/ObsLocRossby.h
+++ b/src/soca/ObsLocalization/ObsLocRossby.h
@@ -8,19 +8,10 @@
 #ifndef SOCA_OBSLOCALIZATION_OBSLOCROSSBY_H_
 #define SOCA_OBSLOCALIZATION_OBSLOCROSSBY_H_
 
-#include <algorithm>
-#include <vector>
-
-#include "eckit/config/Configuration.h"
-
 #include "ioda/ObsSpace.h"
 #include "ioda/ObsVector.h"
 
-#include "oops/generic/gc99.h"
-
 #include "ufo/obslocalization/ObsHorLocGC99.h"
-#include "ufo/obslocalization/ObsHorLocParameters.h"
-
 #include "soca/ObsLocalization/ObsLocRossbyParameters.h"
 
 // -----------------------------------------------------------------------------
@@ -33,7 +24,9 @@ class ObsLocRossby: public ufo::ObsHorLocGC99<MODEL> {
   typedef typename ufo::ObsHorLocalization<MODEL>::LocalObs LocalObs_;
 
  public:
-  ObsLocRossby(const eckit::Configuration &, const ioda::ObsSpace &);
+  typedef ObsLocRossbyParameters Parameters_;
+
+  ObsLocRossby(const Parameters_ &, const ioda::ObsSpace &);
 
   /// Compute Rossby radius based localization and update localization values
   /// in \p locvector. Missing values indicate that observation is outside of
@@ -50,10 +43,10 @@ class ObsLocRossby: public ufo::ObsHorLocGC99<MODEL> {
 
 template<typename MODEL>
 ObsLocRossby<MODEL>::ObsLocRossby(
-      const eckit::Configuration& config,
+      const Parameters_ & options,
       const ioda::ObsSpace & obsspace):
-    ufo::ObsHorLocGC99<MODEL>::ObsHorLocGC99(config, obsspace) {
-  options_.deserialize(config);
+    ufo::ObsHorLocGC99<MODEL>::ObsHorLocGC99(options, obsspace),
+    options_(options) {
 }
 
 // -----------------------------------------------------------------------------

--- a/src/soca/ObsLocalization/ObsLocRossby.h
+++ b/src/soca/ObsLocalization/ObsLocRossby.h
@@ -8,6 +8,8 @@
 #ifndef SOCA_OBSLOCALIZATION_OBSLOCROSSBY_H_
 #define SOCA_OBSLOCALIZATION_OBSLOCROSSBY_H_
 
+#include <algorithm>
+
 #include "ioda/ObsSpace.h"
 #include "ioda/ObsVector.h"
 


### PR DESCRIPTION
## Description

Goes with https://github.com/JCSDA-internal/oops/pull/1589 and https://github.com/JCSDA-internal/ufo/pull/1787
Parameters are now passed directly to `ObsLocalization` ctor, and they have to be a subclass of `oops::ObsLocalizationParametersBase`. 

## Testing

Tested on my mac with jedi-clang/12.0.5 and mpich/3.3.2. Some test failures that seem to be unrelated to this PR. (but CI will tell!)

## Dependencies

- [x] https://github.com/JCSDA-internal/oops/pull/1589
- [x] https://github.com/JCSDA-internal/ufo/pull/1787