### PR TITLE
Wrap call to test_wrapper.sh in bash to evade macOS System Integration Protection

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -348,8 +348,9 @@ function(soca_add_test)
     # run the comapre.py script afterwards
     ecbuild_add_test( TARGET  test_soca_${ARG_NAME}
                       TYPE    SCRIPT
-                      COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test_wrapper.sh"
-                      ARGS    "${CMAKE_BINARY_DIR}/bin/${ARG_EXE}"
+                      COMMAND bash
+                      ARGS    "${CMAKE_CURRENT_SOURCE_DIR}/test_wrapper.sh"
+                              "${CMAKE_BINARY_DIR}/bin/${ARG_EXE}"
                               ${CONFIG_FILE}
                       ENVIRONMENT
                               ${TRAPFPE_ENV}


### PR DESCRIPTION
## Description

This PR wraps the call to `test_wrapper.sh` in a call to `bash` to evade the macOS System Integration Protection (SIP). See https://github.com/NOAA-EMC/spack-stack/issues/78#issuecomment-1072775946 for a detailed description of the problem. 

### Issue(s) addressed

Fixes https://github.com/JCSDA-internal/soca/issues/726.

## Testing

Tested on macOS Monterey.
