### PR TITLE
Model variable naming code sprint: part 5

### DIFF
--- a/test/Data/fields_metadata.yml
+++ b/test/Data/fields_metadata.yml
@@ -210,7 +210,7 @@
   constant value: 6
 
 - name: pres
-  getval name: surface_pressure
+  getval name: air_pressure_at_surface
   constant value: 999
 
 - name: rh


### PR DESCRIPTION
## Description

Renaming `surface_pressure` -> `air_pressure_at_surface`.

build-group=https://github.com/JCSDA-internal/vader/pull/274
build-group=https://github.com/JCSDA-internal/saber/pull/947
build-group=https://github.com/JCSDA-internal/ufo-data/pull/449
build-group=https://github.com/JCSDA-internal/ufo/pull/3476
build-group=https://github.com/JCSDA-internal/mpas-jedi/pull/1017
build-group=https://github.com/JCSDA-internal/fv3-jedi/pull/1278
build-group=https://github.com/MetOffice/opsinputs/pull/226
build-group=https://github.com/JCSDA-internal/ops-um-jedi/pull/234
build-group=https://github.com/JCSDA-internal/lfric-jedi/pull/906

## Testing

I didn't run tests, I'm relying on CI. 🙀 