### PR TITLE
obs_absolute_dynamic_topography to absolute_dynamic_topography

### DIFF
--- a/test/Data/Obs/adt.nc
+++ b/test/Data/Obs/adt.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd2a89662a5b70e5a2033f142d6b7eed79314008387b65f2a35aea8c5f73cbed
-size 34694
+oid sha256:6e8c7ba4a92e750d7a8a6a450907c82ad43c78ec364a08c37a3727728b29bc22
+size 24196

--- a/test/testinput/3dhyb.yml
+++ b/test/testinput/3dhyb.yml
@@ -121,7 +121,7 @@ cost function:
       name: ADT
       obsdataout: {obsfile: ./Data/adt.out.nc}
       obsdatain:  {obsfile: ./Data/adt.nc}
-      simulated variables: [obs_absolute_dynamic_topography]
+      simulated variables: [absolute_dynamic_topography]
     obs operator:
       name: ADT
     obs error:

--- a/test/testinput/3dhybfgat.yml
+++ b/test/testinput/3dhybfgat.yml
@@ -126,7 +126,7 @@ cost function:
       name: ADT
       obsdataout: {obsfile: ./Data/adt.out.nc}
       obsdatain:  {obsfile: ./Data/adt.nc}
-      simulated variables: [obs_absolute_dynamic_topography]
+      simulated variables: [absolute_dynamic_topography]
     obs operator:
       name: ADT
     obs error:

--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -127,7 +127,7 @@ cost function:
       name: ADT
       obsdataout: {obsfile: ./Data/adt.out.nc}
       obsdatain:  {obsfile: ./Data/adt.nc}
-      simulated variables: [obs_absolute_dynamic_topography]
+      simulated variables: [absolute_dynamic_topography]
     obs operator:
       name: ADT
     obs error:
@@ -144,7 +144,7 @@ cost function:
           name: LinearCombination@ObsFunction
           options:
             variables: [mesoscale_representation_error@GeoVaLs,
-                        obs_absolute_dynamic_topography@ObsError]
+                        absolute_dynamic_topography@ObsError]
             coefs: [1.0,
                     1.0]
 

--- a/test/testinput/3dvar_soca.yml
+++ b/test/testinput/3dvar_soca.yml
@@ -152,7 +152,7 @@ cost function:
       name: ADT
       obsdataout: {obsfile: ./Data/adt.out.nc}
       obsdatain:  {obsfile: ./Data/adt.nc}
-      simulated variables: [obs_absolute_dynamic_topography]
+      simulated variables: [absolute_dynamic_topography]
     obs operator:
       name: ADT
     obs error:

--- a/test/testinput/3dvarbump.yml
+++ b/test/testinput/3dvarbump.yml
@@ -116,7 +116,7 @@ cost function:
       name: ADT
       obsdataout: {obsfile: ./Data/adt.out.nc}
       obsdatain:  {obsfile: ./Data/adt.nc}
-      simulated variables: [obs_absolute_dynamic_topography]
+      simulated variables: [absolute_dynamic_topography]
     obs operator:
       name: ADT
     obs error:

--- a/test/testinput/3dvarfgat.yml
+++ b/test/testinput/3dvarfgat.yml
@@ -134,7 +134,7 @@ cost function:
       name: ADT
       obsdataout: {obsfile: ./Data/adt.out.nc}
       obsdatain:  {obsfile: ./Data/adt.nc}
-      simulated variables: [obs_absolute_dynamic_topography]
+      simulated variables: [absolute_dynamic_topography]
     obs operator:
       name: ADT
     obs error:

--- a/test/testinput/3dvarfgat_pseudo.yml
+++ b/test/testinput/3dvarfgat_pseudo.yml
@@ -126,7 +126,7 @@ cost function:
       name: ADT
       obsdataout: {obsfile: ./Data/adt.out.nc}
       obsdatain:  {obsfile: ./Data/adt.nc}
-      simulated variables: [obs_absolute_dynamic_topography]
+      simulated variables: [absolute_dynamic_topography]
     obs operator:
       name: ADT
     obs error:

--- a/test/testinput/3dvarlowres_soca.yml
+++ b/test/testinput/3dvarlowres_soca.yml
@@ -120,7 +120,7 @@ cost function:
       name: ADT
       obsdataout: {obsfile: ./Data/adt.out.nc}
       obsdatain:  {obsfile: ./Data/adt.nc}
-      simulated variables: [obs_absolute_dynamic_topography]
+      simulated variables: [absolute_dynamic_topography]
     obs operator:
       name: ADT
     obs error:

