### PR TITLE
Update bundle/CMakeLists.txt: recursive checkout of jedi-cmake

### DIFF
--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -14,7 +14,7 @@ include( ecbuild_bundle )
 
 ecbuild_bundle_initialize()
 
-ecbuild_bundle( PROJECT jedicmake GIT "https://github.com/jcsda-internal/jedi-cmake.git" UPDATE BRANCH develop )
+ecbuild_bundle( PROJECT jedicmake GIT "https://github.com/jcsda-internal/jedi-cmake.git" UPDATE BRANCH develop RECURSIVE )
 include( jedicmake/cmake/Functions/git_functions.cmake  )
 
 # ECMWF repos that you probably dont need to build yourself because they


### PR DESCRIPTION
## Description

Add `RECURSIVE` checkout option to `jedi-cmake` in bundle.

### Issue(s) addressed

Required for https://github.com/JCSDA-internal/jedi-cmake/pull/27

## Acceptance Criteria (Definition of Done)

PR merged

## Dependencies

None

## Impact

None