### PR TITLE
Improve Soca2Cice (use icepack to cleanup after rescaling)

### DIFF
--- a/src/soca/VariableChange/Soca2Cice/Soca2Cice.F90
+++ b/src/soca/VariableChange/Soca2Cice/Soca2Cice.F90
@@ -77,7 +77,10 @@ subroutine soca_soca2cice_setup_f90(c_key_self, c_conf, c_key_geom) &
   call f_conf%get_or_die("antarctic.rescale prior.rescale", self%antarctic%rescale_prior)
   call f_conf%get_or_die("antarctic.rescale prior.min hice", self%antarctic%rescale_min_hice)
   call f_conf%get_or_die("antarctic.rescale prior.min hsno", self%antarctic%rescale_min_hsno)
-
+  ! icepack time step for rebinning
+  call f_conf%get_or_die("icepack time step", self%dt)
+  ! shuffle stencil size
+  call f_conf%get_or_die("shuffle stencil size", self%shuffle_n)
   ! cice input restart
   call f_conf%get_or_die("cice background state.restart", self%rst_filename)
 

--- a/src/soca/VariableChange/Soca2Cice/Soca2Cice.h
+++ b/src/soca/VariableChange/Soca2Cice/Soca2Cice.h
@@ -81,6 +81,10 @@ class Soca2Cice: public VariableChangeBase {
     oops::RequiredParameter<OutputParameters> output{"cice output", this};
     oops::RequiredParameter<RedistributionParameters> arctic{"arctic", this};
     oops::RequiredParameter<RedistributionParameters> antarctic{"antarctic", this};
+    oops::Parameter<float> icepackTstep{"icepack time step",
+            "icepack time step used for thickness categories rebinning", 300, this};
+    oops::Parameter<int> shuffleStencilSize{"shuffle stencil size",
+            "stencil size used in the shuffle search", 9, this, {oops::minConstraint(9)}};
   };
 
   const std::string classname() {return "soca::Soca2Cice";}

--- a/src/soca/VariableChange/Soca2Cice/soca_ciceutils_mod.F90
+++ b/src/soca/VariableChange/Soca2Cice/soca_ciceutils_mod.F90
@@ -32,18 +32,18 @@ type, public :: cice_state
    logical :: initialized = .false.
    character(len=:), allocatable :: rst_filename
    character(len=:), allocatable :: rst_out_filename
-   real(kind=kind_real),  allocatable :: aicen(:,:,:)
-   real(kind=kind_real),  allocatable :: vicen(:,:,:)
-   real(kind=kind_real),  allocatable :: vsnon(:,:,:)
-   real(kind=kind_real),  allocatable :: apnd(:,:,:)
-   real(kind=kind_real),  allocatable :: hpnd(:,:,:)
-   real(kind=kind_real),  allocatable :: ipnd(:,:,:)
-   real(kind=kind_real),  allocatable :: tsfcn(:,:,:)
-   real(kind=kind_real),  allocatable :: qice(:,:,:,:)
-   real(kind=kind_real),  allocatable :: qsno(:,:,:,:)
-   real(kind=kind_real),  allocatable :: sice(:,:,:,:)
+   real(kind=kind_real),  allocatable :: aicen(:,:,:)    ! ice concentration
+   real(kind=kind_real),  allocatable :: vicen(:,:,:)    ! ice volume
+   real(kind=kind_real),  allocatable :: vsnon(:,:,:)    ! snow volume
+   real(kind=kind_real),  allocatable :: apnd(:,:,:)     ! melt pond area fraction
+   real(kind=kind_real),  allocatable :: hpnd(:,:,:)     ! melt pond depth
+   real(kind=kind_real),  allocatable :: ipnd(:,:,:)     ! melt pond refrozen lid thickness
+   real(kind=kind_real),  allocatable :: tsfcn(:,:,:)    ! ice/snow temperature
+   real(kind=kind_real),  allocatable :: qice(:,:,:,:)   ! volume-weighted ice enthalpy
+   real(kind=kind_real),  allocatable :: qsno(:,:,:,:)   ! volume-weighted snow enthalpy
+   real(kind=kind_real),  allocatable :: sice(:,:,:,:)   ! volume-weighted ice bulk salinity
    real(kind=kind_real),  allocatable :: iceumask(:,:)
