### PR TITLE
Update soca Geometry to give level order

### DIFF
--- a/src/soca/Geometry/Geometry.h
+++ b/src/soca/Geometry/Geometry.h
@@ -57,6 +57,8 @@ namespace soca {
       Geometry(const Geometry &);
       ~Geometry();
 
+      bool levelsAreTopDown() const {return true;}
+
       GeometryIterator begin() const;
       GeometryIterator end() const;
       int IteratorDimension() const;


### PR DESCRIPTION
## Description

Companion PR to https://github.com/JCSDA-internal/oops/pull/1846

Adds a new function `bool levelsAreTopDown()` to the model Geometry.