### PR TITLE
Add OASIM and test obs to the repo... but don't do anything with it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,15 @@
 env:
   global:
     - MAIN_REPO=soca
-    - LIB_REPOS="gsw mom6 icepack oops vader ioda ufo saber"
-    - BUILD_OPT="-DBUILD_ICEPACK=ON"
+    - LIB_REPOS="gsw mom6 icepack oasim oops vader ioda ufo saber"
+    - BUILD_OPT="-DBUILD_ICEPACK=ON -DBUILD_OASIM=ON"
     - BUILD_OPT_mom6="-DENABLE_OCEAN_BGC=ON"
     - BUILD_OPT_oops="-DENABLE_QG_MODEL=OFF -DENABLE_LORENZ95_MODEL=OFF"
     - BUILD_OPT_ioda="-DBUILD_PYTHON_BINDINGS=OFF -DBUILD_TESTING=OFF"
     - BUILD_OPT_ufo="-DLOCAL_PATH_TESTFILES_IODA=NONE"
     - BUILD_OPT_saber="-DENABLE_TESTS=OFF"
     - BUILD_OPT_soca="-DENABLE_OCEAN_BGC=ON"
-    - MATCH_REPOS="saber oops ioda ufo mom6 soca"
+    - MATCH_REPOS="saber oops ioda ufo mom6 soca oasim"
     - LFS_REPOS=""
     # ENABLE_VALGRIND="ON"
 

--- a/bundle/.gitignore
+++ b/bundle/.gitignore
@@ -7,6 +7,7 @@ ioda-data/
 ioda/
 jedicmake/
 mom6/
+oasim/
 oops/
 saber-data/
 saber/

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -36,6 +36,11 @@ if ( BUILD_ICEPACK )
   ecbuild_bundle( PROJECT icepack         GIT "https://github.com/JCSDA-internal/Icepack.git"         UPDATE BRANCH feature/ecbuild-new )
 endif()
 
+option(BUILD_OASIM "download and build OASIM ocean color forward operator" OFF)
+if ( BUILD_OASIM )
+  ecbuild_bundle( PROJECT oasim         GIT "https://github.com/JCSDA-internal/oasim.git"           UPDATE BRANCH develop )
+endif ()
+
 #===================================================================================================
 # required repositories
 #===================================================================================================

--- a/test/Data/obs/pace_radiance.nc
+++ b/test/Data/obs/pace_radiance.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b881f3e7f3f5c824de932a149db4f77e7e91dd114a8c5b0aab716cae7e91f8d0
+size 150457


### PR DESCRIPTION
## Description
* closes https://github.com/JCSDA-internal/soca/issues/925

* OASIM can now be built with the soca bundle by setting `-DBUILD_OASIM=ON` at ecbuild time. It is off by default.
* Sample obs were added. They were taken from the obs that are in ufo-data, except I changed their date to match the dates we use for our ctests
* OASIM should now be built by default within TravisCI