### PR TITLE
release/skylab-v3: bump version to 1.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 ################################################################################
 
 cmake_minimum_required( VERSION 3.12 )
-project( soca VERSION 1.2.0 LANGUAGES C CXX Fortran)
+project( soca VERSION 1.3.0 LANGUAGES C CXX Fortran)
 
 find_package(ecbuild 3.3.2 REQUIRED)
 include( ecbuild_system NO_POLICY_SCOPE )


### PR DESCRIPTION
## Description

Bump version in `CMakeLists.txt` to 1.3.0 for release/skylab-v3 branch.

Note. This PR does not update any version numbers of the required packages listed in `CMakeLists.txt`, since I don't know what is needed and what is not.
