### PR TITLE
No param inheritance from OOPS in change vars

### DIFF
--- a/src/soca/LinearVariableChange/Base/LinearVariableChangeBase.h
+++ b/src/soca/LinearVariableChange/Base/LinearVariableChangeBase.h
@@ -14,7 +14,7 @@
 
 #include <boost/noncopyable.hpp>
 
-#include "oops/base/LinearVariableChangeParametersBase.h"
+#include "oops/base/ParameterTraitsVariables.h"
 #include "oops/base/Variables.h"
 #include "oops/util/AssociativeContainers.h"
 #include "oops/util/parameters/ConfigurationParameter.h"
@@ -32,13 +32,12 @@ namespace soca {
 
 // -----------------------------------------------------------------------------
 
-class LinearVariableChangeParametersBase :
-                               public oops::LinearVariableChangeParametersBase {
-  OOPS_ABSTRACT_PARAMETERS(LinearVariableChangeParametersBase,
-                                       oops::LinearVariableChangeParametersBase)
+class LinearVariableChangeParametersBase : public oops::Parameters {
+  OOPS_ABSTRACT_PARAMETERS(LinearVariableChangeParametersBase, oops::Parameters)
  public:
-  oops::OptionalParameter<std::string>
-                                      name{"linear variable change name", this};
+  oops::OptionalParameter<oops::Variables> inputVariables{"input variables", this};
+  oops::OptionalParameter<oops::Variables> outputVariables{"output variables", this};
+  oops::OptionalParameter<std::string> name{"linear variable change name", this};
 };
 
 // -----------------------------------------------------------------------------

--- a/src/soca/LinearVariableChange/LinearVariableChange.h
+++ b/src/soca/LinearVariableChange/LinearVariableChange.h
@@ -14,7 +14,8 @@
 
 #include <boost/ptr_container/ptr_vector.hpp>
 
-#include "oops/base/LinearVariableChangeParametersBase.h"
+#include "oops/base/ParameterTraitsVariables.h"
+#include "oops/base/Variables.h"
 #include "oops/util/parameters/OptionalParameter.h"
 #include "oops/util/parameters/Parameter.h"
 #include "oops/util/parameters/Parameters.h"
@@ -30,11 +31,11 @@ class State;
 
 // -----------------------------------------------------------------------------
 
-class LinearVariableChangeParameters :
-  public oops::LinearVariableChangeParametersBase {
-  OOPS_CONCRETE_PARAMETERS(LinearVariableChangeParameters,
-                           oops::LinearVariableChangeParametersBase)
+class LinearVariableChangeParameters : public oops::Parameters {
+  OOPS_CONCRETE_PARAMETERS(LinearVariableChangeParameters, oops::Parameters)
  public:
+  oops::OptionalParameter<oops::Variables> inputVariables{"input variables", this};
+  oops::OptionalParameter<oops::Variables> outputVariables{"output variables", this};
   oops::OptionalParameter<std::vector<LinearVariableChangeParametersWrapper>>
          linearVariableChangesWrapper{"linear variable changes", this};
 };

--- a/src/soca/VariableChange/Base/VariableChangeBase.h
+++ b/src/soca/VariableChange/Base/VariableChangeBase.h
@@ -14,7 +14,7 @@
 
 #include <boost/noncopyable.hpp>
 
-#include "oops/base/VariableChangeParametersBase.h"
+#include "oops/base/ParameterTraitsVariables.h"
 #include "oops/base/Variables.h"
 #include "oops/util/AssociativeContainers.h"
 #include "oops/util/parameters/ConfigurationParameter.h"
@@ -31,10 +31,11 @@ namespace soca {
 
 // -----------------------------------------------------------------------------
 
-class VariableChangeParametersBase : public oops::VariableChangeParametersBase {
-  OOPS_ABSTRACT_PARAMETERS(VariableChangeParametersBase,
-                           oops::VariableChangeParametersBase)
+class VariableChangeParametersBase : public oops::Parameters {
+  OOPS_ABSTRACT_PARAMETERS(VariableChangeParametersBase, oops::Parameters)
  public:
+  oops::OptionalParameter<oops::Variables> inputVariables{"input variables", this};
+  oops::OptionalParameter<oops::Variables> outputVariables{"output variables", this};
   oops::OptionalParameter<std::string> name{"variable change name", this};
 };
 

--- a/src/soca/VariableChange/VariableChange.h
+++ b/src/soca/VariableChange/VariableChange.h
@@ -13,7 +13,6 @@
 
 #include <boost/ptr_container/ptr_vector.hpp>
 
-#include "oops/base/VariableChangeParametersBase.h"
 #include "oops/util/parameters/Parameter.h"
 #include "oops/util/parameters/Parameters.h"
 #include "oops/util/Printable.h"
@@ -29,9 +28,8 @@ namespace soca {
 
 // -----------------------------------------------------------------------------
 
-class VariableChangeParameters : public oops::VariableChangeParametersBase {
-  OOPS_CONCRETE_PARAMETERS(VariableChangeParameters,
-                           oops::VariableChangeParametersBase)
+class VariableChangeParameters : public oops::Parameters {
+  OOPS_CONCRETE_PARAMETERS(VariableChangeParameters, oops::Parameters)
  public:
   // Wrapper to VariableChange parameters
   VariableChangeParametersWrapper variableChangeParametersWrapper{this};


### PR DESCRIPTION
## Description

No Parameters inheritance from OOPS in change of variables
`VariableChangeParametersBase` and `LinearVariableChangeParametersBase` will be removed from OOPS.

## Impact

No expected impact

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR