### PR TITLE
Bugfix to allow read/write of "many" files

### DIFF
--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -25,7 +25,7 @@ use oops_variables_mod, only: oops_variables
 use tools_const, only: deg2rad
 
 ! MOM6 / FMS modules
-use fms_io_mod, only: fms_io_init, fms_io_exit, register_restart_field, &
+use fms_io_mod, only: register_restart_field, &
                       restart_file_type, restore_state, free_restart_type, save_restart, &
                       file_exist, field_exist
 use fms_mod,    only: write_data, set_domain
@@ -707,12 +707,10 @@ subroutine soca_fields_read(self, f_conf, vdate)
      h_common = 0.0_kind_real
 
      ! Read common vertical coordinate from file
-     call fms_io_init()
      idr = register_restart_field(ocean_remap_restart, remap_filename, 'h', h_common, &
           domain=self%geom%Domain%mpp_domain)
      call restore_state(ocean_remap_restart, directory='')
      call free_restart_type(ocean_remap_restart)
-     call fms_io_exit()
   end if
 
   ! Create unit increment
@@ -773,8 +771,6 @@ subroutine soca_fields_read(self, f_conf, vdate)
       call f_conf%get_or_die("bio_filename", str)
       bio_filename = trim(basename)//trim(str)
     end if
-
-    call fms_io_init()
 
     seaice_categories_vars = oops_variables()
     ! built-in variables
@@ -857,8 +853,6 @@ subroutine soca_fields_read(self, f_conf, vdate)
       call restore_state(bio_restart, directory='')
       call free_restart_type(bio_restart)
     end if
-
-    call fms_io_exit()
 
     ! read sea ice variables with categoriy and/or levels dimensions
     if (seaice_categories_vars%nvars() > 0) then
@@ -1032,14 +1026,12 @@ subroutine soca_fields_read_seaice(self, filename, seaice_categories_vars)
   if (cice_vars_cats%nvars() > 0) then
     allocate(tmp3d(self%geom%isd:self%geom%ied,self%geom%jsd:self%geom%jed,ncat,cice_vars_cats%nvars()))
     tmp3d = 0.0_kind_real
-    call fms_io_init()
     do i=1,cice_vars_cats%nvars()
       idr = register_restart_field(restart, filename, cice_vars_cats%variable(i), &
                          tmp3d(:,:,:,i), domain=self%geom%Domain%mpp_domain)
     end do
     call restore_state(restart, directory='')
     call free_restart_type(restart)
-    call fms_io_exit()
 
     ! copy the variable into the corresponding field
     cnt = 1
@@ -1064,14 +1056,12 @@ subroutine soca_fields_read_seaice(self, filename, seaice_categories_vars)
     allocate(tmp4d(self%geom%isd:self%geom%ied,self%geom%jsd:self%geom%jed,icelevs,&
     &ncat,cice_vars_cats_levs%nvars()))
     tmp4d = 0.0_kind_real
-    call fms_io_init()
     do i=1,cice_vars_cats_levs%nvars()
       idr = register_restart_field(restart, filename, cice_vars_cats_levs%variable(i), &
                          tmp4d(:,:,:,:,i), domain=self%geom%Domain%mpp_domain)
     end do
     call restore_state(restart, directory='')
     call free_restart_type(restart)
-    call fms_io_exit()
 
     ! copy the variable into the corresponding field
     cnt = 1
@@ -1155,16 +1145,11 @@ subroutine soca_fields_write_file(self, filename)
 
   integer :: ii
 
-  call fms_io_init()
-  call set_domain( self%geom%Domain%mpp_domain )
-
   ! write out all fields
   do ii = 1, size(self%fields)
     call write_data( filename, self%fields(ii)%name, self%fields(ii)%val(:,:,:), self%geom%Domain%mpp_domain)
   end do
 
-
-  call fms_io_exit()
 end subroutine soca_fields_write_file
 
 
@@ -1190,7 +1175,6 @@ subroutine soca_fields_write_rst(self, f_conf, vdate)
   write_sfc = .false.
   write_wav = .false.
   write_bio = .false.
-  call fms_io_init()
 
   ! Get date IO format (colons or not?)
   date_cols = .true.
@@ -1265,7 +1249,6 @@ subroutine soca_fields_write_rst(self, f_conf, vdate)
     call save_restart(bio_restart, directory='')
     call free_restart_type(bio_restart)
  endif
-  call fms_io_exit()
 
 end subroutine soca_fields_write_rst
 

--- a/src/soca/Geometry/soca_geom_mod.F90
+++ b/src/soca/Geometry/soca_geom_mod.F90
@@ -192,7 +192,6 @@ subroutine soca_geom_init(self, f_conf, f_comm, gen)
   call MOM_domains_init(self%Domain, param_file)
   call get_param(param_file, "soca_mom6", "NK", self%nzo, fail_if_missing=.true.)
   call close_param_file(param_file)
