### PR TITLE
fix soca::readNcAndInterp to only read netcdf file on root PE

### DIFF
--- a/src/soca/Utils/readNcAndInterp.cc
+++ b/src/soca/Utils/readNcAndInterp.cc
@@ -10,6 +10,8 @@
 #include "atlas/interpolation/Interpolation.h"
 #include "atlas/util/Point.h"
 
+#include "oops/util/Timer.h"
+
 #include "soca/Utils/readNcAndInterp.h"
 
 
@@ -19,6 +21,8 @@ atlas::FieldSet readNcAndInterp(
     const std::string & filename,
     const std::vector<std::string> & vars,
     const atlas::FunctionSpace & dstFunctionSpace ) {
+  util::Timer timer("soca::readNcAndInterp", "readNcAndInterp");
+
   atlas::FieldSet fieldSet;
 
   int ncid;

--- a/src/soca/Utils/readNcAndInterp.h
+++ b/src/soca/Utils/readNcAndInterp.h
@@ -17,7 +17,7 @@ namespace soca
 /// @brief Read a netCDF file and interpolate the values to the destination atlas FunctionSpace.
 ///
 /// It is assumed that variables in the input file are all 1D, and that "latitude" and "longitude"
-/// variables are present in addition to the variables listed in `vars`
+/// variables are present in addition to the variables listed in `vars`. All  resulting fields are 2D
 ///
 /// @param filename The name of the netCDF file to read.
 /// @param vars A list of variable names to read in and process

--- a/src/soca/Utils/readNcAndInterp.h
+++ b/src/soca/Utils/readNcAndInterp.h
@@ -17,7 +17,8 @@ namespace soca
 /// @brief Read a netCDF file and interpolate the values to the destination atlas FunctionSpace.
 ///
 /// It is assumed that variables in the input file are all 1D, and that "latitude" and "longitude"
-/// variables are present in addition to the variables listed in `vars`. All  resulting fields are 2D
+/// variables are present in addition to the variables listed in `vars`. All
+/// resulting fields are 2D
 ///
 /// @param filename The name of the netCDF file to read.
 /// @param vars A list of variable names to read in and process


### PR DESCRIPTION
## Description
- fixes https://github.com/JCSDA-internal/soca/issues/1067

Reading the netcdf file for the Rossby radius file was done on every PE. This caused gridgen to go slow when many PEs were used on the HPC. Not a big deal, since gridgen is only run once, but this function is going to be used in the C++ refactored saber blocks, so it was noticeable there.

This fixes the problem by only reading the netcdf file on the root PE, and broadcasting to all other PEs.

## Testing

There is no change in behavior (other than running slightly faster when lots of PEs used)