--- a/test/testinput/enshofx_1.yml
+++ b/test/testinput/enshofx_1.yml
@@ -51,7 +51,7 @@ observations:
       name: ADT
       #obsdataout: {obsfile: ./Data/adt.out.nc}
       obsdatain:  {obsfile: ./Data/adt.nc}
-      simulated variables: [obs_absolute_dynamic_topography]
+      simulated variables: [absolute_dynamic_topography]
     obs operator:
       name: ADT
 

--- a/test/testinput/enshofx_2.yml
+++ b/test/testinput/enshofx_2.yml
@@ -51,7 +51,7 @@ observations:
       name: ADT
       #obsdataout: {obsfile: ./Data/adt.out.nc}
       obsdatain:  {obsfile: ./Data/adt.nc}
-      simulated variables: [obs_absolute_dynamic_topography]
+      simulated variables: [absolute_dynamic_topography]
     obs operator:
       name: ADT
 

--- a/test/testinput/enshofx_3.yml
+++ b/test/testinput/enshofx_3.yml
@@ -51,7 +51,7 @@ observations:
       name: ADT
       #obsdataout: {obsfile: ./Data/adt.out.nc}
       obsdatain:  {obsfile: ./Data/adt.nc}
-      simulated variables: [obs_absolute_dynamic_topography]
+      simulated variables: [absolute_dynamic_topography]
     obs operator:
       name: ADT
 

--- a/test/testinput/hofx_3d.yml
+++ b/test/testinput/hofx_3d.yml
@@ -43,7 +43,7 @@ observations:
       name: ADT
       obsdataout: {obsfile: ./Data/adt.out.nc}
       obsdatain:  {obsfile: ./Data/adt.nc}
-      simulated variables: [obs_absolute_dynamic_topography]
+      simulated variables: [absolute_dynamic_topography]
     obs operator:
       name: ADT
 

--- a/test/testinput/hofx_4d.yml
+++ b/test/testinput/hofx_4d.yml
@@ -49,7 +49,7 @@ observations:
       name: ADT
       obsdataout: {obsfile: ./Data/adt.out.nc}
       obsdatain:  {obsfile: ./Data/adt.nc}
-      simulated variables: [obs_absolute_dynamic_topography]
+      simulated variables: [absolute_dynamic_topography]
     obs operator:
       name: ADT
 

--- a/test/testinput/hofx_4d_pseudo.yml
+++ b/test/testinput/hofx_4d_pseudo.yml
@@ -53,7 +53,7 @@ observations:
       name: ADT
       obsdataout: {obsfile: ./Data/adt.out.nc}
       obsdatain:  {obsfile: ./Data/adt.nc}
-      simulated variables: [obs_absolute_dynamic_topography]
+      simulated variables: [absolute_dynamic_topography]
     obs operator:
       name: ADT
 

--- a/test/testref/3dhyb.test
+++ b/test/testref/3dhyb.test
@@ -1,7 +1,7 @@
 Test     : CostJb   : Nonlinear Jb = 0
 Test     : CostJo   : Nonlinear Jo(ADT) = 224.622, nobs = 100, Jo/n = 2.24622, err = 0.1
 Test     : CostFunction: Nonlinear J = 224.622
-Test     : RPCGMinimizer: reduction in residual norm = 0.512814
+Test     : RPCGMinimizer: reduction in residual norm = 0.512815
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=   -0.000079   max=    1.000000   mean=    0.117523
@@ -18,6 +18,6 @@ Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395529
 Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008644
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 4.649862
-Test     : CostJo   : Nonlinear Jo(ADT) = 164.308574, nobs = 100, Jo/n = 1.643086, err = 0.100000
-Test     : CostFunction: Nonlinear J = 168.958437
+Test     : CostJb   : Nonlinear Jb = 4.649861
+Test     : CostJo   : Nonlinear Jo(ADT) = 164.308542, nobs = 100, Jo/n = 1.643085, err = 0.100000
+Test     : CostFunction: Nonlinear J = 168.958403

--- a/test/testref/3dhybfgat.test
+++ b/test/testref/3dhybfgat.test
@@ -17,6 +17,6 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 2.323731
-Test     : CostJo   : Nonlinear Jo(ADT) = 78.197002, nobs = 31, Jo/n = 2.522484, err = 0.100000
-Test     : CostFunction: Nonlinear J = 80.520734
+Test     : CostJb   : Nonlinear Jb = 2.323730
+Test     : CostJo   : Nonlinear Jo(ADT) = 78.196969, nobs = 31, Jo/n = 2.522483, err = 0.100000
+Test     : CostFunction: Nonlinear J = 80.520699