-  call fms_io_exit()
 
   ! Allocate geometry arrays
   call soca_geom_allocate(self)
@@ -234,7 +233,6 @@ subroutine soca_geom_init(self, f_conf, f_comm, gen)
     ! Read in the precomputed grid from the soca gridspec file instead
     ! NOTE that we will rerad the gridspec file later for some of the variables
     ! once the altas FunctionSpace has been created.
-    call fms_io_init()
     if (.not. f_conf%get("geom_grid_file", str)) str = "soca_gridspec.nc"
     r = register_restart_field(geom_restart, str, "lonh",    self%lonh,      self%Domain%mpp_domain)
     r = register_restart_field(geom_restart, str, "lath",    self%lath,      self%Domain%mpp_domain)
@@ -256,7 +254,6 @@ subroutine soca_geom_init(self, f_conf, f_comm, gen)
     r = register_restart_field(geom_restart, str, "mask2dv", self%mask2dv,   self%Domain%mpp_domain)
     call restore_state(geom_restart, directory='')
     call free_restart_type(geom_restart)
-    call fms_io_exit()
   endif
 
   ! Fill halos
@@ -288,6 +285,7 @@ end subroutine soca_geom_init
 subroutine soca_geom_end(self)
   class(soca_geom), intent(out)  :: self
 
+  call fms_io_exit()
   if (allocated(self%lonh))          deallocate(self%lonh)
   if (allocated(self%lath))          deallocate(self%lath)
   if (allocated(self%lonq))          deallocate(self%lonq)
@@ -432,13 +430,11 @@ subroutine soca_geom_init_fieldset(self, f_conf, gen)
     allocate(fieldDataVars(self%isd:self%ied, self%jsd:self%jed, size(atlasVars)))
 
     ! read in from gridspec file
-    call fms_io_init()
     do v = 1, size(atlasVars)
       r = register_restart_field(geom_restart, str, atlasVars(v), fieldDataVars(:,:,v), self%Domain%mpp_domain)
     end do
     call restore_state(geom_restart, directory='')
     call free_restart_type(geom_restart)
-    call fms_io_exit()
 
     ! copy from fortran array to atlas field
     do v = 1, size(atlasVars)
@@ -608,7 +604,6 @@ subroutine soca_geom_write(self, f_conf)
   character(len=256) :: geom_output_pe
 
   ! Save global domain
-  call fms_io_init()
   if (.not. f_conf%get("geom_grid_file", str)) str = "soca_gridspec.nc"
   r = register_restart_field(geom_restart, str, "lonh",    self%lonh,      self%Domain%mpp_domain)
   r = register_restart_field(geom_restart, str, "lath",    self%lath,      self%Domain%mpp_domain)
@@ -650,7 +645,6 @@ subroutine soca_geom_write(self, f_conf)
 
   call save_restart(geom_restart, directory='')
   call free_restart_type(geom_restart)
-  call fms_io_exit()
 
   ! Set output option for local geometry
   if ( .not. f_conf%get("save_local_domain", save_local) ) save_local = .false.

--- a/src/soca/LinearVariableChange/Balance/soca_balance_mod.F90
+++ b/src/soca/LinearVariableChange/Balance/soca_balance_mod.F90
@@ -6,7 +6,6 @@
 module soca_balance_mod
 
 use fckit_configuration_module, only: fckit_configuration
-use fms_io_mod, only: fms_io_init, fms_io_exit
 use fms_mod, only: read_data
 use kinds, only: kind_real
 
@@ -186,9 +185,7 @@ subroutine soca_balance_setup(self, f_conf, traj, geom)
     if ( f_conf%has("dcdt") ) then
       call f_conf%get_or_die("dcdt.filename", filename)
       call f_conf%get_or_die("dcdt.name", kct_name)
-      call fms_io_init()
       call read_data(filename, kct_name, kct, domain=geom%Domain%mpp_domain)
-      call fms_io_exit()
     end if
     allocate(self%kct(isc:iec,jsc:jec))
     self%kct = 0.0_kind_real


### PR DESCRIPTION
## Description

LETKF with 80 members was choking on fms_io with an error:
```
FATAL from PE    14: fms_io(setup_one_field), 1: max_domains exceeded, needs increasing
```
This is because FMS has a bug in `fms_io_init` that gets exposed if you run `fms_io_init`/`fms_io_exit` one too many times (one over 100 to be precise). Due to the bug `fms_io` increases the domain counter every read/write call even though it's the same domain every time. 
This PR changes soca to call `fms_io_init`/`fms_io_exit` once per `Geometry` to avoid hitting this bug (I think it's the way to use these subroutines intended by developers anyway). 

### Issue(s) addressed

- fixes #1121 

## Testing

hera/intel:
- soca CI: change enspert test to generate 120 members; fails with the above error on develop, runs fine with this branch
- gdasapp high-res LETKF with 80 members: fails with the above error on develop, runs fine with this branch