### PR TITLE
bugfix for soca 3dvar under ewok

### DIFF
--- a/ewok/static/5deg/MOM_input
+++ b/ewok/static/5deg/MOM_input
@@ -1,3 +1,3 @@
 NIGLOBAL = 72
 NJGLOBAL = 35
-NK = 33
+NK = 25

--- a/ewok/tasks/runSaveAnalysis.py
+++ b/ewok/tasks/runSaveAnalysis.py
@@ -27,8 +27,14 @@ filename = base + '.$(file_type).nc'
 # TODO put analysis back in restart file correctly?
 file_type = ['MOM.res', 'cice.res']
 expid=conf['experiment']['expid']
-shutil.move(f'ice.an.nc', f'{expid}.an.cice.res.nc')
-shutil.move(f'ocn.an.nc', f'{expid}.an.MOM.res.nc')
+for in_pfx, out_pfx in (
+        ('ice', 'cice.res'),
+        ('ocn', 'MOM.res')):
+    infile=f'{in_pfx}.{expid}.an.{andate}.nc'
+    outfile=f'{expid}.an.{out_pfx}.nc'
+    print (f"moving {infile} to {outfile}")
+    shutil.move(infile, outfile)
+
 
 r2d2.store(
     model=conf['experiment']['model'],

--- a/ewok/templates/anout.yaml
+++ b/ewok/templates/anout.yaml
@@ -1,5 +1,4 @@
 type : an
-# NOTE, for some reason SOCA isn't using arbitrary exp correctly
-exp: an
 date: '{{current_cycle}}'
-datadir: $(anworkdir)/
+exp: $(expid)
+datadir: ./

--- a/ewok/templates/background.yaml
+++ b/ewok/templates/background.yaml
@@ -1,4 +1,4 @@
-basename: $(bgworkdir)/
+basename: ./
 date: '{{background_time}}'
 
 ice_filename: $(expid).fc.$(fcdatetime).$(fcstep).cice.res.nc


### PR DESCRIPTION
## Description

- use relative instead of absolute paths for the soca executables. The filenames produced by `soca_var.x` were not correct, and were being truncated, because of the well known and loved "fms has filename lengths that are too short" issue.
- The number of vertical levels for the 5 deg case was wrong (should be 25, it _was_ 33), which seemed to run fine until NaNs appears in the var

## Testing

This PR has been tested under https://github.com/JCSDA-internal/ewok/pull/415
