### PR TITLE
disable enshofx

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -645,12 +645,18 @@ soca_add_test( NAME hofx_4d_pseudo
                TEST_DEPENDS test_soca_gridgen
                             test_soca_forecast_mom6 )
 
-  # TODO Re-enable the comparison once that's fixed
-soca_add_test( NAME enshofx
-               EXE  soca_enshofx.x
-               MPI 3
-               NOTRAPFPE
-               TEST_DEPENDS test_soca_gridgen )
+# NOTE, enshofx is disabled because MOM6 always writes out some diagnostic
+# netcdf files (which can't be disabled). This is normally not a problem, except
+# with enshofx, because multiple instances of MOM6 are started under separate
+# MPI_COMMs, causing problems when they all try to write to the same file at the
+# same time. We'll need to take a closer look at MOM6 output when we start
+# dealing with in-core MOM6
+
+# soca_add_test( NAME enshofx
+#                EXE  soca_enshofx.x
+#                MPI 3
+#                NOTRAPFPE
+#                TEST_DEPENDS test_soca_gridgen )
 
 
 # variational methods


### PR DESCRIPTION
## Description
- closes https://github.com/JCSDA-internal/soca/issues/981

Removes the enshofx ctest because it causes problems. We don't use enshofx in the real world anyway
