### PR TITLE
fix single ob bug in getvalues, add tests

### DIFF
--- a/src/soca/GetValues/soca_getvalues_mod.F90
+++ b/src/soca/GetValues/soca_getvalues_mod.F90
@@ -225,12 +225,11 @@ subroutine soca_getvalues_fillgeovals(self, geom, fld, t1, t2, locs, geovals)
 
   ! Allocate temporary geoval and 3d field for the current time window
   do ivar = 1, geovals%nvar
+    ! NOTE: cannot simply exit if nlocs == 0 because
+    ! of the MPI communications inside the interp calls
 
     call fld%get(geovals%variables(ivar), fldptr)
     nval = fldptr%nz
-
-    ! Return if no observations
-    if ( geovals%geovals(ivar)%nlocs == 0 ) return
 
     allocate(gom_window(locs%nlocs()))
     allocate(fld3d(isc:iec,jsc:jec,1:nval))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,9 @@ set( soca_test_input
   testinput/3dhybfgat.yml
   testinput/3dvarbump.yml
   testinput/3dvar_godas.yml
+  testinput/3dvar_single_ob.yml
   testinput/3dvar_soca.yml
+  testinput/3dvar_zero_ob.yml
   testinput/3dvarlowres_soca.yml
   testinput/3dvarfgat.yml
   testinput/3dvarfgat_pseudo.yml
@@ -75,7 +77,9 @@ set( soca_test_ref
   testref/3dhybfgat.test
   testref/3dvarbump.test
   testref/3dvar_godas.test
+  testref/3dvar_single_ob.test
   testref/3dvar_soca.test
+  testref/3dvar_zero_ob.test
   testref/3dvarlowres_soca.test
   testref/3dvarfgat.test
   testref/3dvarfgat_pseudo.test
@@ -159,7 +163,9 @@ set( soca_obs
   Data/Obs/gmi_gpm_obs.nc
   Data/Obs/icec.nc
   Data/Obs/icefb.nc
+  Data/Obs/zero_ob.nc
   Data/Obs/prof.nc
+  Data/Obs/single_ob.nc
   Data/Obs/sss.nc
   Data/Obs/sst.nc
   Data/Obs/swh.nc
@@ -707,6 +713,19 @@ soca_add_test( NAME 3dvar_soca
                TOL  4e-9 0
                NOTRAPFPE
                TEST_DEPENDS test_soca_static_socaerror_init )
+
+soca_add_test( NAME 3dvar_single_ob
+               EXE  soca_var.x
+               TOL  4e-9 0
+               NOTRAPFPE
+               TEST_DEPENDS test_soca_static_socaerror_init )
+
+# # Following test does not work yet. IODA crashes
+# soca_add_test( NAME 3dvar_zero_ob
+#                EXE  soca_var.x
+#                TOL  4e-9 0
+#                NOTRAPFPE
+#                TEST_DEPENDS test_soca_static_socaerror_init )
 
 soca_add_test( NAME 3dvarbump
                EXE  soca_var.x

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -163,7 +163,6 @@ set( soca_obs
   Data/Obs/gmi_gpm_obs.nc
   Data/Obs/icec.nc
   Data/Obs/icefb.nc
-  Data/Obs/zero_ob.nc
   Data/Obs/prof.nc
   Data/Obs/single_ob.nc
   Data/Obs/sss.nc
@@ -171,6 +170,7 @@ set( soca_obs
   Data/Obs/swh.nc
   Data/Obs/uocn_surface.nc
   Data/Obs/vocn_surface.nc
+  Data/Obs/zero_ob.nc
 )
 
 # Create Data directory for test input/output and symlink all files

--- a/test/Data/Obs/single_ob.nc
+++ b/test/Data/Obs/single_ob.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e99664388b6e5f909b94b540aca426a3ec3580341c68e53fcf6860ba51a51787
+size 15923

--- a/test/Data/Obs/zero_ob.nc
+++ b/test/Data/Obs/zero_ob.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b6dac0d7d3f402e457f0f37735abdf60076681b7002931f2e5780afa5d2fe16
+size 15974

--- a/test/testinput/3dvar_single_ob.yml
+++ b/test/testinput/3dvar_single_ob.yml
@@ -1,0 +1,82 @@
+# common filters used later on
+_: &land_mask
+  filter: Domain Check
+  where:
+  - variable: {name: sea_area_fraction@GeoVaLs}
+    minvalue: 0.5
+
+cost function:
+  cost type: 3D-Var
+  window begin: 2018-04-14T00:00:00Z
+  window length: P2D
+  analysis variables: &soca_vars [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us, mld, layer_depth]
+  geometry:
+    mom6_input_nml: ./inputnml/input.nml
+    fields metadata: ./fields_metadata.yml
+
+  background:
+    read_from_file: 1
+    basename: ./INPUT/
+    ocn_filename: MOM.res.nc
+    ice_filename: cice.res.nc
+    sfc_filename: sfc.res.nc
+    date: &bkg_date 2018-04-15T00:00:00Z
+    state variables: *soca_vars
+
+  background error:
+    covariance model: SocaError
+    analysis variables: [cicen, hicen, hsnon, socn, tocn, ssh, sw, lhf, shf, lw, us]
+    date: *bkg_date
+    bump:
+      verbosity: main
+      datadir: ./bump
+      strategy: specific_univariate
+      load_nicas_local: true
+    correlation:
+    - name: ocn
+      variables: [hsnon, socn, tocn, ssh, sw, lhf, shf, lw, us]
+    - name: ice
+      variables: [cicen, hicen]
+
+  observations:
+  - obs space:
+      name: SeaSurfaceTemp
+      obsdataout: {obsfile: ./Data/single_ob.out.nc}
+      obsdatain:  {obsfile: ./Data/single_ob.nc}
+      simulated variables: [sea_surface_temperature]
+    obs operator:
+      name: Identity
+    obs error:
+      covariance model: diagonal
+    obs filters:
+    - *land_mask
+
+
+variational:
+  minimizer:
+    algorithm: RPCG
+  iterations:
+  - geometry:
+      mom6_input_nml: ./inputnml/input.nml
+      fields metadata: ./fields_metadata.yml
+    ninner: 5
+    gradient norm reduction: 1e-15
+    test: on
+    diagnostics:
+      departures: ombg
+    online diagnostics:
+      write increment: true
+      increment:
+        datadir: Data
+        date: *bkg_date
+        exp: 3dvargodas.iter1
+        type: incr
+
+output:
+  datadir: Data
+  exp: 3dvargodas
+  type: an
+
+final:
+  diagnostics:
+    departures: oman

--- a/test/testinput/3dvar_zero_ob.yml
+++ b/test/testinput/3dvar_zero_ob.yml
@@ -1,0 +1,82 @@
+# common filters used later on
+_: &land_mask
+  filter: Domain Check
+  where:
+  - variable: {name: sea_area_fraction@GeoVaLs}
+    minvalue: 0.5
+
+cost function:
+  cost type: 3D-Var
+  window begin: 2018-04-14T00:00:00Z
+  window length: P2D
+  analysis variables: &soca_vars [cicen, hicen, hsnon, socn, tocn, ssh, hocn, sw, lhf, shf, lw, us, mld, layer_depth]
+  geometry:
+    mom6_input_nml: ./inputnml/input.nml
+    fields metadata: ./fields_metadata.yml
+
+  background:
+    read_from_file: 1
+    basename: ./INPUT/
+    ocn_filename: MOM.res.nc
+    ice_filename: cice.res.nc
+    sfc_filename: sfc.res.nc
+    date: &bkg_date 2018-04-15T00:00:00Z
+    state variables: *soca_vars
+
+  background error:
+    covariance model: SocaError
+    analysis variables: [cicen, hicen, hsnon, socn, tocn, ssh, sw, lhf, shf, lw, us]
+    date: *bkg_date
+    bump:
+      verbosity: main
+      datadir: ./bump
+      strategy: specific_univariate
+      load_nicas_local: true
+    correlation:
+    - name: ocn
+      variables: [hsnon, socn, tocn, ssh, sw, lhf, shf, lw, us]
+    - name: ice
+      variables: [cicen, hicen]
+
+  observations:
+  - obs space:
+      name: SeaSurfaceTemp
+      obsdataout: {obsfile: ./Data/zero_ob.out.nc}
+      obsdatain:  {obsfile: ./Data/zero_ob.nc}
+      simulated variables: [sea_surface_temperature]
+    obs operator:
+      name: Identity
+    obs error:
+      covariance model: diagonal
+    obs filters:
+    - *land_mask
+
+
+variational:
+  minimizer:
+    algorithm: RPCG
+  iterations:
+  - geometry:
+      mom6_input_nml: ./inputnml/input.nml
+      fields metadata: ./fields_metadata.yml
+    ninner: 5
+    gradient norm reduction: 1e-15
+    test: on
+    diagnostics:
+      departures: ombg
+    online diagnostics:
+      write increment: true
+      increment:
+        datadir: Data
+        date: *bkg_date
+        exp: 3dvargodas.iter1
+        type: incr
+
+output:
+  datadir: Data
+  exp: 3dvargodas
+  type: an
+
+final:
+  diagnostics:
+    departures: oman

--- a/test/testref/3dvar_single_ob.test
+++ b/test/testref/3dvar_single_ob.test
@@ -1,0 +1,23 @@
+Test     : CostJb   : Nonlinear Jb = 0
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 0.00421408, nobs = 1, Jo/n = 0.00421408, err = 0.29
+Test     : CostFunction: Nonlinear J = 0.00421408
+Test     : RPCGMinimizer: reduction in residual norm = 1.75352e-16
+Test     : CostFunction::addIncrement: Analysis: 
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :   cicen   min=    0.000000   max=    1.000000   mean=    0.117513
+Test     :   hicen   min=    0.000000   max=    4.032667   mean=    0.471252
+Test     :   hsnon   min=    0.000000   max=    1.271283   mean=    0.088687
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017603
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     :      sw   min= -225.097763   max=   -0.000000   mean=  -71.739321
+Test     :     lhf   min=  -38.137398   max=  256.597656   mean=   42.010040
+Test     :     shf   min=  -58.949295   max=  201.374298   mean=    6.075334
+Test     :      lw   min=    0.000000   max=   88.036087   mean=   31.395529
+Test     :      us   min=    0.004396   max=    0.019658   mean=    0.008644
+Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
+Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
+Test     : CostJb   : Nonlinear Jb = 0.009696
+Test     : CostJo   : Nonlinear Jo(SeaSurfaceTemp) = 0.000026, nobs = 1, Jo/n = 0.000026, err = 0.290000
+Test     : CostFunction: Nonlinear J = 0.009722


### PR DESCRIPTION
## Description
Fixes a bug where GetValues hangs if the number of observations are less than the number of PEs used. This was happening because the initialization of the interpolation requires a global MPI communication, but some of the PEs were exiting early if they had no obs in the obsspace.

I also added two tests, a single ob 3dvar test, and a zero ob 3dvar test. The zero ob test is disable because it causes IODA to crash.... another issue for another day.

### Issue(s) addressed

closes #702 