--- a/test/testref/3dvar_soca.test
+++ b/test/testref/3dvar_soca.test
@@ -33,11 +33,11 @@ Test     : CostJb   : Nonlinear Jb = 10.717663
 Test     : CostJo   : Nonlinear Jo(CoolSkin) = 13854.164949, nobs = 173, Jo/n = 80.081878, err = 0.363227
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 781.845769, nobs = 145, Jo/n = 5.392040, err = 0.363828
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 5.519423, nobs = 28, Jo/n = 0.197122, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 159.432717, nobs = 92, Jo/n = 1.732964, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(ADT) = 159.432678, nobs = 92, Jo/n = 1.732964, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.698178, nobs = 206, Jo/n = 1.692710, err = 0.897281
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 354.213359, nobs = 218, Jo/n = 1.624832, err = 0.608197
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 678.106725, nobs = 89, Jo/n = 7.619177, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceChlorophyll) = 1518.905733, nobs = 129, Jo/n = 11.774463, err = 0.061865
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceBiomassP) = 391.756403, nobs = 112, Jo/n = 3.497825, err = 0.000000
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceHS) = 981.317798, nobs = 6, Jo/n = 163.552966, err = 0.100000
-Test     : CostFunction: Nonlinear J = 19084.678718
+Test     : CostFunction: Nonlinear J = 19084.678680

--- a/test/testref/3dvarbump.test
+++ b/test/testref/3dvarbump.test
@@ -11,13 +11,13 @@ Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    hocn   min=    0.001000   max= 1297.170000   mean=  110.562284
 Test     :    socn   min=    0.000000   max=   37.417185   mean=   28.649349
 Test     :    tocn   min=   -2.144503   max=   37.739373   mean=    5.079994
-Test     :     ssh   min=   -1.979442   max=    0.875830   mean=   -0.134431
+Test     :     ssh   min=   -1.979441   max=    0.875830   mean=   -0.134431
 Test     :     mld   min=    0.000500   max= 3446.494302   mean=  119.933096
 Test     : layer_depth   min=    0.000500   max= 5592.096099   mean= 1053.471947
-Test     : CostJb   : Nonlinear Jb = 261.898126
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 227.597622, nobs = 80, Jo/n = 2.844970, err = 0.381671
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 28.701435, nobs = 42, Jo/n = 0.683367, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 144.169550, nobs = 84, Jo/n = 1.716304, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 223.929657, nobs = 134, Jo/n = 1.671117, err = 0.913795
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 411593.160327, nobs = 218, Jo/n = 1888.042020, err = 0.608197
-Test     : CostFunction: Nonlinear J = 412479.456718
+Test     : CostJb   : Nonlinear Jb = 261.898147
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 227.597624, nobs = 80, Jo/n = 2.844970, err = 0.381671
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 28.701434, nobs = 42, Jo/n = 0.683367, err = 1.000000
+Test     : CostJo   : Nonlinear Jo(ADT) = 144.169588, nobs = 84, Jo/n = 1.716305, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 223.929648, nobs = 134, Jo/n = 1.671117, err = 0.913795
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 411593.160347, nobs = 218, Jo/n = 1888.042020, err = 0.608197
+Test     : CostFunction: Nonlinear J = 412479.456789

--- a/test/testref/3dvarfgat.test
+++ b/test/testref/3dvarfgat.test
@@ -23,12 +23,12 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 5426.162344
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 2979.271387, nobs = 48, Jo/n = 62.068154, err = 0.387632
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 914.835838, nobs = 43, Jo/n = 21.275252, err = 0.385815
+Test     : CostJb   : Nonlinear Jb = 5426.162198
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 2979.271419, nobs = 48, Jo/n = 62.068155, err = 0.387632
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 914.835823, nobs = 43, Jo/n = 21.275252, err = 0.385815
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.460015, nobs = 17, Jo/n = 0.144707, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 84.281003, nobs = 29, Jo/n = 2.906241, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 38.451355, nobs = 31, Jo/n = 1.240366, err = 0.908940
+Test     : CostJo   : Nonlinear Jo(ADT) = 84.280979, nobs = 29, Jo/n = 2.906241, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 38.451350, nobs = 31, Jo/n = 1.240366, err = 0.908940
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 13.818843, nobs = 33, Jo/n = 0.418753, err = 0.610430
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 127.371517, nobs = 24, Jo/n = 5.307147, err = 0.100000
-Test     : CostFunction: Nonlinear J = 9586.652303
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 127.371518, nobs = 24, Jo/n = 5.307147, err = 0.100000
+Test     : CostFunction: Nonlinear J = 9586.652146

