### PR TITLE
replace rossrad.dat with rossrad.nc (#1083)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 *.nc filter=lfs diff=lfs merge=lfs -text
 *.nc4 filter=lfs diff=lfs merge=lfs -text
-test/Data/rossrad.nc filter=lfs diff=lfs merge=lfs -text
 *.pt filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 *.nc filter=lfs diff=lfs merge=lfs -text
 *.nc4 filter=lfs diff=lfs merge=lfs -text
-test/Data/rossrad.dat filter=lfs diff=lfs merge=lfs -text
+test/Data/rossrad.nc filter=lfs diff=lfs merge=lfs -text
 *.pt filter=lfs diff=lfs merge=lfs -text

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -185,7 +185,7 @@ install(FILES ${soca_install_model_input}
         DESTINATION ${INSTALL_DATA_DIR}/testdata/72x35x25/INPUT/ )
 
 set( soca_install_data
-  Data/rossrad.dat
+  Data/rossrad.nc
   Data/godas_sst_bgerr.nc )
 install(FILES ${soca_install_data}
         DESTINATION ${INSTALL_DATA_DIR}/testdata/ )

--- a/tutorial/tutorial_tools.sh
+++ b/tutorial/tutorial_tools.sh
@@ -26,7 +26,7 @@ function mom6_soca_static() {
     cp $datadir/Data/72x35x25/MOM_input .
     ln -sf $datadir/Data/fields_metadata.yml .
     ln -sf $datadir/Data/72x35x25/*_table .
-    ln -sf $datadir/Data/rossrad.dat .
+    ln -sf $datadir/Data/rossrad.nc .
     ln -sf $datadir/Data/godas_sst_bgerr.nc .
 }
 


### PR DESCRIPTION
## Description

Three files reference `rossrad.dat` whereas `test/Data` contains `rossrad.nc`.  This PR replaces the three occurrences of `rossrad.dat` with `rossrad.nc`.


### Issue(s) addressed
- fixes #1083 


## Testing

to be done



## Dependencies

none