-   real(kind=kind_real),  allocatable :: aice(:,:)
+   real(kind=kind_real),  allocatable :: aice(:,:)       ! total ice concentration
    type(agg_cice_state):: agg
 contains
   procedure :: init => soca_ciceutils_init

--- a/src/soca/VariableChange/Soca2Cice/soca_soca2cice_mod.F90
+++ b/src/soca/VariableChange/Soca2Cice/soca_soca2cice_mod.F90
@@ -11,12 +11,12 @@ use fckit_exception_module, only: fckit_exception
 use fckit_mpi_module, only: fckit_mpi_comm
 use kinds, only: kind_real
 
-use icepack_itd
-use icepack_mushy_physics, only: liquidus_temperature_mush
-use icepack_therm_shared, only: l_brine, icepack_ice_temperature
+use icepack_itd, only: icepack_init_itd, cleanup_itd
+use icepack_warnings, only: icepack_warnings_flush
+use icepack_tracers, only: icepack_init_tracer_indices, nt_tsfc, nt_qice, nt_qsno, nt_sice
 use icepack_parameters, only: icepack_init_parameters, icepack_recompute_constants
 use icepack_parameters, only: ktherm, heat_capacity
-use icepack_parameters, only: rhos, Lfresh, cp_ice
+use icepack_therm_shared, only: l_brine
 
 use soca_geom_mod, only: soca_geom
 use soca_state_mod, only: soca_state
@@ -269,12 +269,22 @@ subroutine cleanup_ice(self, geom, xm)
   type(soca_geom), target, intent(in)  :: geom
   type(soca_state),      intent(inout) :: xm
 
-  integer :: i, j, k, n, n_src
+  integer :: i, j, k, n, n_src, ntracers
+  integer :: nt_tsfc_in, nt_qice_in, nt_qsno_in, nt_sice_in
+  real(kind=kind_real) :: aice, aice0
   type(soca_field), pointer :: t_ana, s_ana, aice_ana, hice_ana, hsno_ana
-
+  real(kind=kind_real) :: dt
   real(kind=kind_real), allocatable :: h_bounds(:)
-  real(kind=kind_real), allocatable :: zTin(:), zTsn(:), temp_sno_test
+  real(kind=kind_real), allocatable :: tracers(:,:)   ! (ntracers, ncat)
+  logical, allocatable :: first_ice(:)                ! (ncat) ! For bgc and S tracers. set to true if zapping ice.
+  integer, allocatable :: trcr_depend(:)              ! (ntracers), = 0 for aicen tracers, 1 for vicen, 2 for vsnon
+  real(kind=kind_real), allocatable :: trcr_base(:,:) ! (ntracers, 3);  = 0 or 1 depending on tracer dependency
+                                                      ! argument 2:  (1) aice, (2) vice, (3) vsno
+  integer, allocatable :: n_trcr_strata(:)            ! number of underlying tracer layers
+  integer, allocatable :: nt_strata(:,:)              ! indices of underlying tracer layers
+  real(kind=kind_real), allocatable :: fiso_ocn(:)    ! isotope flux to ocean     (kg/m^2/s)
 
+  dt = 900.0 ! randomly chosen
   ! pointers to soca fields (most likely an analysis)
   call xm%get("sea_water_potential_temperature",t_ana)
   call xm%get("sea_water_salinity",s_ana)
@@ -285,57 +295,63 @@ subroutine cleanup_ice(self, geom, xm)
   ! get thickness category bounds
   allocate(h_bounds(0:self%ncat))
   call icepack_init_itd(self%ncat, h_bounds) ! TODO (G): move that in setup