--- a/test/testref/3dvarfgat.test
+++ b/test/testref/3dvarfgat.test
@@ -8,7 +8,7 @@ Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.7809, nobs = 33, Jo/n = 
 Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 255.973, nobs = 24, Jo/n = 10.6655, err = 0.1
 Test     : CostFunction: Nonlinear J = 5970.14
 Test     : RPCGMinimizer: reduction in residual norm = 0.287517
-Test     : CostFunction::addIncrement: Analysis: 
+Test     : CostFunction::addIncrement: Analysis:
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :   cicen   min=   -0.007116   max=    1.236459   mean=    0.127948
 Test     :   hicen   min=    0.000000   max=    4.032667   mean=    0.471252
@@ -23,12 +23,12 @@ Test     :      lw   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :      us   min=    0.000000   max=    0.000000   mean=    0.000000
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 5426.162198
-Test     : CostJo   : Nonlinear Jo(CoolSkin) = 2979.271419, nobs = 48, Jo/n = 62.068155, err = 0.387632
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 914.835823, nobs = 43, Jo/n = 21.275252, err = 0.385815
+Test     : CostJb   : Nonlinear Jb = 5426.162298
+Test     : CostJo   : Nonlinear Jo(CoolSkin) = 2979.271388, nobs = 48, Jo/n = 62.068154, err = 0.387632
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 914.835838, nobs = 43, Jo/n = 21.275252, err = 0.385815
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.460015, nobs = 17, Jo/n = 0.144707, err = 1.000000
 Test     : CostJo   : Nonlinear Jo(ADT) = 84.280979, nobs = 29, Jo/n = 2.906241, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 38.451350, nobs = 31, Jo/n = 1.240366, err = 0.908940
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 38.451355, nobs = 31, Jo/n = 1.240366, err = 0.908940
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 13.818843, nobs = 33, Jo/n = 0.418753, err = 0.610430
-Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 127.371518, nobs = 24, Jo/n = 5.307147, err = 0.100000
-Test     : CostFunction: Nonlinear J = 9586.652146
+Test     : CostJo   : Nonlinear Jo(SeaIceFraction) = 127.371517, nobs = 24, Jo/n = 5.307147, err = 0.100000
+Test     : CostFunction: Nonlinear J = 9586.652233

--- a/test/testref/3dvarfgat_pseudo.test
+++ b/test/testref/3dvarfgat_pseudo.test
@@ -16,10 +16,10 @@ Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 502.810236
-Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 301.969746, nobs = 43, Jo/n = 7.022552, err = 0.385815
+Test     : CostJb   : Nonlinear Jb = 502.810540
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 301.969745, nobs = 43, Jo/n = 7.022552, err = 0.385815
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.484320, nobs = 17, Jo/n = 0.146136, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 59.156958, nobs = 29, Jo/n = 2.039895, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(ADT) = 59.156914, nobs = 29, Jo/n = 2.039894, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 40.565580, nobs = 31, Jo/n = 1.308567, err = 0.908940
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.780930, nobs = 33, Jo/n = 0.447907, err = 0.610430
-Test     : CostFunction: Nonlinear J = 921.767770
+Test     : CostFunction: Nonlinear J = 921.768029

--- a/test/testref/3dvarfgat_pseudo.test
+++ b/test/testref/3dvarfgat_pseudo.test
@@ -6,7 +6,7 @@ Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 40.5656, nobs = 31, Jo/n
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.7809, nobs = 33, Jo/n = 0.447907, err = 0.61043
 Test     : CostFunction: Nonlinear J = 450.719
 Test     : RPCGMinimizer: reduction in residual norm = 0.874387
-Test     : CostFunction::addIncrement: Analysis: 
+Test     : CostFunction::addIncrement: Analysis:
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.566561
 Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.016435
