### PR TITLE
Update use of C++ iterator to latest standard

### DIFF
--- a/src/soca/GeometryIterator/GeometryIterator.h
+++ b/src/soca/GeometryIterator/GeometryIterator.h
@@ -29,11 +29,15 @@ namespace soca {
 
 namespace soca {
 // -----------------------------------------------------------------------------
-class GeometryIterator: public std::iterator<std::forward_iterator_tag,
-                                               eckit::geometry::Point3>,
-                          public util::Printable,
+class GeometryIterator:   public util::Printable,
                           private util::ObjectCounter<GeometryIterator> {
  public:
+  typedef std::forward_iterator_tag iterator_category;
+  typedef eckit::geometry::Point3 value_type;
+  typedef ptrdiff_t difference_type;
+  typedef eckit::geometry::Point3 & reference;
+  typedef eckit::geometry::Point3 * pointer;
+
   static const std::string classname() {return "soca::GeometryIterator";}
 
   GeometryIterator(const GeometryIterator &);


### PR DESCRIPTION
## Description

fixes a dozen or so warnings that looked like

```
/home/tsluka/work/soca/bundle/soca/src/soca/../soca/GeometryIterator/GeometryIterator.h:32:37: warning: ‘template<class _Category, class _Tp, class _Distance, class _Pointer, class _Reference> struct std::iterator’ is deprecated [-Wdeprecated-declarations]
   32 | class GeometryIterator: public std::iterator<std::forward_iterator_tag,
      |                                     ^~~~~~~~                                
```

by copying what was done in https://github.com/JCSDA-internal/fv3-jedi/pull/1043


## testing
nothing changes, ctests pass. Compilation warnings go away.