### PR TITLE
Remove Geometry::latlon method

### DIFF
--- a/src/soca/Geometry/Geometry.cc
+++ b/src/soca/Geometry/Geometry.cc
@@ -172,36 +172,5 @@ namespace soca {
     // TODO(Travis): Implement this correctly.
   }
   // -----------------------------------------------------------------------------
-  void Geometry::latlon(std::vector<double> & lats, std::vector<double> & lons,
-      const bool halo) const {
-    // get the number of total grid points (including halo)
-    int gridSizeWithHalo = functionSpace_.size();
-    auto vLonlat = atlas::array::make_view<double, 2>(functionSpace_.lonlat());
-
-    // count the number of owned non-ghost points (isn't there an atlas function for this??)
-    auto vGhost = atlas::array::make_view<int, 1>(functionSpace_.ghost());
-    int gridSizeNoHalo = 0;
-    for (size_t i = 0; i < gridSizeWithHalo; i++) {
-      if (vGhost(i) == 0) gridSizeNoHalo++;
-    }
-
-    // allocate arrays
-    int gridSize = (halo) ? gridSizeWithHalo : gridSizeNoHalo;
-    lons.resize(gridSize);
-    lats.resize(gridSize);
-
-    // fill
-    int idx = 0;
-    for (size_t i=0; i < gridSizeWithHalo; i++) {
-      if (!halo && vGhost(i)) continue;
-      double lon = vLonlat(i, 0);
-      double lat = vLonlat(i, 1);
-      lats[idx] = lat;
-      lons[idx++] = lon;
-    }
-    ASSERT(idx == gridSize);
-  }
-
-  // -----------------------------------------------------------------------------
 
 }  // namespace soca

--- a/src/soca/Geometry/Geometry.h
+++ b/src/soca/Geometry/Geometry.h
@@ -73,8 +73,6 @@ namespace soca {
       const atlas::FieldSet & fields() const {return fields_;}
       atlas::FieldSet & fields() {return fields_;}
 
-      void latlon(std::vector<double> &, std::vector<double> &, const bool) const;
-
    private:
       Geometry(const Geometry &);
       void mask(std::vector<double> &, const bool, const char) const;


### PR DESCRIPTION
## Description

Companion to OOPS PR https://github.com/JCSDA-internal/oops/pull/2628

This companion can be merged anytime after the OOPS PR is merged — it's deleting soca code that OOPS will no longer call.

### Issue(s) addressed

## Testing

Ran soca unit tests on Orion+GNU

## Dependencies

build-group=https://github.com/JCSDA-internal/oops/pull/2628
build-group=https://github.com/JCSDA-internal/saber/pull/844

