### PR TITLE
UFO PR185 broke soca: fix "assign error" in ctest yaml

### DIFF
--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -137,6 +137,7 @@ cost function:
     - filter: Bounds Check
       minvalue: -2.0
       maxvalue: 2.0
+    - filter: Perform Action
       action:
         name: assign error
         error function:


### PR DESCRIPTION
## Description

https://github.com/JCSDA-internal/ufo/pull/1856 changed the way that `assign error` worked, which broke our answers in our ctests.

I'm assuming that what was happening now is that the error was assigned to adt obs with values between -2.0 and 2.0, but obs outside that range were not being removed (as they were before).
fixed the yaml file to replicate the old behavior

~soca-science should be checked and fixed as well~ (mesoscale error stuff is disabled currently in soca-science)

