### PR TITLE
update version number and dependencies numbers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# (C) Copyright 2017-2021 UCAR.
+# (C) Copyright 2017-2022 UCAR.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -9,7 +9,7 @@
 ################################################################################
 
 cmake_minimum_required( VERSION 3.12 )
-project( soca VERSION 1.0.0 LANGUAGES C CXX Fortran)
+project( soca VERSION 1.1.0 LANGUAGES C CXX Fortran)
 
 find_package(ecbuild 3.3.2 REQUIRED)
 include( ecbuild_system NO_POLICY_SCOPE )
@@ -23,16 +23,15 @@ include( soca_compiler_flags )
 ################################################################################
 find_package( NetCDF REQUIRED COMPONENTS Fortran)
 find_package( gsl-lite REQUIRED HINTS $ENV{gsl_list_DIR})
-find_package( eckit  1.11.6   REQUIRED)
-find_package( fckit  0.7.0    REQUIRED)
-find_package( atlas  0.20.2   REQUIRED)
-find_package( oops   1.0.0    REQUIRED)
+find_package( eckit  1.18.2   REQUIRED)
+find_package( fckit  0.9.5    REQUIRED)
+find_package( atlas  0.27.0   REQUIRED)
+find_package( oops   1.3.0    REQUIRED)
 find_package( saber  1.0.0    REQUIRED)
 find_package( ioda   1.0.0    REQUIRED)
-find_package( ufo    1.0.0    REQUIRED)
+find_package( ufo    1.3.0    REQUIRED)
 find_package( fms    2020.4.0 REQUIRED)
 find_package( mom6   2020.4.0 REQUIRED)
-find_package( crtm   2.2.3)
 include_directories( ${NETCDF_INCLUDE_DIRS} )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package( saber  1.0.0    REQUIRED)
 find_package( ioda   1.0.0    REQUIRED)
 find_package( ufo    1.3.0    REQUIRED)
 find_package( fms    2020.4.0 REQUIRED)
-find_package( mom6   2020.4.0 REQUIRED)
+find_package( mom6   2022.1.0 REQUIRED)
 include_directories( ${NETCDF_INCLUDE_DIRS} )
 
 


### PR DESCRIPTION
## Description

update version numbers for skylab v1.0.0.0.0-rc1

the following upstream still need to be updated when they are updated.
- [ ] saber
- [ ] ioda
- [x] fms ? (probably not)
- [x] mom6 ? (maybe)