@@ -16,10 +16,10 @@ Test     :    uocn   min=   -0.858169   max=    0.700095   mean=   -0.000259
 Test     :    vocn   min=   -0.766110   max=    1.437777   mean=    0.002197
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 502.810540
+Test     : CostJb   : Nonlinear Jb = 502.810490
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 301.969745, nobs = 43, Jo/n = 7.022552, err = 0.385815
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 2.484320, nobs = 17, Jo/n = 0.146136, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 59.156914, nobs = 29, Jo/n = 2.039894, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(ADT) = 59.156915, nobs = 29, Jo/n = 2.039894, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 40.565580, nobs = 31, Jo/n = 1.308567, err = 0.908940
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 14.780930, nobs = 33, Jo/n = 0.447907, err = 0.610430
-Test     : CostFunction: Nonlinear J = 921.768029
+Test     : CostFunction: Nonlinear J = 921.767980

--- a/test/testref/3dvarlowres_soca.test
+++ b/test/testref/3dvarlowres_soca.test
@@ -14,10 +14,10 @@ Test     :     ssh   min=   -1.992878   max=    0.885148   mean=   -0.278444
 Test     :    hocn   min=    0.002000   max= 2691.280000   mean=  257.256128
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 75864.647752
+Test     : CostJb   : Nonlinear Jb = 75837.277059
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 246.970336, nobs = 147, Jo/n = 1.680070, err = 0.361776
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.068261, nobs = 51, Jo/n = 0.962123, err = 1.000000
-Test     : CostJo   : Nonlinear Jo(ADT) = 99.081569, nobs = 87, Jo/n = 1.138869, err = 0.100000
-Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 5351.013376, nobs = 206, Jo/n = 25.975793, err = 0.897281
-Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 540.860894, nobs = 218, Jo/n = 2.481013, err = 0.608197
-Test     : CostFunction: Nonlinear J = 82151.642188
+Test     : CostJo   : Nonlinear Jo(ADT) = 99.081552, nobs = 87, Jo/n = 1.138868, err = 0.100000
+Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 5351.013389, nobs = 206, Jo/n = 25.975793, err = 0.897281
+Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 540.860895, nobs = 218, Jo/n = 2.481013, err = 0.608197
+Test     : CostFunction: Nonlinear J = 82124.271492

--- a/test/testref/3dvarlowres_soca.test
+++ b/test/testref/3dvarlowres_soca.test
@@ -6,7 +6,7 @@ Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 348.787, nobs = 206, Jo/
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 355.419, nobs = 218, Jo/n = 1.63036, err = 0.608197
 Test     : CostFunction: Nonlinear J = 1669.38
 Test     : RPCGMinimizer: reduction in residual norm = 0.122973
-Test     : CostFunction::addIncrement: Analysis: 
+Test     : CostFunction::addIncrement: Analysis:
 Test     :   Valid time: 2018-04-15T00:00:00Z
 Test     :    socn   min=   10.721046   max=   40.441679   mean=   34.544836
 Test     :    tocn   min=   -1.888701   max=   31.788334   mean=    6.030155
@@ -14,10 +14,10 @@ Test     :     ssh   min=   -1.992878   max=    0.885148   mean=   -0.278444
 Test     :    hocn   min=    0.002000   max= 2691.280000   mean=  257.256128
 Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
 Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
-Test     : CostJb   : Nonlinear Jb = 75837.277059
+Test     : CostJb   : Nonlinear Jb = 75837.277077
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 246.970336, nobs = 147, Jo/n = 1.680070, err = 0.361776
 Test     : CostJo   : Nonlinear Jo(SeaSurfaceSalinity) = 49.068261, nobs = 51, Jo/n = 0.962123, err = 1.000000
 Test     : CostJo   : Nonlinear Jo(ADT) = 99.081552, nobs = 87, Jo/n = 1.138868, err = 0.100000
 Test     : CostJo   : Nonlinear Jo(InsituTemperature) = 5351.013389, nobs = 206, Jo/n = 25.975793, err = 0.897281
 Test     : CostJo   : Nonlinear Jo(InsituSalinity) = 540.860895, nobs = 218, Jo/n = 2.481013, err = 0.608197
-Test     : CostFunction: Nonlinear J = 82124.271492
+Test     : CostFunction: Nonlinear J = 82124.271510


### PR DESCRIPTION
## Description
Obs variable name change from **obs_absolute_dynamic_topography** to **absolute_dynamic_topography**.

## Dependencies 
- waiting on [ufo PR#1876](https://github.com/JCSDA-internal/ufo/pull/1876)

*post scriptum*
Changing the variable name with nco was segfaulting, apparently a common problem with netcdf4 files. I resorted to dumping the file to ascii, editing out ``obs_`` and using ncgen to convert back to netcdf. This process unfortunately looses a few digit of accuracy and changes slightly the test output. 

