### PR TITLE
Add bgens parameter for variational task (for use in EnVar)

### DIFF
--- a/ewok/tasks/variationalMOM6.py
+++ b/ewok/tasks/variationalMOM6.py
@@ -7,9 +7,9 @@ import os
 from ewok.tasks.variational import variational
 
 class variationalMOM6(variational):
-    def setup(self, config, execs, fix, hcoeffs, statb, bg, obs):
+    def setup(self, config, execs, fix, hcoeffs, statb, bg, bgens, obs):
         # overwrite the executable names
         build = os.environ.get("JEDI_BUILD")
         bindir = os.path.join(build, 'bin')
         execs['anexec'] = os.path.join(bindir, 'soca_var.x')
-        super().setup(config, execs, fix, hcoeffs, statb, bg, obs)
+        super().setup(config, execs, fix, hcoeffs, statb, bg, bgens, obs)


### PR DESCRIPTION
## Description

Fixing an issue from https://github.com/JCSDA-internal/ewok/pull/381: Variational task now takes an extra argument `bgens` (that can be used in EnVar). The experiments in https://github.com/JCSDA-internal/ewok/pull/415 get created with this fix (and fail to create without). I'll leave it as draft until I see a cycle or two succeed in ewok experiments.