### PR TITLE
Addition of the ConvertIncrement  application

### DIFF
--- a/src/mains/CMakeLists.txt
+++ b/src/mains/CMakeLists.txt
@@ -80,6 +80,12 @@ ecbuild_add_executable( TARGET  soca_letkf.x
                         SOURCES LETKF.cc
                         LIBS    soca
                       )
+
+ecbuild_add_executable( TARGET  soca_convertincrement.x
+                        SOURCES ConvertIncrement.cc
+                        LIBS    soca
+                        )
+
 ecbuild_add_executable( TARGET  soca_convertstate.x
                         SOURCES ConvertState.cc
                         LIBS    soca

--- a/src/mains/ConvertIncrement.cc
+++ b/src/mains/ConvertIncrement.cc
@@ -1,0 +1,17 @@
+/*
+ * (C) Copyright 2017-2022 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+
+#include "oops/runs/ConvertIncrement.h"
+#include "oops/runs/Run.h"
+#include "soca/Traits.h"
+
+int main(int argc,  char ** argv) {
+  oops::Run run(argc, argv);
+  oops::ConvertIncrement<soca::Traits> convertincrement;
+  return run.execute(convertincrement);
+}

--- a/src/soca/LinearVariableChange/Balance/soca_balance_mod.F90
+++ b/src/soca/LinearVariableChange/Balance/soca_balance_mod.F90
@@ -101,7 +101,7 @@ subroutine soca_balance_setup(self, f_conf, traj, geom)
   ! Setup mask for Jacobians related to the dynamic height balance
   allocate(jac_mask(isd:ied,jsd:jed))
   jac_mask = 1.0_kind_real
-  nlayers = 0.0_kind_real
+  nlayers = 0
   if ( f_conf%has("jac_mask") ) then
     jac_mask = 0.0_kind_real
     call f_conf%get_or_die("jac_mask.filename", filename)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ set( soca_test_input
   testinput/addincrement.yml
   testinput/balance_mask.yml
   testinput/checkpointmodel.yml
+  testinput/convertincrement.yml
   testinput/convertstate.yml
   testinput/convertstate_changevar.yml
   testinput/diffstates.yml
@@ -87,6 +88,7 @@ set( soca_test_ref
   testref/addincrement.test
   testref/balance_mask.test
   testref/checkpointmodel.test
+  testref/convertincrement.test
   testref/convertstate.test
   testref/convertstate_changevar.test
   testref/diffstates.test
@@ -749,6 +751,13 @@ soca_add_test( NAME 3dvar_godas
 soca_add_test( NAME addincrement
                EXE  soca_addincrement.x
                NOCOMPARE
+               TEST_DEPENDS 3dvar_godas )
+
+# Remapping MOM6 (horiz+vertical intterpolation)
+soca_add_test( NAME convertincrement
+               EXE  soca_convertincrement.x
+               TOL  2e-5 0
+               NOTRAPFPE
                TEST_DEPENDS 3dvar_godas )
 
 soca_add_test( NAME 3dvarlowres_soca

--- a/test/testinput/convertincrement.yml
+++ b/test/testinput/convertincrement.yml
@@ -1,0 +1,40 @@
+input geometry:
+  geom_grid_file: soca_gridspec.nc
+  mom6_input_nml: ./inputnml/input.nml
+  fields metadata: ./fields_metadata.yml
+
+output geometry:
+  geom_grid_file: soca_gridspec.nc
+  mom6_input_nml: ./inputnml/input.nml
+  fields metadata: ./fields_metadata.yml
+
+linear variable change:
+  input variables: [tocn, socn, ssh, hocn]
+  output variables: [tocn, socn, ssh, hocn]
+  linear variable changes:
+  - linear variable change name: BalanceSOCA
+    dsdtmax: 0.0
+    dsdzmin: 0.0
+    dtdzmin: 0.0
+    nlayers: 2
+
+increments:
+- date: 2018-04-15T00:00:00Z
+  input variables: [tocn, socn, ssh, hocn]
+  input:
+     read_from_file: 1
+     basename: ./Data/
+     ocn_filename: ocn.3dvargodas.iter1.incr.2018-04-15T00:00:00Z.nc
+     date: 2018-04-15T00:00:00Z
+     state variables: [ssh, tocn, socn, hocn]
+  trajectory:
+     read_from_file: 1
+     basename: ./INPUT/
+     ocn_filename: MOM.res.nc
+     date: 2018-04-15T00:00:00Z
+     state variables: [ssh, tocn, socn, hocn, layer_depth, mld]
+  output:
+     datadir: Data
+     exp: convert_incr
+     type: incr
+     date: 2018-04-15T00:00:00Z

--- a/test/testref/convertincrement.test
+++ b/test/testref/convertincrement.test
@@ -1,0 +1,20 @@
+Test     : Input increment: 
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    tocn   min=   -0.051001   max=    0.332471   mean=    0.002194
+Test     :    socn   min=   -0.001313   max=    0.002829   mean=    0.000008
+Test     :     ssh   min=   -0.000272   max=    0.001732   mean=    0.000070
+Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000
+Test     : Trajectory state: 
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :     ssh   min=   -1.924485   max=    0.927283   mean=   -0.276790
+Test     :    tocn   min=   -1.888390   max=   31.700465   mean=    6.017565
+Test     :    socn   min=   10.721046   max=   40.441659   mean=   34.544390
+Test     :    hocn   min=    0.001000   max= 1345.640000   mean=  128.628064
+Test     : layer_depth   min=    2.285472   max= 5658.305747   mean= 1200.522954
+Test     :     mld   min=    2.285472   max= 4593.153342   mean=  192.410907
+Test     : Output increment: 
+Test     :   Valid time: 2018-04-15T00:00:00Z
+Test     :    tocn   min=   -0.051001   max=    0.332471   mean=    0.002194
+Test     :    socn   min=   -0.001313   max=    0.002829   mean=        -nan
+Test     :     ssh   min=   -0.000559   max=    0.003465   mean=    0.000140
+Test     :    hocn   min=    0.000000   max=    0.000000   mean=    0.000000


### PR DESCRIPTION
## Description
See issue #744 for more details. This feature branch adds the `ConvertIncrement` `oops` application and implement a test that applies the dynamic height balance to the T, S increment field from the 3dvar_godas test.
The example isn't what we would end up doing exactly, since the ssh field in the input increment would need to be zero-ed out. The output test for ssh is the initial ssh field + the output of the dynamic height calculation. Not what we want but a good enough demonstration of the working plumbing.
 

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #744



## Testing
Unit test and visual inspection of the output increment.

## Dependencies

- [oops PR #1724](https://github.com/JCSDA-internal/oops/pull/1724)

