### PR TITLE
Adapt to name changes in ufo

### DIFF
--- a/src/soca/AnalyticInit/AnalyticInit.cc
+++ b/src/soca/AnalyticInit/AnalyticInit.cc
@@ -13,7 +13,7 @@ namespace soca {
   static oops::AnalyticInitMaker<ufo::ObsTraits, AnalyticInit>
     makerAnalyticInit_("soca_ana_init");
 
-  void AnalyticInit::fillGeoVaLs(const ufo::Locations & locs,
+  void AnalyticInit::fillGeoVaLs(const ufo::SampledLocations & locs,
                                  ufo::GeoVaLs & geovals) const {
     soca_analytic_geovals_f90(geovals.toFortran(), locs);
   }

--- a/src/soca/AnalyticInit/AnalyticInit.h
+++ b/src/soca/AnalyticInit/AnalyticInit.h
@@ -28,7 +28,7 @@ namespace soca {
     typedef AnalyticInitParameters Parameters_;
 
     explicit AnalyticInit(const Parameters_ &) {}
-    void fillGeoVaLs(const ufo::Locations &, ufo::GeoVaLs &) const override;
+    void fillGeoVaLs(const ufo::SampledLocations &, ufo::GeoVaLs &) const override;
   };
 
 }  // namespace soca

--- a/src/soca/AnalyticInit/AnalyticInitFortran.h
+++ b/src/soca/AnalyticInit/AnalyticInitFortran.h
@@ -12,13 +12,13 @@
 
 // Forward declarations
 namespace ufo {
-  class Locations;
+  class SampledLocations;
 }
 
 namespace soca {
 
   extern "C" {
-    void soca_analytic_geovals_f90(F90goms &, const ufo::Locations &);
+    void soca_analytic_geovals_f90(F90goms &, const ufo::SampledLocations &);
   }
 }  // namespace soca
 #endif  // SOCA_ANALYTICINIT_ANALYTICINITFORTRAN_H_

--- a/src/soca/AnalyticInit/soca_analytic.interface.F90
+++ b/src/soca/AnalyticInit/soca_analytic.interface.F90
@@ -11,7 +11,7 @@ use iso_c_binding
 
 USE ufo_geovals_mod,            ONLY : ufo_geovals
 USE ufo_geovals_mod_c,          ONLY : ufo_geovals_registry
-USE ufo_locations_mod,          ONLY : ufo_locations
+USE ufo_sampled_locations_mod,  ONLY : ufo_sampled_locations
 
 use soca_analytic_mod
 
@@ -28,10 +28,10 @@ subroutine soca_analytic_geovals_c(c_key_geovals, c_locs) &
     type(c_ptr), value, intent(in) :: c_locs
 
     type(ufo_geovals), pointer :: geovals
-    type(ufo_locations) :: locs
+    type(ufo_sampled_locations) :: locs
 
     call ufo_geovals_registry%get(c_key_geovals, geovals)
-    locs = ufo_locations(c_locs)
+    locs = ufo_sampled_locations(c_locs)
 
     call soca_analytic_geovals(geovals, locs)
 

--- a/src/soca/AnalyticInit/soca_analytic_mod.F90
+++ b/src/soca/AnalyticInit/soca_analytic_mod.F90
@@ -8,7 +8,7 @@ module soca_analytic_mod
 
 use kinds, only : kind_real
 use ufo_geovals_mod, only : ufo_geovals
-use ufo_locations_mod, only : ufo_locations
+use ufo_sampled_locations_mod, only : ufo_sampled_locations
 use soca_state_mod, only : soca_state
 
 
@@ -26,7 +26,7 @@ contains
 !! \see soca_analytic_val
 subroutine soca_analytic_geovals(geovals, locs)
     type(ufo_geovals), intent(inout) :: geovals  !< output geovals
-    type(ufo_locations),  intent(in) :: locs !< input locations
+    type(ufo_sampled_locations),  intent(in) :: locs !< input locations
 
     real(kind=kind_real), allocatable :: lons(:), lats(:)
     integer :: ivar, iloc, ival

--- a/src/soca/AnalyticInit/soca_analytic_mod.F90
+++ b/src/soca/AnalyticInit/soca_analytic_mod.F90
@@ -40,7 +40,7 @@ subroutine soca_analytic_geovals(geovals, locs)
 
     do ivar = 1, geovals%nvar
         name = geovals%variables(ivar)
-        do iloc = 1, geovals%geovals(ivar)%nlocs
+        do iloc = 1, geovals%geovals(ivar)%nprofiles
             do ival = 1, geovals%geovals(ivar)%nval
                 val = soca_analytic_val(&
                     name, lats(iloc), lons(iloc), ival*1.0_kind_real)

--- a/src/soca/AnalyticInit/soca_analytic_mod.F90
+++ b/src/soca/AnalyticInit/soca_analytic_mod.F90
@@ -33,8 +33,8 @@ subroutine soca_analytic_geovals(geovals, locs)
     real(kind=kind_real) :: val
     character(len=:), allocatable :: name
 
-    allocate(lons(locs%nlocs()))
-    allocate(lats(locs%nlocs()))
+    allocate(lons(locs%npaths()))
+    allocate(lats(locs%npaths()))
     call locs%get_lons(lons)
     call locs%get_lats(lats)
 

--- a/src/soca/Increment/Increment.cc
+++ b/src/soca/Increment/Increment.cc
@@ -28,7 +28,6 @@
 #include "oops/util/Logger.h"
 
 #include "ufo/GeoVaLs.h"
-#include "ufo/Locations.h"
 
 using oops::Log;
 

--- a/src/soca/Increment/Increment.h
+++ b/src/soca/Increment/Increment.h
@@ -36,7 +36,6 @@ namespace eckit {
 }
 namespace ufo {
   class GeoVaLs;
-  class Locations;
 }
 namespace soca {
   class Geometry;

--- a/src/soca/State/State.cc
+++ b/src/soca/State/State.cc
@@ -23,7 +23,6 @@
 #include "oops/util/Logger.h"
 
 #include "ufo/GeoVaLs.h"
-#include "ufo/Locations.h"
 
 using oops::Log;
 

--- a/src/soca/State/State.h
+++ b/src/soca/State/State.h
@@ -27,7 +27,6 @@ namespace eckit {
 }
 namespace ufo {
   class GeoVaLs;
-  class Locations;
 }
 namespace soca {
   class Geometry;


### PR DESCRIPTION
## Description

This PR adapts `soca` code to some name changes made in https://github.com/JCSDA-internal/ufo/pull/2688, in particular to the renaming of `ufo::Locations` to `ufo::SampledLocations`.

(Just in case you're interested: this name change reflects a change in the role of that class. Conceptually, it is now a collection of interpolation paths sampling the observation locations, and the number of these paths may be different from the number of locations. In particular, an observation operator that wants to take the finite footprint of each observation into account may ask for model variables to be interpolated along multiple paths sampling each observation location; the list of these paths would be stored in a `SampledLocations` object. Not all variables need to be interpolated along the same paths; for instance, those varying slowly might require interpolation along fewer paths than those varying quickly. In that case the observation operator would create multiple `SampledLocations` objects and pass them to oops together with a mapping assigning one of these objects to each requested model variable.)

### Issue(s) addressed

Part of the work on https://github.com/JCSDA-internal/oops/issues/2003.

## Testing

CI

## Dependencies

To build and test this branch, `oops` and `ufo` need to be on the `feature/flexible_geovals` branch as well.

- waiting on https://github.com/JCSDA-internal/oops/pull/2096
- waiting on https://github.com/JCSDA-internal/ufo/pull/2688