### PR TITLE
change linearvarchange interface

### DIFF
--- a/src/soca/LinearVariableChange/LinearVariableChange.cc
+++ b/src/soca/LinearVariableChange/LinearVariableChange.cc
@@ -32,8 +32,11 @@ LinearVariableChange::~LinearVariableChange() {}
 
 // -----------------------------------------------------------------------------
 
-void LinearVariableChange::setTrajectory(const State & xbg, const State & xfg) {
+void LinearVariableChange::changeVarTraj(const State & xfg,
+                                         const oops::Variables & vars) {
   Log::trace() << "LinearVariableChange::setTrajectory starting" << std::endl;
+
+  // TODO(travis): do something with vars.
 
   const boost::optional<std::vector<LinearVariableChangeParametersWrapper>> &
     linVarChgs = params_.linearVariableChangesWrapper;
@@ -49,13 +52,13 @@ void LinearVariableChange::setTrajectory(const State & xbg, const State & xfg) {
             linVarChaParWra.linearVariableChangeParameters;
       // Add linear variable change to vector
       linVarChas_.push_back(
-        LinearVariableChangeFactory::create(xbg, xfg, geom_, linVarChaPar));
+        LinearVariableChangeFactory::create(xfg, xfg, geom_, linVarChaPar));
     }
   } else {
     // No variable changes were specified, use the default (LinearModel2GeoVaLs)
     eckit::LocalConfiguration conf;
     conf.set("linear variable change name", "default");
-    linVarChas_.push_back(LinearVariableChangeFactory::create(xbg, xfg, geom_,
+    linVarChas_.push_back(LinearVariableChangeFactory::create(xfg, xfg, geom_,
       oops::validateAndDeserialize<GenericLinearVariableChangeParameters>(
         conf)));
   }
@@ -64,8 +67,8 @@ void LinearVariableChange::setTrajectory(const State & xbg, const State & xfg) {
 
 // -----------------------------------------------------------------------------
 
-void LinearVariableChange::multiply(Increment & dx,
-                                    const oops::Variables & vars) const {
+void LinearVariableChange::changeVarTL(Increment & dx,
+                                       const oops::Variables & vars) const {
   Log::trace() << "LinearVariableChange::multiply starting" << std::endl;
 
   // If all variables already in incoming state just remove the no longer
@@ -99,8 +102,8 @@ void LinearVariableChange::multiply(Increment & dx,
 
 // -----------------------------------------------------------------------------
 
-void LinearVariableChange::multiplyInverse(Increment & dx,
-                                           const oops::Variables & vars) const {
+void LinearVariableChange::changeVarInverseTL(Increment & dx,
+                                              const oops::Variables & vars) const {
   Log::trace() << "LinearVariableChange::multiplyInverse starting"
                << vars << std::endl;
 
@@ -120,8 +123,8 @@ void LinearVariableChange::multiplyInverse(Increment & dx,
 
 // -----------------------------------------------------------------------------
 
-void LinearVariableChange::multiplyAD(Increment & dx,
-                                           const oops::Variables & vars) const {
+void LinearVariableChange::changeVarAD(Increment & dx,
+                                       const oops::Variables & vars) const {
   Log::trace() << "LinearVariableChange::multiplyAD starting" << std::endl;
   Increment dxout(dx.geometry(), vars, dx.time());
 
@@ -138,8 +141,8 @@ void LinearVariableChange::multiplyAD(Increment & dx,
 
 // -----------------------------------------------------------------------------
 
-void LinearVariableChange::multiplyInverseAD(Increment & dx,
-                                          const oops::Variables & vars) const {
+void LinearVariableChange::changeVarInverseAD(Increment & dx,
+                                              const oops::Variables & vars) const {
   Log::trace() << "LinearVariableChange::multiplyInverseAD starting"
                << std::endl;
 

--- a/src/soca/LinearVariableChange/LinearVariableChange.cc
+++ b/src/soca/LinearVariableChange/LinearVariableChange.cc
@@ -36,7 +36,12 @@ void LinearVariableChange::changeVarTraj(const State & xfg,
                                          const oops::Variables & vars) {
   Log::trace() << "LinearVariableChange::setTrajectory starting" << std::endl;
 
-  // TODO(travis): do something with vars.
+  // TODO(travis): do something with vars?
+
+  // TODO(travis): this is not ideal. We are saving the first trajectory and
+  // assuming it is the background. This should all get ripped out when the
+  // variable changes that rely on the background are dealt with properly.
+  if (!bkg_) { bkg_.reset(new State(xfg)); }
 
   const boost::optional<std::vector<LinearVariableChangeParametersWrapper>> &
     linVarChgs = params_.linearVariableChangesWrapper;
@@ -52,13 +57,13 @@ void LinearVariableChange::changeVarTraj(const State & xfg,
             linVarChaParWra.linearVariableChangeParameters;
       // Add linear variable change to vector
       linVarChas_.push_back(
-        LinearVariableChangeFactory::create(xfg, xfg, geom_, linVarChaPar));
+        LinearVariableChangeFactory::create(*bkg_, xfg, geom_, linVarChaPar));
     }
   } else {
     // No variable changes were specified, use the default (LinearModel2GeoVaLs)
     eckit::LocalConfiguration conf;
     conf.set("linear variable change name", "default");
-    linVarChas_.push_back(LinearVariableChangeFactory::create(xfg, xfg, geom_,
+    linVarChas_.push_back(LinearVariableChangeFactory::create(*bkg_, xfg, geom_,
       oops::validateAndDeserialize<GenericLinearVariableChangeParameters>(
         conf)));
   }

--- a/src/soca/LinearVariableChange/LinearVariableChange.h
+++ b/src/soca/LinearVariableChange/LinearVariableChange.h
@@ -25,6 +25,9 @@
 
 namespace soca {
 
+// Forward declarations
+class State;
+
 // -----------------------------------------------------------------------------
 
 class LinearVariableChangeParameters :
@@ -63,6 +66,7 @@ class LinearVariableChange : public util::Printable {
   void print(std::ostream &) const override;
   Parameters_ params_;
   const Geometry & geom_;
+  std::unique_ptr<State> bkg_;
   LinVarChaVec_ linVarChas_;
 };
 

--- a/src/soca/LinearVariableChange/LinearVariableChange.h
+++ b/src/soca/LinearVariableChange/LinearVariableChange.h
@@ -52,12 +52,12 @@ class LinearVariableChange : public util::Printable {
   explicit LinearVariableChange(const Geometry &, const Parameters_ &);
   ~LinearVariableChange();
 
-  void setTrajectory(const State &, const State &);
+  void changeVarTraj(const State &, const oops::Variables &);
 
-  void multiply(Increment &, const oops::Variables &) const;
-  void multiplyInverse(Increment &, const oops::Variables &) const;
-  void multiplyAD(Increment &, const oops::Variables &) const;
-  void multiplyInverseAD(Increment &, const oops::Variables &) const;
+  void changeVarTL(Increment &, const oops::Variables &) const;
+  void changeVarInverseTL(Increment &, const oops::Variables &) const;
+  void changeVarAD(Increment &, const oops::Variables &) const;
+  void changeVarInverseAD(Increment &, const oops::Variables &) const;
 
  private:
   void print(std::ostream &) const override;


### PR DESCRIPTION
## Description

closes https://github.com/JCSDA-internal/soca/issues/768
see issue for details

As a "temporary" work around to some of the variable changes requiring the background, a copy of the first trajectory is made and assumed to be the background. This is untested, because outer loops are currently broken with soca until https://github.com/JCSDA-internal/oops/pull/1799 is merged

## Dependencies

requires oops branch of same name
- coordinate with https://github.com/JCSDA-internal/oops/pull/1800
