### PR TITLE
fix ewok files for var

### DIFF
--- a/ewok/defaults/bstatic.yaml
+++ b/ewok/defaults/bstatic.yaml
@@ -5,7 +5,7 @@ bump:
   io:
     data directory: $(soca_static_dir)/bump
   drivers:
-    multivariate strategy: specific_univariate
+    multivariate strategy: univariate
     read local nicas: true
 correlation:
   - name: ocn

--- a/ewok/static/5deg/bump/ice_nicas_local_000004-000001.nc
+++ b/ewok/static/5deg/bump/ice_nicas_local_000004-000001.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5a7c5b5efb4efc9b28a14b8a3e9199a62db44864ef1cfe607ed9f8aa49a37c48
-size 189390
+oid sha256:fdf794a6274e32695318a10e308749fa84e1326fe284bbbb27f6ace954aafbf4
+size 189718

--- a/ewok/static/5deg/bump/ice_nicas_local_000004-000002.nc
+++ b/ewok/static/5deg/bump/ice_nicas_local_000004-000002.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:df198b606a31a3dbc141a798f1a6532d0b363f4ccec4a604e364a1b00a4149ee
-size 169178
+oid sha256:a440d2bb389e79e5a40deacf79d72477be7e38d279c51622c3c6933271615f70
+size 169506

--- a/ewok/static/5deg/bump/ice_nicas_local_000004-000003.nc
+++ b/ewok/static/5deg/bump/ice_nicas_local_000004-000003.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:be5ac6f398d2c8c144aadedb2b06ac85f96eefc1b054c42198c05815b6537ed3
-size 152798
+oid sha256:cb350eb3e57c7792449e0c280423372997e81d9f214f2060434ee71361f35dd9
+size 153126

--- a/ewok/static/5deg/bump/ice_nicas_local_000004-000004.nc
+++ b/ewok/static/5deg/bump/ice_nicas_local_000004-000004.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6e24b513fc0cf297870e52841d479a3a17cbf91e8f9a36f7d4539d3d570da99e
-size 136094
+oid sha256:ba9fade6b08ba7acae3eb93b94d657d097e748ea892af46c36a46b83d1f6166c
+size 136422

--- a/ewok/static/5deg/bump/ocn_nicas_local_000004-000001.nc
+++ b/ewok/static/5deg/bump/ocn_nicas_local_000004-000001.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f8ae4199749f15dcd756b13cca337f8255def3c187ee60e847822a872c018c4
-size 320619
+oid sha256:bcf0ae9314a521ae95508238a098baa921806c17a80943b4acf2a03c57be65ed
+size 320947

--- a/ewok/static/5deg/bump/ocn_nicas_local_000004-000002.nc
+++ b/ewok/static/5deg/bump/ocn_nicas_local_000004-000002.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:46f77cf8806fb380331e6429dc10f065c5f3d237eae941049eb0ea7b047439e7
-size 285079
+oid sha256:97ff2cd26103c8bf803a928dd5b80a26611d21a1ded1e4e976aeb05d3ef67021
+size 285407

--- a/ewok/static/5deg/bump/ocn_nicas_local_000004-000003.nc
+++ b/ewok/static/5deg/bump/ocn_nicas_local_000004-000003.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:585dbbaf44bb8178cd1a54f3339d2ee199d3ceb21ae451737ec086badc607e60
-size 218734
+oid sha256:2c2b2a36d3620547a7a05f3ebbeaa9e15d311ff36ba443514988eb4ea3da5f51
+size 219062

--- a/ewok/static/5deg/bump/ocn_nicas_local_000004-000004.nc
+++ b/ewok/static/5deg/bump/ocn_nicas_local_000004-000004.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:99b09b5975096d304bdc7713c17da5c30802fda51bdc91d76b6142dbabe6795c
-size 193362
+oid sha256:d1d39b965f20cb6d7f1c4362a1aa8e273799813f9611f366d2b489b33305db58
+size 193690


### PR DESCRIPTION
Fix (some) of the issues that are preventing soca ewok experiments from running

* update the yaml needed for 3dvar
* update the static 5 deg bump files (025deg files will be handled separately)

partially addresses #855 