### PR TITLE
keep fortran logs on only 1 PE

### DIFF
--- a/src/soca/Covariance/soca_covariance_mod.F90
+++ b/src/soca/Covariance/soca_covariance_mod.F90
@@ -86,7 +86,7 @@ subroutine soca_cov_setup(self, f_conf, geom, bkg, vars)
   if (f_conf%get("perturbation scales", f_conf2)) then
     do ivar=1,self%vars%nvars()
       if ( .not. f_conf2%get(self%vars%variable(ivar), self%pert_scale(ivar))) then
-        if (geom%f_comm%rank() == 0) call oops_log%info( &
+        call oops_log%info( &
           "WARNING: no pertubation scale given for '"  //trim(self%vars%variable(ivar)) &
            // "' using default of 1.0")
       end if

--- a/src/soca/Covariance/soca_covariance_mod.F90
+++ b/src/soca/Covariance/soca_covariance_mod.F90
@@ -9,7 +9,7 @@ module soca_covariance_mod
 
 use atlas_module, only: atlas_fieldset, atlas_field, atlas_real, atlas_integer, atlas_functionspace
 use fckit_configuration_module, only: fckit_configuration
-use fckit_log_module, only: fckit_log
+use logger_mod
 use kinds, only: kind_real
 use oops_variables_mod, only: oops_variables
 use random_mod, only: normal_distribution
@@ -86,7 +86,7 @@ subroutine soca_cov_setup(self, f_conf, geom, bkg, vars)
   if (f_conf%get("perturbation scales", f_conf2)) then
     do ivar=1,self%vars%nvars()
       if ( .not. f_conf2%get(self%vars%variable(ivar), self%pert_scale(ivar))) then
-        if (geom%f_comm%rank() == 0) call fckit_log%warning( &
+        if (geom%f_comm%rank() == 0) call oops_log%info( &
           "WARNING: no pertubation scale given for '"  //trim(self%vars%variable(ivar)) &
            // "' using default of 1.0")
       end if
@@ -151,7 +151,7 @@ subroutine soca_cov_get_conv(self, field, conv)
   ! TODO we really should have separate variable names for staggered/destaggered variables.
   !  The "abort" has been turned into a "warning" until we get u/v names straightened out.
   if (field%metadata%grid /= "h") then
-      call fckit_log%warning("WARNING: Attempting to use a field (" // &
+      call oops_log%info("WARNING: Attempting to use a field (" // &
         trim(field%name) // ") which is on the u/v grid. PROCEED WITH CAUTION")
   end if
 

--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -18,7 +18,7 @@ use datetime_mod, only: datetime, datetime_set, datetime_to_string, datetime_to_
                         datetime_create, datetime_diff
 use duration_mod, only: duration, duration_to_string
 use fckit_configuration_module, only: fckit_configuration
-use fckit_log_module, only: fckit_log
+use logger_mod
 use fckit_mpi_module, only: fckit_mpi_min, fckit_mpi_max, fckit_mpi_sum
 use kinds, only: kind_real
 use oops_variables_mod, only: oops_variables
@@ -1009,7 +1009,7 @@ subroutine soca_fields_read(self, f_conf, vdate)
       if ( self%geom%f_comm%rank() == 0 ) then
         do n=1,size(self%fields)
           if (.not. self%fields(n)%metadata%vert_interp) cycle
-          call fckit_log%info("vertically remapping "//trim(self%fields(n)%name))
+          call oops_log%info("vertically remapping "//trim(self%fields(n)%name))
         end do
       end if
 

--- a/src/soca/State/soca_state_mod.F90
+++ b/src/soca/State/soca_state_mod.F90
@@ -6,7 +6,7 @@
 !> State fields
 module soca_state_mod
 
-use fckit_log_module, only: fckit_log
+use logger_mod
 use kinds, only: kind_real
 use oops_variables_mod
 
@@ -86,12 +86,12 @@ subroutine soca_state_rotate(self, coordinate, uvars, vvars)
     u_names = trim(uvars%variable(i))
     v_names = trim(vvars%variable(i))
     if (self%has(u_names).and.self%has(v_names)) then
-      call fckit_log%info("rotating "//trim(u_names)//" "//trim(v_names))
+      call oops_log%info("rotating "//trim(u_names)//" "//trim(v_names))
       call self%get(u_names, uocn)
       call self%get(v_names, vocn)
     else
       ! Skip if no pair found.
-      call fckit_log%info("not rotating "//trim(u_names)//" "//trim(v_names))
+      call oops_log%info("not rotating "//trim(u_names)//" "//trim(v_names))
       cycle
     end if
     allocate(un(size(uocn%val,1),size(uocn%val,2),size(uocn%val,3)))
@@ -242,11 +242,11 @@ subroutine soca_state_logexpon(self, transfunc, trvars)
     ! get a list variables to be transformed and make a copy
     tr_names = trim(trvars%variable(i))
     if (self%has(tr_names)) then
-      call fckit_log%info("transforming "//trim(tr_names))
+      call oops_log%info("transforming "//trim(tr_names))
       call self%get(tr_names, trocn)
     else
       ! Skip if no variable found.
-      call fckit_log%info("not transforming "//trim(tr_names))
+      call oops_log%info("not transforming "//trim(tr_names))
       cycle
     end if
     allocate(trn(size(trocn%val,1),size(trocn%val,2),size(trocn%val,3)))

--- a/src/soca/Utils/soca_omb_stats_mod.F90
+++ b/src/soca/Utils/soca_omb_stats_mod.F90
@@ -6,7 +6,7 @@
 !> surface background error used by soca_bkgerrgodas_mod
 module soca_omb_stats_mod
 
-use fckit_log_module, only: fckit_log
+use logger_mod
 use fckit_mpi_module, only: fckit_mpi_comm
 use kinds, only: kind_real
 use netcdf
@@ -69,7 +69,7 @@ subroutine soca_omb_stats_init(self, domain, filename)
 
   if (myrank.eq.root) then
 
-     call fckit_log%info("Reading file "  // trim(filename))
+     call oops_log%info("Reading file "  // trim(filename))
 
      call nc_check(nf90_open(filename, nf90_nowrite, ncid))
 


### PR DESCRIPTION
I got tired of being spammed with 
```
WARNING: Attempting to use a field (uocn) which is on the u/v grid. PROCEED WITH CAUTION
```
in the logs, multiplied for each PE that the var was being run with. :face_exhaling: 

This PR changes all the fortran `fckit_log` calls to use `oops_log%info` which internally will check to make sure the log is only given for the root PE. Log files are happier now.

## Testing
- ctests pass
- ran with HAT10 on orion and checked the logs