+  ! initialize tracers (ice/snow temperature, ice and snow enthalpies, ice salinity)
+  ntracers = 4
+  allocate(tracers(1+2*self%ice_lev+self%sno_lev, self%ncat))
+  allocate(trcr_depend(ntracers), trcr_base(ntracers, 3))
+  allocate(n_trcr_strata(ntracers), nt_strata(ntracers, max(self%ice_lev, self%sno_lev)))
+  trcr_base(:, :) = 0.0
+  trcr_depend(1) = 0; trcr_base(1, 1) = 1.0 ! Tsfcn is ice area tracer
+  trcr_depend(2) = 1; trcr_base(2, 2) = 1.0 ! qice is ice volume tracer
+  trcr_depend(3) = 2; trcr_base(3, 3) = 1.0 ! qsno is snow volume tracer
+  trcr_depend(4) = 1; trcr_base(4, 2) = 1.0 ! sice is ice volume tracer
 
-  ! TODO (G): re-bin sea-ice that is out of the thickness category
+  nt_tsfc_in = 1
+  n_trcr_strata(1) = 1                      ! Tsfcn is 1 level
+  nt_strata(1, 1) = nt_tsfc_in
 
-  ! reset sea-ice where ice fraction of the category is 0
-  ! and check/fix snow temperature
-  allocate(zTin(self%ice_lev), zTsn(self%sno_lev))
+  nt_qice_in = nt_tsfc_in + 1
+  n_trcr_strata(2) = self%ice_lev           ! qice is ice_lev levels
+  nt_strata(2, 1:self%ice_lev) = [(nt_qice_in + i - 1, i = 1, self%ice_lev)]
+
+  nt_qsno_in = nt_qice_in + self%ice_lev
+  n_trcr_strata(3) = self%sno_lev           ! qsno is sno_lev levels
+  nt_strata(3, 1:self%sno_lev) = [(nt_qsno_in + i - 1, i = 1, self%sno_lev)]
+
+  nt_sice_in = nt_qsno_in + self%sno_lev
+  n_trcr_strata(4) = self%ice_lev           ! sice is ice_lev levels
+  nt_strata(4, 1:self%ice_lev) = [(nt_sice_in + i - 1, i = 1, self%ice_lev)]
+  call icepack_init_tracer_indices(nt_tsfc_in=nt_tsfc_in, nt_qice_in=nt_qice_in, &
+                                   nt_qsno_in=nt_qsno_in, nt_sice_in=nt_sice_in)
+  allocate(first_ice(self%ncat))
+  first_ice(:) = .true.
+
   do i = geom%isc, geom%iec
      do j = geom%jsc, geom%jec
