### PR TITLE
Fix bug introduced by recent PR

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -274,7 +274,6 @@ function(soca_add_test)
       ${WORKDIR}/data_static/workdir/${FILENAME}
       ${WORKDIR}/${FILENAME} )
   endforeach()
-  file(WRITE ${WORKDIR}/MOM_override "")
 
   # setup output directory
   file( MAKE_DIRECTORY ${WORKDIR}/data_generated/${ARG_NAME})

--- a/test/Data/72x35x25/input_mom6solo.nml
+++ b/test/Data/72x35x25/input_mom6solo.nml
@@ -1,19 +1,19 @@
  &MOM_input_nml
         output_directory = './',
         input_filename = 'r'
-        restart_input_dir = 'data_static/72x35x25/restarts/',
+        restart_input_dir = 'RESTART_IN/',
         restart_output_dir = 'RESTART/',
-        parameter_filename = 'data_static/72x35x25/MOM_input'
-/
+        parameter_filename = 'data_static/72x35x25/MOM_input',
+                             'MOM_override' /
 
  &diag_manager_nml
  /
 
  &ocean_solo_nml
             months = 0
-            days   = 1
+            days   = 0
             date_init = 2018,4,15,0,0,0,
-            hours = 0
+            hours = 24
             minutes = 0
             seconds = 0
             calendar = 'NOLEAP' /

--- a/test/mom6solo.py
+++ b/test/mom6solo.py
@@ -27,9 +27,6 @@ replacements = {
     'days' : '0',
     'hours': fcst_len
   },
-  'MOM_input_nml' : {
-    'restart_input_dir' : "'RESTART_IN/'",
-  }
 }
 
 # read input file

--- a/test/testinput/forecast_mom6.yml
+++ b/test/testinput/forecast_mom6.yml
@@ -1,4 +1,4 @@
-mom6_input_nml: data_static/72x35x25/input.nml
+mom6_input_nml: data_static/72x35x25/input_mom6solo.nml
 forecast length: PT24H
 initial condition: 
   date: 2018-04-15T00:00:00Z

--- a/test/testinput/forecast_mom6_ens1.yml
+++ b/test/testinput/forecast_mom6_ens1.yml
@@ -1,4 +1,4 @@
-mom6_input_nml: data_static/72x35x25/input.nml
+mom6_input_nml: data_static/72x35x25/input_mom6solo.nml
 forecast length: PT24H
 initial condition:
   date: 2018-04-15T00:00:00Z

--- a/test/testinput/forecast_mom6_ens2.yml
+++ b/test/testinput/forecast_mom6_ens2.yml
@@ -1,4 +1,4 @@
-mom6_input_nml: data_static/72x35x25/input.nml
+mom6_input_nml: data_static/72x35x25/input_mom6solo.nml
 forecast length: PT24H
 initial condition:
   date: 2018-04-15T00:00:00Z

--- a/test/testinput/forecast_mom6_ens3.yml
+++ b/test/testinput/forecast_mom6_ens3.yml
@@ -1,4 +1,4 @@
-mom6_input_nml: data_static/72x35x25/input.nml
+mom6_input_nml: data_static/72x35x25/input_mom6solo.nml
 forecast length: PT24H
 initial condition:
   date: 2018-04-15T00:00:00Z


### PR DESCRIPTION
## Description
- fixes problem created by https://github.com/JCSDA-internal/soca/pull/1026

ctests had been modified so that a 'MOM_override' file is dynamically created, which is needed by the mom6solo forecast. However this broke `coupling` because there was no `MOM_override` file.

I reverted the `input.nml` back to how it was, and instead create a new `input_mom6solo.nml` for use with the stand alone mom6solo forecast ctests. 
(not sure what I was thinking previously, it's cleaner this way anyway.)

build-group=https://github.com/JCSDA-internal/coupling/pull/40