### PR TITLE
Update Atlas tag to 0.29.0

### DIFF
--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -31,10 +31,9 @@ if (BUILD_FCKIT)
   # TODO: replace with https://github.com/ecmwf/fckit.git TAG 0.9.2
 endif()
 
-option(BUILD_ATLAS "download and build atlas (not needed if in a jedi container)")
+option(BUILD_ATLAS "download and build atlas")
 if (BUILD_ATLAS)
-  ecbuild_bundle( PROJECT atlas  GIT "https://github.com/jcsda-internal/atlas.git"  UPDATE BRANCH release-stable )
-  # TODO: repalce with https://github.com/ecmwf/atlas.git TAG 0.24.1
+  ecbuild_bundle( PROJECT atlas  GIT "https://github.com/ecmwf/atlas.git" TAG 0.29.0 )
 endif()
 
 


### PR DESCRIPTION
## Description
We need to update `Atlas` to `0.29.0` since [saber PR#268 (wild guess)](https://github.com/JCSDA-internal/saber/pull/268). Probably useless to most, but required if, for example, you are using the JCSDA singularity container, or need to build Atlas for some reason. 