-        if (aice_ana%val(i,j,1).eq.0.0_kind_real) cycle
-
-        do k = 1, self%ncat
-           ! zero out enthalpy if no ice
-           if (self%cice%aicen(i,j,k).eq.0.0_kind_real) then
-              self%cice%vicen(i,j,k) = 0_kind_real
-              self%cice%vsnon(i,j,k) = 0_kind_real
-
-              self%cice%apnd(i,j,k) = 0_kind_real
-              self%cice%hpnd(i,j,k) = 0_kind_real
-              self%cice%ipnd(i,j,k) = 0_kind_real
-
-              self%cice%qice(i,j,k,:) = 0_kind_real
-              self%cice%sice(i,j,k,:) = 0_kind_real
-              self%cice%qsno(i,j,k,:) = 0_kind_real
-
-              self%cice%tsfcn(i,j,k) = liquidus_temperature_mush(s_ana%val(i,j,1))
-           else
-              ! Check snow temperature and adjust if out of wack
-              ! for future ref, vertical geometry from top to bottom:
-              ! T surface                (tsfcn)
-              ! T snow level 1           (from qsno)
-              ! ...
-              ! T snow level sno_lev
-              ! T ice level 1            (from qice)
-              ! ...
-              ! T ice level ice_lev
-              ! Ocean T level 1          (from MOM)
-              do n = 1, self%ice_lev
-                 zTin(n) = icepack_ice_temperature(self%cice%qice(i,j,k,n), self%cice%sice(i,j,k,n))
-              end do
-              zTsn(1) = (Lfresh + self%cice%qsno(i,j,k,1)/rhos)/cp_ice
-              temp_sno_test = 0.5_kind_real*(self%cice%tsfcn(i,j,k) + zTin(1))
-
-              ! TODO (G): the 2 deg departure check is pulled out of thin ice ... or somethin' move
-              !           to config?
-              if (abs(zTsn(1)-temp_sno_test).lt.2.0_kind_real) cycle
-
-              ! if we're here, there's a problem with snow, "fix" it!
-              self%cice%qsno(i,j,k,1) = rhos*(temp_sno_test*cp_ice - Lfresh)
-
-           end if
-        end do
+        ! setup tracers at this gridpoint
+        tracers(nt_tsfc,:) = self%cice%tsfcn(i,j,:)
+        do k = 1, self%ice_lev
+          tracers(nt_qice+k-1, :) = self%cice%qice(i,j,:,k)
+          tracers(nt_sice+k-1, :) = self%cice%sice(i,j,:,k)
+        enddo
+        do k = 1, self%sno_lev
+          tracers(nt_qsno+k-1, :) = self%cice%qsno(i,j,:,k)
+        enddo
+        ! call icepack_cleanup_itd: rebins thickness categories if necessary,
+        ! eliminates very small ice areas while conserving mass and energy
+        call cleanup_itd(dt, ntracers, self%ice_lev, self%sno_lev, self%ncat, &
+                         h_bounds, self%cice%aicen(i,j,:), tracers, &
+                         self%cice%vicen(i,j,:), self%cice%vsnon(i,j,:), &
+                         ! ice and total water concentration are computed in the call using aicen
+                         aice, aice0, &
+                         ! number of aerosol tracers, bio tracers, bio layers
+                         0, 0, 0, &
+                         ! aerosol flag, topo pond flag, heat capacity flag, flag for zapping ice for bgc and s tracers
+                         .false., .false., .true., first_ice, &
+                         ! tracer indices and sizes used in rebinning
+                         trcr_depend, trcr_base, n_trcr_strata, nt_strata, &
+                         fiso_ocn=fiso_ocn)
+        call icepack_warnings_flush(6)
      end do
   end do
 
@@ -347,6 +363,8 @@ subroutine cleanup_ice(self, geom, xm)
         hsno_ana%val(i,j,1) = sum(self%cice%vsnon(i,j,:))
      end do
   end do
+
+  deallocate(h_bounds, tracers, trcr_depend, trcr_base, n_trcr_strata, nt_strata, first_ice)
 
 end subroutine cleanup_ice
 
@@ -380,7 +398,7 @@ subroutine prior_dist_rescale(self, geom, xm)
           rescale_min_hice = self%antarctic%rescale_min_hice
           rescale_min_hsno = self%antarctic%rescale_min_hsno
         endif
-        if (self%cice%aice(i,j).lt.seaice_edge) cycle ! Only rescale within the icepack
+        if (self%cice%aice(i,j).le.seaice_edge) cycle ! Only rescale within the icepack
 
         ! rescale background to match aggregate ice concentration analysis
         alpha = aice_ana%val(i,j,1)/self%cice%aice(i,j)

--- a/src/soca/VariableChange/Soca2Cice/soca_soca2cice_mod.F90
+++ b/src/soca/VariableChange/Soca2Cice/soca_soca2cice_mod.F90
@@ -12,10 +12,11 @@ use fckit_mpi_module, only: fckit_mpi_comm
 use kinds, only: kind_real
 
 use icepack_itd, only: icepack_init_itd, cleanup_itd
-use icepack_warnings, only: icepack_warnings_flush
+use icepack_warnings, only: icepack_warnings_flush, icepack_warnings_aborted
 use icepack_tracers, only: icepack_init_tracer_indices, nt_tsfc, nt_qice, nt_qsno, nt_sice
 use icepack_parameters, only: icepack_init_parameters, icepack_recompute_constants
 use icepack_parameters, only: ktherm, heat_capacity
