### PR TITLE
write out bkgerrgodas

### DIFF
--- a/src/soca/LinearVariableChange/BkgErrGodas/soca_bkgerrgodas_mod.F90
+++ b/src/soca/LinearVariableChange/BkgErrGodas/soca_bkgerrgodas_mod.F90
@@ -63,6 +63,7 @@ subroutine soca_bkgerrgodas_setup(self, f_conf, bkg, geom)
 
   type(soca_field), pointer :: field, field_bkg
   integer :: i
+  character(len=:), allocatable :: str
 
   ! Allocate memory for bkgerrgodasor
   call self%std_bkgerr%copy(bkg)
@@ -107,6 +108,12 @@ subroutine soca_bkgerrgodas_setup(self, f_conf, bkg, geom)
 
   ! Apply config bounds to background error
   call self%bounds%apply(self%std_bkgerr)
+
+  ! optionally write out the values
+  if( f_conf%has("output")) then
+    call f_conf%get_or_die("output.filename", str)
+    call self%std_bkgerr%write_file(str)
+  end if
 
 end subroutine soca_bkgerrgodas_setup
 

--- a/test/testinput/3dvar_godas.yml
+++ b/test/testinput/3dvar_godas.yml
@@ -51,6 +51,9 @@ cost function:
         efold_z: 2500.0       # [m]
 
       - linear variable change name: BkgErrGODAS
+        # optionally save the calculated parameters to a file
+        output:
+          filename: data_generated/3dvar_godas/bkgerrgodas.nc
         sst_bgerr_file: data_static/godas_sst_bgerr.nc
         t_min: 0.1
         t_max: 2.0


### PR DESCRIPTION
## Description

I added the capability to write out the calculated parametric background error to a netcdf file.
See the `3dvar_godas` test now.

I still plan on rewriting the bkgerrgodas class, but this will let us know now just how noisy those fields are. I haven't looked yet with the 1/4 deg grid, but I suspect they are very noisy. @Dooruk would you mind taking a look if you have a chance?
