### PR TITLE
Update tolerances for ctests on mac

### DIFF
--- a/test/testinput/enspert.yml
+++ b/test/testinput/enspert.yml
@@ -90,4 +90,4 @@ output:
 test:
   reference filename: testref/enspert.test
   test output filename: testoutput/enspert.test
-  float relative tolerance: 1e-7
+  float relative tolerance: 1e-6

--- a/test/testinput/gen_hybrid_linear_model_coeffs.yml
+++ b/test/testinput/gen_hybrid_linear_model_coeffs.yml
@@ -107,4 +107,4 @@ test:
   # landmask into account
   reference filename: testref/gen_hybrid_linear_model_coeffs.test
   test output filename: testoutput/gen_hybrid_linear_model_coeffs.test
-  float absolute tolerance: 1e4
+  float absolute tolerance: 1e7

--- a/test/testinput/parameters_bump_cor_nicas_scales.yml
+++ b/test/testinput/parameters_bump_cor_nicas_scales.yml
@@ -60,3 +60,4 @@ background error:
 test:
   reference filename: testref/parameters_bump_cor_nicas_scales.test
   test output filename: testoutput/parameters_bump_cor_nicas_scales.test
+  float relative tolerance: 1e-5

--- a/test/testinput/setcorscales.yml
+++ b/test/testinput/setcorscales.yml
@@ -46,3 +46,4 @@ rv output:
 test:
   reference filename: testref/setcorscales.test
   test output filename: testoutput/setcorscales.test
+  float relative tolerance: 1e-5


### PR DESCRIPTION
## Description

Updated tolerances for ctests to pass on Mac OS Sonoma with spack stack 1.8.0
Somebody should check if they make sense.