+use icepack_mushy_physics, only: liquidus_temperature_mush
 use icepack_therm_shared, only: l_brine
 
 use soca_geom_mod, only: soca_geom
@@ -47,7 +48,8 @@ end type soca_soca2cice_params
 type, public :: soca_soca2cice
    type(fckit_mpi_comm) :: f_comm
    integer :: myrank
-   integer :: ncat, ni, nj, ice_lev, sno_lev
+   integer :: ncat, ni, nj, ice_lev, sno_lev, shuffle_n
+   real(kind=kind_real) :: dt
    character(len=:), allocatable :: rst_filename
    character(len=:), allocatable :: rst_out_filename
    type(cice_state) :: cice
@@ -75,16 +77,6 @@ subroutine soca_soca2cice_setup(self, geom)
   class(soca_soca2cice), intent(inout) :: self
   type(soca_geom), target, intent(in)  :: geom !< geometry
 
-  integer(kind=4) :: ncid
-  integer(kind=4) :: dimid
-  integer(kind=4) :: varid
-
-  integer :: myrank, root=0, count
-  real(kind=kind_real), allocatable :: buffer(:)
-
-  real(kind=kind_real) :: aice, aice0
-  integer, allocatable :: ij(:,:)
-  integer :: l, n_src, i, j, n
   type(atlas_geometry) :: ageometry
 
   ! Communicator
@@ -159,9 +151,6 @@ subroutine check_ice_bounds(self, geom, xm)
   type(soca_state),      intent(inout) :: xm
 
   type(soca_field), pointer :: aice_ana, hice_ana, hsno_ana
-  integer :: i, j
-  real(kind=kind_real) :: hice
-  real(kind=kind_real) :: hice_max = 8.0
 
   ! pointers to soca fields (most likely an analysis)
   call xm%get("sea_ice_area_fraction",aice_ana)
@@ -198,18 +187,17 @@ subroutine shuffle_ice(self, geom, xm)
 
   real(kind=kind_real) :: aice, seaice_edge
   integer :: i, j, k, n, ii, jj
-  type(soca_field), pointer :: t_ana, s_ana, aice_ana
+  type(soca_field), pointer :: s_ana, aice_ana
   integer :: minidx(1), nn_max
   integer, allocatable :: idx(:)
   real(kind=kind_real), allocatable :: testmin(:)
   type(cice_state) :: cice_in
 
   ! Make sure the search tree is smaller than the data size
-  nn_max = min(self%cice%agg%n_src, 9)
+  nn_max = min(self%cice%agg%n_src, self%shuffle_n)
   allocate(idx(nn_max), testmin(nn_max))
 
   ! pointers to soca fields (most likely an analysis)
-  call xm%get("sea_water_potential_temperature",t_ana)
   call xm%get("sea_water_salinity",s_ana)
   call xm%get("sea_ice_area_fraction",aice_ana)
 
@@ -228,7 +216,18 @@ subroutine shuffle_ice(self, geom, xm)
           seaice_edge = self%antarctic%seaice_edge
         endif
         if (self%cice%aice(i,j).gt.seaice_edge) cycle     ! skip if the background has more ice than the threshold
-        if (aice.le.0.0_kind_real) cycle                  ! 0 ice analysis is treated elsewhere
+        if (aice.le.0.0_kind_real) then
+           self%cice%aicen(i,j,:) = 0_kind_real
+           self%cice%vicen(i,j,:) = 0_kind_real
+           self%cice%vsnon(i,j,:) = 0_kind_real
+           self%cice%apnd(i,j,:) = 0_kind_real
+           self%cice%hpnd(i,j,:) = 0_kind_real
+           self%cice%ipnd(i,j,:) = 0_kind_real
+           self%cice%qice(i,j,:,:) = 0_kind_real
+           self%cice%sice(i,j,:,:) = 0_kind_real
+           self%cice%qsno(i,j,:,:) = 0_kind_real
+           self%cice%tsfcn(i,j,:) = liquidus_temperature_mush(s_ana%val(i,j,1))
+        endif
         if (self%cice%agg%n_src == 0) cycle               ! skip if there are no points on this task with ice in the background
         ! find neighbors. TODO (G): add constraint for thickness and snow depth as well
         call self%kdtree%closestPoints(geom%lon(i,j), geom%lat(i,j), nn_max, idx)
