### PR TITLE
Change methods of saber blocks to take oops::FieldSet3D

### DIFF
--- a/src/soca/ExplicitDiffusion/ExplicitDiffusion.cc
+++ b/src/soca/ExplicitDiffusion/ExplicitDiffusion.cc
@@ -26,7 +26,7 @@ ExplicitDiffusion::ExplicitDiffusion(
     const Parameters_ & params,
     const oops::FieldSet3D & xb,
     const oops::FieldSet3D & fg)
-  : saber::SaberCentralBlockBase(params), params_(params)
+  : saber::SaberCentralBlockBase(params, xb.validTime()), params_(params)
 {
   // setup geometry
   geom_.reset(new Geometry(params_.geometry.value(), geometryData.comm()));
@@ -40,24 +40,24 @@ ExplicitDiffusion::ExplicitDiffusion(
 
 // --------------------------------------------------------------------------------------
 
-void ExplicitDiffusion::randomize(atlas::FieldSet &) const {
+void ExplicitDiffusion::randomize(oops::FieldSet3D &) const {
   throw eckit::NotImplemented("read not implemented yet for ExplictDiffusion");
 }
 
 // --------------------------------------------------------------------------------------
 
-void ExplicitDiffusion::multiply(atlas::FieldSet & fset) const {
+void ExplicitDiffusion::multiply(oops::FieldSet3D & fset) const {
   Increment dx(*geom_, vars_, util::DateTime());
-  dx.fromFieldSet(fset);
+  dx.fromFieldSet(fset.fieldSet());
 
   soca_explicitdiffusion_multiply_f90(keyFortran_, dx.toFortran());
 
-  dx.toFieldSet(fset);
+  dx.toFieldSet(fset.fieldSet());
 }
 
 // --------------------------------------------------------------------------------------
 
-void ExplicitDiffusion::directCalibration(const std::vector<atlas::FieldSet> &) {
+void ExplicitDiffusion::directCalibration(const std::vector<oops::FieldSet3D> &) {
   eckit::LocalConfiguration conf = (*params_.calibration.value()).toConfiguration();
   soca_explicitdiffusion_calibrate_f90(keyFortran_, &conf);
 }

--- a/src/soca/ExplicitDiffusion/ExplicitDiffusion.h
+++ b/src/soca/ExplicitDiffusion/ExplicitDiffusion.h
@@ -39,10 +39,10 @@ class ExplicitDiffusion : public saber::SaberCentralBlockBase {
                     const oops::FieldSet3D &,
                     const oops::FieldSet3D &);
 
-  void randomize(atlas::FieldSet &) const override;
-  void multiply(atlas::FieldSet &) const override;
+  void randomize(oops::FieldSet3D &) const override;
+  void multiply(oops::FieldSet3D &) const override;
 
-  void directCalibration(const std::vector<atlas::FieldSet> &) override;
+  void directCalibration(const std::vector<oops::FieldSet3D> &) override;
   void read() override;
   void write() const override;
 


### PR DESCRIPTION
## Description

Surprisingly, there is now a SABER block in SOCA... I really think it should be part of SABER instead of SOCA to avoid this kind of companion PR.

### Issue(s) addressed

None.

## Testing

None.

## Dependencies

- waiting on https://github.com/JCSDA-internal/oops/pull/2450
- waiting on https://github.com/JCSDA-internal/saber/pull/720


## Build tests with other unsubmitted packages.

build-group=JCSDA-internal/saber#720
build-group=JCSDA-internal/oops#2450
build-group=https://github.com/JCSDA-internal/fv3-jedi/pull/1088