### PR TITLE
Fix major memory issues

### DIFF
--- a/src/soca/Geometry/Geometry.cc
+++ b/src/soca/Geometry/Geometry.cc
@@ -45,7 +45,7 @@ namespace soca {
     atlasFieldSet_.reset(new atlas::FieldSet());
     soca_geo_fill_atlas_fieldset_f90(keyGeom_, atlasFieldSet_->get());
 
-    //create kdtrees
+    // create kdtrees
     int kdidx = 0;
     for (auto grid : grids) {
       std::vector<double> lats;
@@ -162,7 +162,7 @@ namespace soca {
     const char grid, const bool masked) const {
 
     // determine which kdtree to use
-    // TODO make sure not -1
+    // TODO(travis) make sure not -1
     int kdidx = -1;
     for (int j=0; j < grids.size(); j++) {
       if (grids[j] == grid) kdidx = j*2;

--- a/src/soca/Geometry/Geometry.cc
+++ b/src/soca/Geometry/Geometry.cc
@@ -16,6 +16,9 @@
 
 // -----------------------------------------------------------------------------
 namespace soca {
+
+  const std::vector<char> grids{ 'h', 'u', 'v'};
+
   // -----------------------------------------------------------------------------
   Geometry::Geometry(const eckit::Configuration & conf,
                      const eckit::mpi::Comm & comm)
@@ -41,6 +44,27 @@ namespace soca {
     // Fill ATLAS fieldset
     atlasFieldSet_.reset(new atlas::FieldSet());
     soca_geo_fill_atlas_fieldset_f90(keyGeom_, atlasFieldSet_->get());
+
+    //create kdtrees
+    int kdidx = 0;
+    for (auto grid : grids) {
+      std::vector<double> lats;
+      std::vector<double> lons;
+      size_t npoints;
+      std::vector<size_t> indx;
+
+      this->latlon(lats, lons, true, grid, false);
+      npoints = lats.size();
+      indx.resize(npoints);
+      for (size_t jj = 0; jj < npoints; ++jj) indx[jj] = jj;
+      localTree_[kdidx++].build(lons, lats, indx);
+
+      this->latlon(lats, lons, true, grid, true);
+      npoints = lats.size();
+      indx.resize(npoints);
+      for (size_t jj = 0; jj < npoints; ++jj) indx[jj] = jj;
+      localTree_[kdidx++].build(lons, lats, indx);
+    }
   }
   // -----------------------------------------------------------------------------
   Geometry::Geometry(const Geometry & other)
@@ -132,6 +156,26 @@ namespace soca {
     soca_geo_gridlatlon_f90(keyGeom_, grid, masked, halo, gridSize,
       lats.data(), lons.data());
   }
+  // -----------------------------------------------------------------------------
+  atlas::util::KDTree<size_t>::ValueList Geometry::closestPoints(
+    const double lat, const double lon, const int npoints,
+    const char grid, const bool masked) const {
+
+    // determine which kdtree to use
+    // TODO make sure not -1
+    int kdidx = -1;
+    for (int j=0; j < grids.size(); j++) {
+      if (grids[j] == grid) kdidx = j*2;
+    }
+    if (masked) kdidx += 1;
+
+    atlas::PointLonLat obsloc(lon, lat);
+    obsloc.normalise();
+    atlas::util::KDTree<size_t>::ValueList neighbours =
+      localTree_[kdidx].closestPoints(obsloc, npoints);
+
+    return neighbours;
+    }
   // -----------------------------------------------------------------------------
   // Get the properties of the grid for a given variable (masked and u/v/h grid)
   void Geometry::getVarGrid(const std::string &var, char & grid, bool & masked) const {

--- a/src/soca/Geometry/Geometry.h
+++ b/src/soca/Geometry/Geometry.h
@@ -14,6 +14,8 @@
 #include <string>
 #include <vector>
 
+#include "atlas/util/KDTree.h"
+
 #include "eckit/config/Configuration.h"
 #include "eckit/config/LocalConfiguration.h"
 #include "eckit/mpi/Comm.h"
@@ -70,6 +72,9 @@ namespace soca {
       void latlon(std::vector<double> &, std::vector<double> &, const bool) const;
       void latlon(std::vector<double> &, std::vector<double> &, const bool,
                   const char, const bool) const;
+      atlas::util::KDTree<size_t>::ValueList closestPoints(
+        const double, const double, const int,
+        const char, const bool) const;
 
       void getVarGrid(const std::string &, char &, bool &) const;
 
@@ -81,6 +86,8 @@ namespace soca {
       FmsInput fmsinput_;
       std::unique_ptr<atlas::functionspace::PointCloud> atlasFunctionSpace_;
       std::unique_ptr<atlas::FieldSet> atlasFieldSet_;
+      atlas::util::IndexKDTree localTree_[6];
+
   };
   // -----------------------------------------------------------------------------
 

--- a/src/soca/Geometry/Geometry.h
+++ b/src/soca/Geometry/Geometry.h
@@ -87,7 +87,6 @@ namespace soca {
       std::unique_ptr<atlas::functionspace::PointCloud> atlasFunctionSpace_;
       std::unique_ptr<atlas::FieldSet> atlasFieldSet_;
       atlas::util::IndexKDTree localTree_[6];
-
   };
   // -----------------------------------------------------------------------------
 

--- a/src/soca/Increment/Increment.cc
+++ b/src/soca/Increment/Increment.cc
@@ -39,25 +39,25 @@ namespace soca {
   // -----------------------------------------------------------------------------
   Increment::Increment(const Geometry & geom, const oops::Variables & vars,
                        const util::DateTime & vt)
-    : time_(vt), vars_(vars), geom_(new Geometry(geom))
+    : time_(vt), vars_(vars), geom_(geom)
   {
-    soca_increment_create_f90(keyFlds_, geom_->toFortran(), vars_);
+    soca_increment_create_f90(keyFlds_, geom_.toFortran(), vars_);
     soca_increment_zero_f90(toFortran());
     Log::trace() << "Increment constructed." << std::endl;
   }
   // -----------------------------------------------------------------------------
   Increment::Increment(const Geometry & geom, const Increment & other)
-    : time_(other.time_), vars_(other.vars_), geom_(new Geometry(geom))
+    : time_(other.time_), vars_(other.vars_), geom_(geom)
   {
-    soca_increment_create_f90(keyFlds_, geom_->toFortran(), vars_);
+    soca_increment_create_f90(keyFlds_, geom_.toFortran(), vars_);
     soca_increment_change_resol_f90(toFortran(), other.keyFlds_);
     Log::trace() << "Increment constructed from other." << std::endl;
   }
   // -----------------------------------------------------------------------------
   Increment::Increment(const Increment & other, const bool copy)
-    : time_(other.time_), vars_(other.vars_), geom_(new Geometry(*other.geom_))
+    : time_(other.time_), vars_(other.vars_), geom_(other.geom_)
   {
-    soca_increment_create_f90(keyFlds_, geom_->toFortran(), vars_);
+    soca_increment_create_f90(keyFlds_, geom_.toFortran(), vars_);
     if (copy) {
       soca_increment_copy_f90(toFortran(), other.toFortran());
     } else {
@@ -67,9 +67,9 @@ namespace soca {
   }
   // -----------------------------------------------------------------------------
   Increment::Increment(const Increment & other)
-    : time_(other.time_), vars_(other.vars_), geom_(new Geometry(*other.geom_))
+    : time_(other.time_), vars_(other.vars_), geom_(other.geom_)
   {
-    soca_increment_create_f90(keyFlds_, geom_->toFortran(), vars_);
+    soca_increment_create_f90(keyFlds_, geom_.toFortran(), vars_);
     soca_increment_copy_f90(toFortran(), other.toFortran());
     Log::trace() << "Increment copy-created." << std::endl;
   }
@@ -84,8 +84,8 @@ namespace soca {
   void Increment::diff(const State & x1, const State & x2) {
     ASSERT(this->validTime() == x1.validTime());
     ASSERT(this->validTime() == x2.validTime());
-    State x1_at_geomres(*geom_, x1);
-    State x2_at_geomres(*geom_, x2);
+    State x1_at_geomres(geom_, x1);
+    State x2_at_geomres(geom_, x2);
     soca_increment_diff_incr_f90(toFortran(), x1_at_geomres.toFortran(),
                                               x2_at_geomres.toFortran());
   }
@@ -165,7 +165,7 @@ namespace soca {
     eckit::geometry::Point3 p3 = *iter;
     std::vector<int> varlens(vars_.size());
 
-    int iteratorDimension = geom_->IteratorDimension();
+    int iteratorDimension = geom_.IteratorDimension();
     switch (iteratorDimension) {
     case (3) :
       if (p3[2] == 0.0) {
@@ -231,17 +231,17 @@ namespace soca {
   /// ATLAS
   // -----------------------------------------------------------------------------
   void Increment::setAtlas(atlas::FieldSet * afieldset) const {
-    soca_increment_set_atlas_f90(toFortran(), geom_->toFortran(), vars_,
+    soca_increment_set_atlas_f90(toFortran(), geom_.toFortran(), vars_,
                                  afieldset->get());
   }
   // -----------------------------------------------------------------------------
   void Increment::toAtlas(atlas::FieldSet * afieldset) const {
-    soca_increment_to_atlas_f90(toFortran(), geom_->toFortran(), vars_,
+    soca_increment_to_atlas_f90(toFortran(), geom_.toFortran(), vars_,
                                 afieldset->get());
   }
   // -----------------------------------------------------------------------------
   void Increment::fromAtlas(atlas::FieldSet * afieldset) {
-    soca_increment_from_atlas_f90(toFortran(), geom_->toFortran(), vars_,
+    soca_increment_from_atlas_f90(toFortran(), geom_.toFortran(), vars_,
                                   afieldset->get());
   }
   // -----------------------------------------------------------------------------
@@ -322,7 +322,7 @@ namespace soca {
   size_t Increment::serialSize() const {
     // Field
     size_t nn;
-    soca_increment_serial_size_f90(toFortran(), geom_->toFortran(), nn);
+    soca_increment_serial_size_f90(toFortran(), geom_.toFortran(), nn);
 
     // Magic factor
     nn += 1;
@@ -336,10 +336,10 @@ namespace soca {
   void Increment::serialize(std::vector<double> & vect) const {
     // Serialize the field
     size_t nn;
-    soca_increment_serial_size_f90(toFortran(), geom_->toFortran(), nn);
+    soca_increment_serial_size_f90(toFortran(), geom_.toFortran(), nn);
     std::vector<double> vect_field(nn, 0);
     vect.reserve(vect.size() + nn + 1 + time_.serialSize());
-    soca_increment_serialize_f90(toFortran(), geom_->toFortran(), nn,
+    soca_increment_serialize_f90(toFortran(), geom_.toFortran(), nn,
                                  vect_field.data());
     vect.insert(vect.end(), vect_field.begin(), vect_field.end());
 
@@ -354,7 +354,7 @@ namespace soca {
                               size_t & index) {
     // Deserialize the field
 
-    soca_increment_deserialize_f90(toFortran(), geom_->toFortran(), vect.size(),
+    soca_increment_deserialize_f90(toFortran(), geom_.toFortran(), vect.size(),
                                    vect.data(), index);
 
     // Use magic value to validate deserialization
@@ -363,11 +363,6 @@ namespace soca {
 
     // Deserialize the date and time
     time_.deserialize(vect, index);
-  }
-  // -----------------------------------------------------------------------------
-
-  std::shared_ptr<const Geometry> Increment::geometry() const {
-    return geom_;
   }
 
   // -----------------------------------------------------------------------------

--- a/src/soca/Increment/Increment.h
+++ b/src/soca/Increment/Increment.h
@@ -116,7 +116,7 @@ namespace soca {
       void accumul(const double &, const State &);
       int & toFortran() {return keyFlds_;}
       const int & toFortran() const {return keyFlds_;}
-      std::shared_ptr<const Geometry> geometry() const;
+      const Geometry & geometry() const {return geom_;}
 
       /// Private variable accessor functions
       const oops::Variables & variables() const {return vars_;}
@@ -135,7 +135,7 @@ namespace soca {
       F90flds keyFlds_;
       oops::Variables vars_;
       util::DateTime time_;
-      std::shared_ptr<const Geometry> geom_;
+      const Geometry & geom_;
   };
   // -----------------------------------------------------------------------------
 

--- a/src/soca/Interpolator/LocalUnstructuredInterpolator.cc
+++ b/src/soca/Interpolator/LocalUnstructuredInterpolator.cc
@@ -28,7 +28,7 @@ LocalUnstructuredInterpolator::
   LocalUnstructuredInterpolator(const eckit::Configuration & config, const Geometry & geom,
                                 const std::vector<double> & lats_out,
                                 const std::vector<double> & lons_out)
-  : config_(config), lats_out_(lats_out), lons_out_(lons_out), geom_(new Geometry(geom)) {
+  : config_(config), lats_out_(lats_out), lons_out_(lons_out), geom_(geom) {
   oops::Log::trace() << "LocalUnstructuredInterpolator::LocalUnstructuredInterpolator start"
                      << std::endl;
 
@@ -123,7 +123,7 @@ LocalUnstructuredInterpolator::getInterpolator(const std::string &var) const {
   // determine which interpolator to use
   char grid;
   bool masked;
-  geom_->getVarGrid(var, grid, masked);
+  geom_.getVarGrid(var, grid, masked);
   int interp_idx = -1;
   for (int j=0; j < grids.size(); j++) {
     if (grids[j] == grid) interp_idx = j*2;
@@ -134,7 +134,7 @@ LocalUnstructuredInterpolator::getInterpolator(const std::string &var) const {
   if (interp_[interp_idx].get() == nullptr) {
     std::vector<double> lats_in;
     std::vector<double> lons_in;
-    geom_->latlon(lats_in, lons_in, true, grid, masked);
+    geom_.latlon(lats_in, lons_in, true, grid, masked);
     interp_[interp_idx] = std::make_shared<UnstructuredInterpolator>(
                                           config_, lats_in, lons_in, lats_out_, lons_out_);
   }

--- a/src/soca/Interpolator/LocalUnstructuredInterpolator.cc
+++ b/src/soca/Interpolator/LocalUnstructuredInterpolator.cc
@@ -132,11 +132,11 @@ LocalUnstructuredInterpolator::getInterpolator(const std::string &var) const {
 
   // does the interpolator need to be created? (if it hasn't already yet)
   if (interp_[interp_idx].get() == nullptr) {
-    std::vector<double> lats_in;
-    std::vector<double> lons_in;
-    geom_.latlon(lats_in, lons_in, true, grid, masked);
+    // std::vector<double> lats_in;
+    // std::vector<double> lons_in;
+    // geom_.latlon(lats_in, lons_in, true, grid, masked);
     interp_[interp_idx] = std::make_shared<UnstructuredInterpolator>(
-                                          config_, lats_in, lons_in, lats_out_, lons_out_);
+      config_, geom_, grid, masked, lats_out_, lons_out_);
   }
 
   // done, return the interpolator

--- a/src/soca/Interpolator/LocalUnstructuredInterpolator.h
+++ b/src/soca/Interpolator/LocalUnstructuredInterpolator.h
@@ -55,7 +55,7 @@ class LocalUnstructuredInterpolator : public util::Printable {
 
   mutable std::shared_ptr<UnstructuredInterpolator> interp_[6];
 
-  const std::shared_ptr<const Geometry> geom_;
+  const Geometry & geom_;
   const eckit::LocalConfiguration config_;
   const std::vector<double> lats_out_;
   const std::vector<double> lons_out_;

--- a/src/soca/LinearVariableChange/HorizFilt/HorizFilt.cc
+++ b/src/soca/LinearVariableChange/HorizFilt/HorizFilt.cc
@@ -33,7 +33,7 @@ namespace soca {
                  const State & traj,
                  const Geometry & geom,
                  const eckit::Configuration & conf):
-    geom_(new Geometry(geom)),
+    geom_(geom),
     vars_(conf, "filter variables") {
     const eckit::Configuration * configc = &conf;
 
@@ -43,7 +43,7 @@ namespace soca {
     // Compute averaging weights
     soca_horizfilt_setup_f90(keyFtnConfig_,
                              &configc,
-                             geom_->toFortran(),
+                             geom_.toFortran(),
                              traj_at_geomres.toFortran(),
                              vars_);
 
@@ -63,7 +63,7 @@ namespace soca {
       soca_horizfilt_mult_f90(keyFtnConfig_,
                               dx_tmp.toFortran(),
                               dxout.toFortran(),
-                              geom_->toFortran());
+                              geom_.toFortran());
     }
   }
   // -----------------------------------------------------------------------------
@@ -80,7 +80,7 @@ namespace soca {
       soca_horizfilt_multad_f90(keyFtnConfig_,
                                 dx_tmp.toFortran(),
                                 dxout.toFortran(),
-                                geom_->toFortran());
+                                geom_.toFortran());
     }
   }
   // -----------------------------------------------------------------------------

--- a/src/soca/LinearVariableChange/HorizFilt/HorizFilt.h
+++ b/src/soca/LinearVariableChange/HorizFilt/HorizFilt.h
@@ -50,7 +50,7 @@ class HorizFilt: public LinearVariableChangeBase {
  private:
   void print(std::ostream &) const override;
   int keyFtnConfig_;
-  std::unique_ptr<const Geometry> geom_;
+  const Geometry & geom_;
   oops::Variables vars_;
   unsigned int niter_;
 };

--- a/src/soca/LinearVariableChange/LinearModel2GeoVaLs/LinearModel2GeoVaLs.cc
+++ b/src/soca/LinearVariableChange/LinearModel2GeoVaLs/LinearModel2GeoVaLs.cc
@@ -29,7 +29,7 @@ static LinearVariableChangeMaker<LinearModel2GeoVaLs>
 LinearModel2GeoVaLs::LinearModel2GeoVaLs(const State & bg, const State &fg,
                                         const Geometry &geom,
                                         const eckit::Configuration &conf)
-  : geom_(new Geometry(geom)) {
+  : geom_(geom) {
 }
 
 // -----------------------------------------------------------------------------
@@ -41,7 +41,7 @@ LinearModel2GeoVaLs::~LinearModel2GeoVaLs() {
 
 void LinearModel2GeoVaLs::multiply(const Increment &dxin,
                                          Increment &dxout) const {
-  soca_model2geovals_linear_changevar_f90(geom_->toFortran(),
+  soca_model2geovals_linear_changevar_f90(geom_.toFortran(),
                                           dxin.toFortran(), dxout.toFortran());
 }
 
@@ -56,7 +56,7 @@ void LinearModel2GeoVaLs::multiplyInverse(const Increment &dxin,
 
 void LinearModel2GeoVaLs::multiplyAD(const Increment &dxin,
                                            Increment &dxout) const {
-  soca_model2geovals_linear_changevarAD_f90(geom_->toFortran(),
+  soca_model2geovals_linear_changevarAD_f90(geom_.toFortran(),
                                             dxin.toFortran(),
                                             dxout.toFortran());
 }

--- a/src/soca/LinearVariableChange/LinearModel2GeoVaLs/LinearModel2GeoVaLs.h
+++ b/src/soca/LinearVariableChange/LinearModel2GeoVaLs/LinearModel2GeoVaLs.h
@@ -38,7 +38,7 @@ class LinearModel2GeoVaLs: public LinearVariableChangeBase {
   void multiplyInverseAD(const Increment &, Increment &) const;
 
  private:
-  std::unique_ptr<const Geometry> geom_;
+  const Geometry & geom_;
   void print(std::ostream &) const;
 };
 

--- a/src/soca/LinearVariableChange/LinearVariableChange.cc
+++ b/src/soca/LinearVariableChange/LinearVariableChange.cc
@@ -83,7 +83,7 @@ void LinearVariableChange::multiply(Increment & dx,
   // }
 
   // Create output state
-  Increment dxout(*dx.geometry(), vars, dx.time());
+  Increment dxout(dx.geometry(), vars, dx.time());
 
   // Call variable change(s)
   for (icst_ it = linVarChas_.begin(); it != linVarChas_.end(); ++it) {
@@ -116,7 +116,7 @@ void LinearVariableChange::multiplyInverse(Increment & dx,
                << vars << std::endl;
 
   // Create output state
-  Increment dxout(*dx.geometry(), vars, dx.time());
+  Increment dxout(dx.geometry(), vars, dx.time());
 
   // Call variable change(s)
   for (ircst_ it = linVarChas_.rbegin(); it != linVarChas_.rend(); ++it) {
@@ -140,7 +140,7 @@ void LinearVariableChange::multiplyAD(Increment & dx,
                << dx.variables() << std::endl;
   Log::debug() << "LinearVariableChange::multiplyAD output vars: "
                << vars << std::endl;
-  Increment dxout(*dx.geometry(), vars, dx.time());
+  Increment dxout(dx.geometry(), vars, dx.time());
 
   // Call variable change(s)
   for (ircst_ it = linVarChas_.rbegin(); it != linVarChas_.rend(); ++it) {
@@ -161,7 +161,7 @@ void LinearVariableChange::multiplyInverseAD(Increment & dx,
                << std::endl;
 
   // Create output state
-  Increment dxout(*dx.geometry(), vars, dx.time());
+  Increment dxout(dx.geometry(), vars, dx.time());
 
   // Call variable change(s)
   for (icst_ it = linVarChas_.begin(); it != linVarChas_.end(); ++it) {

--- a/src/soca/LinearVariableChange/LinearVariableChange.cc
+++ b/src/soca/LinearVariableChange/LinearVariableChange.cc
@@ -68,8 +68,6 @@ void LinearVariableChange::multiply(Increment & dx,
                                     const oops::Variables & vars) const {
   Log::trace() << "LinearVariableChange::multiply starting" << std::endl;
 
-  util::Timer timer("soca::LinearVariableChange", "multiply");
-
   // If all variables already in incoming state just remove the no longer
   // needed fields
   // if (hasAllFields) {
@@ -106,7 +104,6 @@ void LinearVariableChange::multiplyInverse(Increment & dx,
   Log::trace() << "LinearVariableChange::multiplyInverse starting"
                << vars << std::endl;
 
-  util::Timer timer("soca::LinearVariableChange", "multiplyInverse");
   // Create output state
   Increment dxout(dx.geometry(), vars, dx.time());
 
@@ -126,8 +123,6 @@ void LinearVariableChange::multiplyInverse(Increment & dx,
 void LinearVariableChange::multiplyAD(Increment & dx,
                                            const oops::Variables & vars) const {
   Log::trace() << "LinearVariableChange::multiplyAD starting" << std::endl;
-  util::Timer timer("soca::LinearVariableChange", "multiplyAD");
-
   Increment dxout(dx.geometry(), vars, dx.time());
 
   // Call variable change(s)

--- a/src/soca/LinearVariableChange/LinearVariableChange.cc
+++ b/src/soca/LinearVariableChange/LinearVariableChange.cc
@@ -68,10 +68,7 @@ void LinearVariableChange::multiply(Increment & dx,
                                     const oops::Variables & vars) const {
   Log::trace() << "LinearVariableChange::multiply starting" << std::endl;
 
-  Log::debug() << "LinearVariableChange::multiply input vars: "
-               << dx.variables() << std::endl;
-  Log::debug() << "LinearVariableChange::multiply output vars: "
-               << vars << std::endl;
+  util::Timer timer("soca::LinearVariableChange", "multiply");
 
   // If all variables already in incoming state just remove the no longer
   // needed fields
@@ -87,7 +84,6 @@ void LinearVariableChange::multiply(Increment & dx,
 
   // Call variable change(s)
   for (icst_ it = linVarChas_.begin(); it != linVarChas_.end(); ++it) {
-    Log::debug() << "LinearVariableChange::multiply with "<< *it << std::endl;
      dxout.zero();
      it->multiply(dx, dxout);
      dx.updateFields(vars);
@@ -100,7 +96,7 @@ void LinearVariableChange::multiply(Increment & dx,
   // Copy data from temporary state
   // dx = dxout;
 
-  Log::trace() << "LinearVariableChange::multiply done" << dx << std::endl;
+  Log::trace() << "LinearVariableChange::multiply done" << std::endl;
 }
 
 // -----------------------------------------------------------------------------
@@ -110,11 +106,7 @@ void LinearVariableChange::multiplyInverse(Increment & dx,
   Log::trace() << "LinearVariableChange::multiplyInverse starting"
                << vars << std::endl;
 
-  Log::debug() << "LinearVariableChange::multiplyInverse input vars: "
-               << dx.variables() << std::endl;
-  Log::debug() << "LinearVariableChange::multiplyInverse output vars: "
-               << vars << std::endl;
-
+  util::Timer timer("soca::LinearVariableChange", "multiplyInverse");
   // Create output state
   Increment dxout(dx.geometry(), vars, dx.time());
 
@@ -134,12 +126,8 @@ void LinearVariableChange::multiplyInverse(Increment & dx,
 void LinearVariableChange::multiplyAD(Increment & dx,
                                            const oops::Variables & vars) const {
   Log::trace() << "LinearVariableChange::multiplyAD starting" << std::endl;
+  util::Timer timer("soca::LinearVariableChange", "multiplyAD");
 
-  // Create output state
-  Log::debug() << "LinearVariableChange::multiplyAD input vars: "
-               << dx.variables() << std::endl;
-  Log::debug() << "LinearVariableChange::multiplyAD output vars: "
-               << vars << std::endl;
   Increment dxout(dx.geometry(), vars, dx.time());
 
   // Call variable change(s)

--- a/src/soca/LinearVariableChange/LinearVariableChange.cc
+++ b/src/soca/LinearVariableChange/LinearVariableChange.cc
@@ -24,7 +24,7 @@ namespace soca {
 
 LinearVariableChange::LinearVariableChange(const Geometry & geom,
                                            const Parameters_ & params)
-  : geom_(new Geometry(geom)), params_(params), linVarChas_() {}
+  : geom_(geom), params_(params), linVarChas_() {}
 
 // -----------------------------------------------------------------------------
 
@@ -49,13 +49,13 @@ void LinearVariableChange::setTrajectory(const State & xbg, const State & xfg) {
             linVarChaParWra.linearVariableChangeParameters;
       // Add linear variable change to vector
       linVarChas_.push_back(
-        LinearVariableChangeFactory::create(xbg, xfg, *geom_, linVarChaPar));
+        LinearVariableChangeFactory::create(xbg, xfg, geom_, linVarChaPar));
     }
   } else {
     // No variable changes were specified, use the default (LinearModel2GeoVaLs)
     eckit::LocalConfiguration conf;
     conf.set("linear variable change name", "default");
-    linVarChas_.push_back(LinearVariableChangeFactory::create(xbg, xfg, *geom_,
+    linVarChas_.push_back(LinearVariableChangeFactory::create(xbg, xfg, geom_,
       oops::validateAndDeserialize<GenericLinearVariableChangeParameters>(
         conf)));
   }

--- a/src/soca/LinearVariableChange/LinearVariableChange.h
+++ b/src/soca/LinearVariableChange/LinearVariableChange.h
@@ -62,7 +62,7 @@ class LinearVariableChange : public util::Printable {
  private:
   void print(std::ostream &) const override;
   Parameters_ params_;
-  std::shared_ptr<const Geometry> geom_;
+  const Geometry & geom_;
   LinVarChaVec_ linVarChas_;
 };
 

--- a/src/soca/Model/mom6solo/Model.cc
+++ b/src/soca/Model/mom6solo/Model.cc
@@ -30,7 +30,7 @@ namespace soca {
   Model::Model(const Geometry & resol, const eckit::Configuration & model)
     : keyConfig_(0),
       tstep_(0),
-      geom_(new Geometry(resol)),
+      geom_(resol),
       vars_(model, "model variables"),
       setup_mom6_(true)
   {
@@ -41,7 +41,7 @@ namespace soca {
     const eckit::Configuration * configc = &model;
     if (setup_mom6_)
       {
-        soca_model_setup_f90(&configc, geom_->toFortran(), keyConfig_);
+        soca_model_setup_f90(&configc, geom_.toFortran(), keyConfig_);
       }
         Log::trace() << "Model created" << std::endl;
   }

--- a/src/soca/Model/mom6solo/Model.h
+++ b/src/soca/Model/mom6solo/Model.h
@@ -71,7 +71,7 @@ namespace soca {
     int keyConfig_;
     util::Duration tstep_;
     bool setup_mom6_;
-    std::unique_ptr<const Geometry> geom_;
+    const Geometry & geom_;
     const oops::Variables vars_;
   };
   // -----------------------------------------------------------------------------

--- a/src/soca/Model/ufsm6c6/ModelUFSm6c6.cc
+++ b/src/soca/Model/ufsm6c6/ModelUFSm6c6.cc
@@ -31,7 +31,7 @@ namespace soca {
                              const eckit::Configuration & model)
     : keyConfig_(0),
       tstep_(0),
-      geom_(new Geometry(resol)),
+      geom_(resol),
       vars_(model, "model variables")
   {
     Log::trace() << "ModelUFSm6c6::ModelUFSm6c6" << std::endl;

--- a/src/soca/Model/ufsm6c6/ModelUFSm6c6.h
+++ b/src/soca/Model/ufsm6c6/ModelUFSm6c6.h
@@ -70,7 +70,7 @@ namespace soca {
     void print(std::ostream &) const;
     int keyConfig_;
     util::Duration tstep_;
-    std::unique_ptr<const Geometry> geom_;
+    const Geometry & geom_;
     const oops::Variables vars_;
   };
   // -----------------------------------------------------------------------------

--- a/src/soca/State/State.cc
+++ b/src/soca/State/State.cc
@@ -34,20 +34,20 @@ namespace soca {
   // -----------------------------------------------------------------------------
   State::State(const Geometry & geom, const oops::Variables & vars,
                const util::DateTime & vt)
-    : time_(vt), vars_(vars), geom_(new Geometry(geom))
+    : time_(vt), vars_(vars), geom_(geom)
   {
-    soca_state_create_f90(keyFlds_, geom_->toFortran(), vars_);
+    soca_state_create_f90(keyFlds_, geom_.toFortran(), vars_);
     Log::trace() << "State::State created." << std::endl;
   }
   // -----------------------------------------------------------------------------
   State::State(const Geometry & geom, const eckit::Configuration & conf)
     : time_(),
       vars_(conf, "state variables"),
-      geom_(new Geometry(geom))
+      geom_(geom)
   {
     util::DateTime * dtp = &time_;
     oops::Variables vars(vars_);
-    soca_state_create_f90(keyFlds_, geom_->toFortran(), vars);
+    soca_state_create_f90(keyFlds_, geom_.toFortran(), vars);
 
     if (conf.has("analytic init")) {
       std::string dt;
@@ -61,17 +61,17 @@ namespace soca {
   }
   // -----------------------------------------------------------------------------
   State::State(const Geometry & geom, const State & other)
-    : vars_(other.vars_), time_(other.time_), geom_(new Geometry(geom))
+    : vars_(other.vars_), time_(other.time_), geom_(geom)
   {
-    soca_state_create_f90(keyFlds_, geom_->toFortran(), vars_);
+    soca_state_create_f90(keyFlds_, geom_.toFortran(), vars_);
     soca_state_change_resol_f90(toFortran(), other.keyFlds_);
     Log::trace() << "State::State created by interpolation." << std::endl;
   }
   // -----------------------------------------------------------------------------
   State::State(const State & other)
-    : vars_(other.vars_), time_(other.time_), geom_(new Geometry(*other.geom_))
+    : vars_(other.vars_), time_(other.time_), geom_(other.geom_)
   {
-    soca_state_create_f90(keyFlds_, geom_->toFortran(), vars_);
+    soca_state_create_f90(keyFlds_, geom_.toFortran(), vars_);
     soca_state_copy_f90(toFortran(), other.toFortran());
     Log::trace() << "State::State copied." << std::endl;
   }
@@ -110,7 +110,7 @@ namespace soca {
   State & State::operator+=(const Increment & dx) {
     ASSERT(validTime() == dx.validTime());
     // Interpolate increment to analysis grid
-    Increment dx_hr(*geom_, dx);
+    Increment dx_hr(geom_, dx);
 
     // Add increment to background state
     soca_state_add_incr_f90(toFortran(), dx_hr.toFortran());
@@ -153,7 +153,7 @@ namespace soca {
   size_t State::serialSize() const {
     // Field
     size_t nn;
-    soca_state_serial_size_f90(toFortran(), geom_->toFortran(), nn);
+    soca_state_serial_size_f90(toFortran(), geom_.toFortran(), nn);
 
     // Magic factor
     nn += 1;
@@ -167,10 +167,10 @@ namespace soca {
   void State::serialize(std::vector<double> & vect) const {
     // Serialize the field
     size_t nn;
-    soca_state_serial_size_f90(toFortran(), geom_->toFortran(), nn);
+    soca_state_serial_size_f90(toFortran(), geom_.toFortran(), nn);
     std::vector<double> vect_field(nn, 0);
     vect.reserve(vect.size() + nn + 1 + time_.serialSize());
-    soca_state_serialize_f90(toFortran(), geom_->toFortran(), nn,
+    soca_state_serialize_f90(toFortran(), geom_.toFortran(), nn,
                              vect_field.data());
     vect.insert(vect.end(), vect_field.begin(), vect_field.end());
 
@@ -183,7 +183,7 @@ namespace soca {
   // -----------------------------------------------------------------------------
   void State::deserialize(const std::vector<double> & vect, size_t & index) {
     // Deserialize the field
-    soca_state_deserialize_f90(toFortran(), geom_->toFortran(), vect.size(),
+    soca_state_deserialize_f90(toFortran(), geom_.toFortran(), vect.size(),
                                vect.data(), index);
 
     // Use magic value to validate deserialization
@@ -236,7 +236,7 @@ namespace soca {
   // -----------------------------------------------------------------------------
   util::DateTime & State::validTime() {return time_;}
   // -----------------------------------------------------------------------------
-  std::shared_ptr<const Geometry> State::geometry() const {return geom_;}
+  const Geometry & State::geometry() const {return geom_;}
   // -----------------------------------------------------------------------------
 
   void State::getFieldSet(const oops::Variables &vars, atlas::FieldSet &fset) const {

--- a/src/soca/State/State.h
+++ b/src/soca/State/State.h
@@ -87,7 +87,7 @@ namespace soca {
 
       int & toFortran() {return keyFlds_;}
       const int & toFortran() const {return keyFlds_;}
-      std::shared_ptr<const Geometry> geometry() const;
+      const Geometry & geometry() const;
       const oops::Variables & variables() const {return vars_;}
       const util::DateTime & time() const {return time_;}
 
@@ -106,7 +106,7 @@ namespace soca {
 
       F90flds keyFlds_;
 
-      std::shared_ptr<const Geometry> geom_;
+      const Geometry & geom_;
       oops::Variables vars_;
       util::DateTime time_;
   };

--- a/src/soca/VariableChange/Model2GeoVaLs/Model2GeoVaLs.cc
+++ b/src/soca/VariableChange/Model2GeoVaLs/Model2GeoVaLs.cc
@@ -24,7 +24,7 @@ static VariableChangeMaker<Model2GeoVaLs>
 
 Model2GeoVaLs::Model2GeoVaLs(const Geometry & geom,
                              const eckit::Configuration & conf)
-  : geom_(new Geometry(geom)) {
+  : geom_(geom) {
 }
 
 // -----------------------------------------------------------------------------
@@ -34,7 +34,7 @@ Model2GeoVaLs::~Model2GeoVaLs() {}
 // -----------------------------------------------------------------------------
 
 void Model2GeoVaLs::changeVar(const State & xin, State & xout) const {
-  soca_model2geovals_changevar_f90(geom_->toFortran(),
+  soca_model2geovals_changevar_f90(geom_.toFortran(),
                                    xin.toFortran(), xout.toFortran());
 }
 

--- a/src/soca/VariableChange/Model2GeoVaLs/Model2GeoVaLs.h
+++ b/src/soca/VariableChange/Model2GeoVaLs/Model2GeoVaLs.h
@@ -27,7 +27,7 @@ class Model2GeoVaLs: public VariableChangeBase {
   void changeVarInverse(const State &, State &) const override;
 
  private:
-  std::unique_ptr<Geometry> geom_;
+  const Geometry & geom_;
   void print(std::ostream &) const override {}
 };
 

--- a/src/soca/VariableChange/VariableChange.cc
+++ b/src/soca/VariableChange/VariableChange.cc
@@ -47,7 +47,7 @@ void VariableChange::changeVar(State & x, const oops::Variables & vars) const {
   // if (!(x.variables() == vars)) {
 
   // Create output state
-  State xout(*x.geometry(), vars, x.time());
+  State xout(x.geometry(), vars, x.time());
 
   // Call variable change
   variableChange_->changeVar(x, xout);
@@ -75,7 +75,7 @@ void VariableChange::changeVarInverse(State & x,
   // If the variables are the same, don't bother doing anything!
   if (!(x.variables() == vars)) {
     // Create output state
-    State xout(*x.geometry(), vars, x.time());
+    State xout(x.geometry(), vars, x.time());
 
     // Call variable change
     variableChange_->changeVarInverse(x, xout);

--- a/test/testinput/3dvar_soca.yml
+++ b/test/testinput/3dvar_soca.yml
@@ -268,7 +268,7 @@ variational:
   - geometry:
       mom6_input_nml: ./inputnml/input.nml
       fields metadata: ./fields_metadata.yml
-    ninner: 100
+    ninner: 5
     gradient norm reduction: 1e-15
     test: on
     diagnostics:

--- a/test/testinput/3dvar_soca.yml
+++ b/test/testinput/3dvar_soca.yml
@@ -268,7 +268,7 @@ variational:
   - geometry:
       mom6_input_nml: ./inputnml/input.nml
       fields metadata: ./fields_metadata.yml
-    ninner: 5
+    ninner: 100
     gradient norm reduction: 1e-15
     test: on
     diagnostics:


### PR DESCRIPTION
## Description
Way too much memory was being used when the PE count got high. This fixes two main unrelated issues

1) Stop making so many unnecessary copies of `Geometry`
2) stop creating the kdtree multiple times in the iterpolator


The SOCA leads (both current and past) have a tendency to lose things. We figured `Geometry` was important, so to keep from losing it we apparently were making tens of thousands of copies of it. Turns out this uses a lot of memory. No surprise.

All of the `geom_(new geometry(...))` statements were removed by having the various classes that store geometry do so as a copy of a const reference instead of creating a new class and putting it in a shared pointer. (The one exception is the `ErrorCovariance` class, where it currently needs to make a copy of the geometry)

I always knew this was wasteful and needed to be fixed, but wasn't a problem until recently when we started making needless copies of `Geometry` in the thousands of interpolator objects.

Also the kdtree creation was moved out of `LocalUnstructuredInterpolator` and placed in `Geometry` so that it only has to be initialized once

### Issue(s) addressed

- fisrt part of https://github.com/JCSDA-internal/soca/issues/748

## Testing

- the ctests pass on my machine. Trust me. TravisCI is still broken due to an oops issue.
- tested with the configuration @guillaumevernieres had shown in the related issue.

With that configuration on orion,  **before**:

```
OOPS_STATS ----------------------------------------------------------------------------------
OOPS_STATS --------------------------- Object counts ----------------------------------------
OOPS_STATS ----------------------------------------------------------------------------------
OOPS_STATS                                      Total  Simult. Remain    Avg (Mb)    HWM (Mb)
OOPS_STATS soca::Geometry                  :     3960     993      17

OOPS_STATS ---------------------------------- Parallel Timing Statistics ( 480 MPI tasks) -----------------------------------
OOPS_STATS Run end                                  - Runtime:    108.40 sec,  Memory: total:  1818.54 Gb, per task: min =     3.78 Gb, max =     4.77 Gb
```

And **after** this PR

```
OOPS_STATS ----------------------------------------------------------------------------------
OOPS_STATS --------------------------- Object counts ----------------------------------------
OOPS_STATS ----------------------------------------------------------------------------------
OOPS_STATS                                      Total  Simult. Remain    Avg (Mb)    HWM (Mb)
OOPS_STATS soca::Geometry                  :        9       7        

OOPS_STATS ---------------------------------- Parallel Timing Statistics ( 480 MPI tasks) -----------------------------------
OOPS_STATS Run end                                  - Runtime:     97.33 sec,  Memory: total:   416.93 Gb, per task: min =   848.73 Mb, max =  1868.52 Mb

```

@frolovsa @weihuang-jedi , I suspect this has at least something to do with the problems you have been having lately