@@ -269,11 +268,10 @@ subroutine cleanup_ice(self, geom, xm)
   type(soca_geom), target, intent(in)  :: geom
   type(soca_state),      intent(inout) :: xm
 
-  integer :: i, j, k, n, n_src, ntracers
+  integer :: i, j, k, ntracers
   integer :: nt_tsfc_in, nt_qice_in, nt_qsno_in, nt_sice_in
   real(kind=kind_real) :: aice, aice0
   type(soca_field), pointer :: t_ana, s_ana, aice_ana, hice_ana, hsno_ana
-  real(kind=kind_real) :: dt
   real(kind=kind_real), allocatable :: h_bounds(:)
   real(kind=kind_real), allocatable :: tracers(:,:)   ! (ntracers, ncat)
   logical, allocatable :: first_ice(:)                ! (ncat) ! For bgc and S tracers. set to true if zapping ice.
@@ -282,9 +280,9 @@ subroutine cleanup_ice(self, geom, xm)
                                                       ! argument 2:  (1) aice, (2) vice, (3) vsno
   integer, allocatable :: n_trcr_strata(:)            ! number of underlying tracer layers
   integer, allocatable :: nt_strata(:,:)              ! indices of underlying tracer layers
-  real(kind=kind_real), allocatable :: fiso_ocn(:)    ! isotope flux to ocean     (kg/m^2/s)
+  real(kind=kind_real), allocatable :: fiso_ocn(:)    ! isotope flux to ocean, not used as long as icepack's
+                                                      ! tr_iso is false (default), so not initialized here.
 
-  dt = 900.0 ! randomly chosen
   ! pointers to soca fields (most likely an analysis)
   call xm%get("sea_water_potential_temperature",t_ana)
   call xm%get("sea_water_salinity",s_ana)
@@ -339,7 +337,7 @@ subroutine cleanup_ice(self, geom, xm)
         enddo
         ! call icepack_cleanup_itd: rebins thickness categories if necessary,
         ! eliminates very small ice areas while conserving mass and energy
-        call cleanup_itd(dt, ntracers, self%ice_lev, self%sno_lev, self%ncat, &
+        call cleanup_itd(self%dt, ntracers, self%ice_lev, self%sno_lev, self%ncat, &
                          h_bounds, self%cice%aicen(i,j,:), tracers, &
                          self%cice%vicen(i,j,:), self%cice%vsnon(i,j,:), &
                          ! ice and total water concentration are computed in the call using aicen
@@ -352,12 +350,10 @@ subroutine cleanup_ice(self, geom, xm)
                          trcr_depend, trcr_base, n_trcr_strata, nt_strata, &
                          fiso_ocn=fiso_ocn)
         call icepack_warnings_flush(6)
-     end do
-  end do
-
-  ! re-compute aggregates = analysis that is effectively inserted in the restart
-  do i = geom%isc, geom%iec
-     do j = geom%jsc, geom%jec
+        if (icepack_warnings_aborted()) then
+           call abor1_ftn("Soca2Cice: icepack aborted during cleanup_itd")
+        endif
+        ! re-compute aggregates = analysis that is effectively inserted in the restart
         aice_ana%val(i,j,1) = sum(self%cice%aicen(i,j,:))
         hice_ana%val(i,j,1) = sum(self%cice%vicen(i,j,:))
         hsno_ana%val(i,j,1) = sum(self%cice%vsnon(i,j,:))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -796,7 +796,7 @@ if( ${icepack_FOUND} )
        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/data_generated/convertstate_soca2cice/ )
      soca_add_test( NAME convertstate_soca2cice
                     EXE  soca_convertstate.x
-                    MPI 2
+                    MPI 1
                     NOTRAPFPE
                     TEST_DEPENDS test_soca_gridgen
                                  test_soca_3dvar )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -796,7 +796,7 @@ if( ${icepack_FOUND} )
        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/data_generated/convertstate_soca2cice/ )
      soca_add_test( NAME convertstate_soca2cice
                     EXE  soca_convertstate.x
-                    MPI 1
+                    MPI 2
                     NOTRAPFPE
                     TEST_DEPENDS test_soca_gridgen
                                  test_soca_3dvar )

