### PR TITLE
Adjust tolerances

### DIFF
--- a/test/testinput/dirac_soca_cov.yml
+++ b/test/testinput/dirac_soca_cov.yml
@@ -92,4 +92,4 @@ output dirac:
 test:
   reference filename: testref/dirac_soca_cov.test
   test output filename: testoutput/dirac_soca_cov.test
-  float relative tolerance: 1e-5
+  float relative tolerance: 1e-4

--- a/test/testinput/dirac_socahyb_cov.yml
+++ b/test/testinput/dirac_socahyb_cov.yml
@@ -127,4 +127,4 @@ output dirac:
 test:
   reference filename: testref/dirac_socahyb_cov.test
   test output filename: testoutput/dirac_socahyb_cov.test
-  float relative tolerance: 1e-5
+  float relative tolerance: 1e-4

--- a/test/testinput/ensvariance.yml
+++ b/test/testinput/ensvariance.yml
@@ -52,4 +52,4 @@ ensemble:
 test:
   reference filename: testref/ensvariance.test
   test output filename: testoutput/ensvariance.test
-  float relative tolerance: 1e-5
+  float relative tolerance: 1e-3


### PR DESCRIPTION
## Description

I had to adjust tolerance for some tests to pass on a Mac M1 with clang 14.0.3 and gfortran 12.2.0

Is this acceptable? Or should the soca team dig deeper? :-)

## Dependencies

None