### PR TITLE
re-enable getvalues test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,7 @@ set( soca_test_input
   testinput/geometry.yml
   testinput/geometry_iterator_2d.yml
   testinput/geometry_iterator_3d.yml
+  testinput/getvalues.yml
   testinput/gridgen.yml
   testinput/gridgen_small.yml
   testinput/hofx_3d.yml
@@ -511,6 +512,9 @@ soca_add_test( NAME increment
                SRC  TestIncrement.cc
                TEST_DEPENDS test_soca_gridgen )
 
+soca_add_test( NAME getvalues
+               SRC  TestGetValues.cc
+               TEST_DEPENDS test_soca_gridgen )
 
 soca_add_test( NAME errorcovariance
                SRC  TestErrorCovariance.cc

--- a/test/testinput/getvalues.yml
+++ b/test/testinput/getvalues.yml
@@ -2,39 +2,36 @@ geometry:
   mom6_input_nml: ./inputnml/input.nml
   fields metadata: ./fields_metadata.yml
 
-state variables: &geovals [sea_water_potential_temperature,
-                           sea_water_salinity,
-                           sea_water_cell_thickness,
-                           sea_surface_height_above_geoid,
-                           sea_surface_temperature,
-                           sea_ice_category_area_fraction,
-                           sea_ice_category_thickness,
-                           sea_surface_wave_significant_height,
-                           net_downwelling_shortwave_radiation,
-                           upward_latent_heat_flux_in_air,
-                           upward_sensible_heat_flux_in_air,
-                           net_downwelling_longwave_radiation,
-                           friction_velocity_over_water,
-                           surface_eastward_sea_water_velocity,
-                           eastward_sea_water_velocity,
-                           surface_northward_sea_water_velocity,
-                           northward_sea_water_velocity]
+state:
+  analytic init:
+    method: soca_ana_init
+  date: &date 2018-04-15T03:00:00Z
+  state variables: [tocn, socn, hocn, ssh, cicen, hicen, swh, sw, lw, lhf, shf, us, uocn, vocn ]
 
-getvalues test:
-  interpolation tolerance: 2.0  # This seems horribly large!
-
-  state generate:
-    analytic init:
-      method: soca_ana_init
-    date: &date 2018-04-15T00:00:00Z
-    state variables: [tocn, socn, hocn, ssh, cicen, hicen, swh, sw, lw, lhf, shf, us, uocn, vocn ]
+variables: &vars [sea_water_potential_temperature,
+                  sea_water_salinity,
+                  sea_water_cell_thickness,
+                  sea_surface_height_above_geoid,
+                  sea_surface_temperature,
+                  sea_ice_category_area_fraction,
+                  sea_ice_category_thickness,
+                  sea_surface_wave_significant_height,
+                  net_downwelling_shortwave_radiation,
+                  upward_latent_heat_flux_in_air,
+                  upward_sensible_heat_flux_in_air,
+                  net_downwelling_longwave_radiation,
+                  friction_velocity_over_water,
+                  surface_eastward_sea_water_velocity,
+                  eastward_sea_water_velocity,
+                  surface_northward_sea_water_velocity,
+                  northward_sea_water_velocity]
 
 locations:
   window begin: 2018-04-15T00:00:00Z
-  window end: 2018-04-15T03:00:00Z
+  window end: 2018-04-15T06:00:00Z
   obs space:
     name: Random Locations
-    simulated variables: *geovals
+    simulated variables: *vars
     generate:
       random:
         random seed: 0
@@ -44,3 +41,5 @@ locations:
         lon1: -192.5
         lon2: -57
       obs errors: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+
+tolerance interpolation: 1.5  # still really huge... should probably figure out why sometime.


### PR DESCRIPTION
## Description

re-enable the getvalues unit test which was made possible after https://github.com/JCSDA-internal/oops/pull/1731 was merged

the tolerances are slightly smaller now, 1.5 !   (yes, that's huge, I should probably figure out why at some point)