--- a/test/testref/convertstate_soca2cice.test
+++ b/test/testref/convertstate_soca2cice.test
@@ -1,27 +1,27 @@
 Input state: 
   Valid time: 2018-04-15T00:00:00Z
-sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772900527789
-             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897729602
-       sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642064969300
+sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772900527558
+             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897728181
+       sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642065405004
           sea_ice_area_fraction   min=-0.0001291896179326   max=1.0000039848914242   mean=0.1175172743974210
-              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246947   mean=0.4712515705773916
+              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246947   mean=0.4712515705773919
          sea_ice_snow_thickness   min=0.0000000000000000   max=1.2712833951042413   mean=0.0886865877527975
 Variable transform: 
 Variable change from: 6 variables: sea_water_potential_temperature, sea_water_salinity, sea_water_cell_thickness, sea_ice_area_fraction, sea_ice_thickness, sea_ice_snow_thickness
 Variable change to: 6 variables: sea_water_potential_temperature, sea_water_salinity, sea_water_cell_thickness, sea_ice_area_fraction, sea_ice_thickness, sea_ice_snow_thickness
 State after variable transform: 
   Valid time: 2018-04-15T00:00:00Z
-sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772900527789
-             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897729602
-       sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642064969300
-          sea_ice_area_fraction   min=0.0000000000000000   max=1.0000000000000002   mean=0.1167399140259270
-              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246938   mean=0.2834655186435748
-         sea_ice_snow_thickness   min=0.0000000000000000   max=1.2712833951042413   mean=0.0433887838705210
+sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772900527558
+             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897728181
+       sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642065405004
+          sea_ice_area_fraction   min=0.0000000000000000   max=1.0000000000000000   mean=0.1164131299079067
+              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246938   mean=0.2837213547153729
+         sea_ice_snow_thickness   min=0.0000000000000000   max=0.0000000000000000   mean=0.0000000000000000
 Output state: 
   Valid time: 2018-04-15T00:00:00Z
-sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772900527789
-             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897729602
-       sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642064969300
-          sea_ice_area_fraction   min=0.0000000000000000   max=1.0000000000000002   mean=0.1167399140259270
-              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246938   mean=0.2834655186435748
-         sea_ice_snow_thickness   min=0.0000000000000000   max=1.2712833951042413   mean=0.0433887838705210
+sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772900527558
+             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897728181
+       sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642065405004
+          sea_ice_area_fraction   min=0.0000000000000000   max=1.0000000000000000   mean=0.1164131299079067
+              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246938   mean=0.2837213547153729
+         sea_ice_snow_thickness   min=0.0000000000000000   max=0.0000000000000000   mean=0.0000000000000000

--- a/test/testref/convertstate_soca2cice.test
+++ b/test/testref/convertstate_soca2cice.test
@@ -1,27 +1,27 @@
 Input state: 
   Valid time: 2018-04-15T00:00:00Z
-sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772900527558
-             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897728181
-       sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642065405004
+sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772900527789
+             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897729602
+       sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642064969300
           sea_ice_area_fraction   min=-0.0001291896179326   max=1.0000039848914242   mean=0.1175172743974210
-              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246947   mean=0.4712515705773919
+              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246947   mean=0.4712515705773916
          sea_ice_snow_thickness   min=0.0000000000000000   max=1.2712833951042413   mean=0.0886865877527975
 Variable transform: 
 Variable change from: 6 variables: sea_water_potential_temperature, sea_water_salinity, sea_water_cell_thickness, sea_ice_area_fraction, sea_ice_thickness, sea_ice_snow_thickness
 Variable change to: 6 variables: sea_water_potential_temperature, sea_water_salinity, sea_water_cell_thickness, sea_ice_area_fraction, sea_ice_thickness, sea_ice_snow_thickness
 State after variable transform: 
   Valid time: 2018-04-15T00:00:00Z
-sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772900527558
-             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897728181
-       sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642065405004
-          sea_ice_area_fraction   min=0.0000000000000000   max=1.0000000000000000   mean=0.1164131299079067
-              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246938   mean=0.2837213547153729
-         sea_ice_snow_thickness   min=0.0000000000000000   max=0.0000000000000000   mean=0.0000000000000000
+sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772900527789
+             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897729602
+       sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642064969300
+          sea_ice_area_fraction   min=0.0000000000000000   max=1.0000000000000000   mean=0.1170864570139951
+              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246938   mean=0.2835359264682376
+         sea_ice_snow_thickness   min=0.0000000000000000   max=1.2712833951042413   mean=0.0434021370299769
 Output state: 
   Valid time: 2018-04-15T00:00:00Z
-sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772900527558
-             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897728181
-       sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642065405004
-          sea_ice_area_fraction   min=0.0000000000000000   max=1.0000000000000000   mean=0.1164131299079067
-              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246938   mean=0.2837213547153729
-         sea_ice_snow_thickness   min=0.0000000000000000   max=0.0000000000000000   mean=0.0000000000000000
+sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772900527789
+             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897729602
+       sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642064969300
+          sea_ice_area_fraction   min=0.0000000000000000   max=1.0000000000000000   mean=0.1170864570139951
+              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246938   mean=0.2835359264682376
+         sea_ice_snow_thickness   min=0.0000000000000000   max=1.2712833951042413   mean=0.0434021370299769


### PR DESCRIPTION
## Description

There are several improvements to Soca2Cice here:

- **use icepack's `cleanup_itd` after rescaling** to rebin thickness categories if necessary, remove very small ice areas and remove snow if snow enthalpy indicates out-of-bounds temperatures (see details in `cleanup_itd`).
Notes:
  - Ice thickness categories are set up automatically by `icepack_init_itd`. I am not sure this is always the correct way to set up ice categories; does anyone know? It's important for rebinning.
  - I have removed the existing adjustment of snow enthalpy from the code since I expect it's now covered (in a different way) by `cleanup_itd`.
  - The rebinning uses the model's time step. I added a new yaml option `icepack time step` with pseudorandom default 300.
  - If `cleanup_itd` indicates that icepack aborted, the code will abort. This can be replaced (or optionally replaced) by shuffling if the `cleanup_itd` aborts.
  - Only ice/snow temperature, ice and snow enthalpies and ice salinity are currently updated in the `cleanup_itd`, but I can add more tracers (e.g. melt ponds?)
- **exclude backgrounds that are equal to `sea ice edge` value from rescaling**. Previously the code both shuffled and rescaled where background == `sea ice edge`. This fix is mostly to cover an edge case when `sea ice edge` is set to zero. In this case, when the background is zero, we definitely don't want to rescale (i.e. divide by zero)
- **explicitly cover zero analysis ice concentration case**. I think this was not covered before (`cleanup_ice` on develop covers the case where the restart fields updated after shuffling and rescaling are zero, but doesn't cover the case where they should have been updated to zero).
Note: I kept Guillaume's update to the ice/snow temperature as icepack's `liquidus_temperature_mush`. 
- **add `shuffle stencil size` as a yaml option (default is 9)** to add some flexibility for testing
- removed some unused variables.


### Issue(s) addressed

fixes https://github.com/JCSDA-internal/soca/issues/993 in a roundabout way (instead of adding the fixes suggested here, `cleanup_itd` is used to do that and more)

## Testing

Tested on orion with gnu and unit tests, the current test mostly rebins categories up and down, and zaps small areas on a few occasions.

Tested on hera with intel with high res gdas 3DVar experiment, setting ice edge to 0.15 and running a few cycles. `cleanup_itd` mostly rebins categories and zaps snow with low snow volumes and zero snow enthalpies.