### PR TITLE
Add optional increment output in Soca2Cice

### DIFF
--- a/src/soca/VariableChange/Soca2Cice/Soca2Cice.cc
+++ b/src/soca/VariableChange/Soca2Cice/Soca2Cice.cc
@@ -20,16 +20,15 @@ static VariableChangeMaker<Soca2Cice>
 // -----------------------------------------------------------------------------
 
 Soca2Cice::Soca2Cice(const Geometry & geom,
-                             const eckit::Configuration & conf)
+                     const eckit::Configuration & conf)
   : geom_(geom)
 {
   util::Timer timer("soca::Soca2Cice", "Soca2Cice");
 
-  Parameters params;
-  params.deserialize(conf);
+  params_.deserialize(conf);
 
   soca_soca2cice_setup_f90(keySoca2Cice_,
-                           params.toConfiguration(),
+                           params_.toConfiguration(),
                            geom_.toFortran());
 }
 
@@ -46,6 +45,22 @@ void Soca2Cice::changeVar(const State & xin, State & xout) const
   xout = xin;
   soca_soca2cice_changevar_f90(keySoca2Cice_, geom_.toFortran(),
                                xin.toFortran(), xout.toFortran());
+  if (params_.incOutput.value() != boost::none) {
+    if (params_.incInput.value() == boost::none) {
+      throw eckit::BadParameter("Can not output increment if soca increment is not in yaml");
+    }
+    // this increment is difference between the analysis written to CICE restart
+    // and soca analysis, i.e. difference between post-processed increment and soca
+    // increment
+    Increment inc(xin.geometry(), xin.variables(), xin.validTime());
+    inc.diff(xout, xin);
+    // this increment is soca increment
+    Increment socainc(xin.geometry(), xin.variables(), xin.validTime());
+    socainc.read(*params_.incInput.value());
+    // adding soca increment to get the post-processed increment
+    inc += socainc;
+    inc.write(*params_.incOutput.value());
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/src/soca/VariableChange/Soca2Cice/Soca2Cice.h
+++ b/src/soca/VariableChange/Soca2Cice/Soca2Cice.h
@@ -79,6 +79,8 @@ class Soca2Cice: public VariableChangeBase {
    public:
     oops::RequiredParameter<BackgroundParameters> background{"cice background state", this};
     oops::RequiredParameter<OutputParameters> output{"cice output", this};
+    oops::OptionalParameter<eckit::LocalConfiguration> incOutput{"increment output", this};
+    oops::OptionalParameter<eckit::LocalConfiguration> incInput{"soca increment", this};
     oops::RequiredParameter<RedistributionParameters> arctic{"arctic", this};
     oops::RequiredParameter<RedistributionParameters> antarctic{"antarctic", this};
   };
@@ -93,6 +95,7 @@ class Soca2Cice: public VariableChangeBase {
 
  private:
   const Geometry & geom_;
+  Parameters params_;
   int keySoca2Cice_;
   void print(std::ostream &) const override {}
 };


### PR DESCRIPTION
## Description

Adds an option to output the postprocessed sea ice increment from Soca2Cice (useful for comparing the increment that DA/soca generated to the increment that we actually could add to the model). I'm not super satisfied with where/how it's implemented in the code, but the good news it's optional 😆 . 

## Testing

Tested on orion with gnu (ctests) and on hera with intel within gdasapp workflow.

An example of output:
soca increment (no postprocessing):
![aice_h_North](https://github.com/user-attachments/assets/fc05eeb3-e172-4849-96c2-ce7647e672a7)

postprocessed soca2cice increment (shuffle on, sea ice edge = 0.4) -- used in cp4 experiment
![aice_h_North](https://github.com/user-attachments/assets/232a4d99-3154-4cb2-a83c-047bac11db39)

out of interest, postprocessed soca2cice increment (shuffle off, sea ice edge = 0.8) -- used before cp4 experiments
![aice_h_North](https://github.com/user-attachments/assets/48ef722a-9122-4046-a88e-b64460d1f1da)
