### PR TITLE
Limit the vertical remapping log to 1 pe only.

### DIFF
--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -906,7 +906,7 @@ subroutine soca_fields_read(self, f_conf, vdate)
 
     ! built-in variables
     do i=1,size(self%fields)
-      
+
       if(self%fields(i)%metadata%io_file == "CONSTANT") then
         self%fields(i)%val(:,:,:) = self%fields(i)%metadata%constant_value
 
@@ -978,10 +978,12 @@ subroutine soca_fields_read(self, f_conf, vdate)
     if (vert_remap) then
 
       ! output log of  what fields are going to be interpolated vertically
-      do n=1,size(self%fields)
-        if (.not. self%fields(n)%metadata%vert_interp) cycle
-        call fckit_log%info("vertically remapping "//trim(self%fields(n)%name))
-      end do
+      if ( self%geom%f_comm%rank() == 0 ) then
+        do n=1,size(self%fields)
+          if (.not. self%fields(n)%metadata%vert_interp) cycle
+          call fckit_log%info("vertically remapping "//trim(self%fields(n)%name))
+        end do
+      end if
 
       allocate(h_common_ij(nz), hocn_ij(nz), varocn_ij(nz), varocn2_ij(nz))
       call initialize_remapping(remapCS,'PCM')


### PR DESCRIPTION
## Description
I've had it!!! Working with ensembles and a few 100 pe's makes the log output unreadable. @kbhargava asked me to add a log of what variables were remapped in a previous PR, which is a good idea, but I forgot  to limit the output to 1 pe only. I don't know or remember if there is a better solution, but this feature branch fixes that problem.

### Issue(s) addressed
- fixes #941 

