### PR TITLE
Update icepack version

### DIFF
--- a/src/soca/VariableChange/Soca2Cice/soca_ciceutils_mod.F90
+++ b/src/soca/VariableChange/Soca2Cice/soca_ciceutils_mod.F90
@@ -8,7 +8,7 @@ module soca_ciceutils_mod
 use kinds, only: kind_real
 use netcdf
 use fckit_mpi_module, only: fckit_mpi_comm
-use icepack_itd
+use icepack_itd, only: aggregate_area
 use soca_utils, only: nc_check
 use soca_geom_mod, only: soca_geom
 use mpp_domains_mod, only : mpp_update_domains
@@ -307,8 +307,7 @@ subroutine soca_ciceutils_read(self, geom)
   do j = geom%jsd, geom%jed
      do i = geom%isd, geom%ied
         if (self%iceumask(i,j).eq.1) then
-           call aggregate_area (self%ncat, &
-                                self%aicen(i,j,:), &
+           call aggregate_area (self%aicen(i,j,:), &
                                 self%aice(i,j), aice0)
            self%agg%lon(cnt) = geom%lon(i,j)
            self%agg%lat(cnt) = geom%lat(i,j)

--- a/src/soca/VariableChange/Soca2Cice/soca_soca2cice_mod.F90
+++ b/src/soca/VariableChange/Soca2Cice/soca_soca2cice_mod.F90
@@ -13,11 +13,10 @@ use kinds, only: kind_real
 
 use icepack_itd, only: icepack_init_itd, cleanup_itd
 use icepack_warnings, only: icepack_warnings_flush, icepack_warnings_aborted
-use icepack_tracers, only: icepack_init_tracer_indices, nt_tsfc, nt_qice, nt_qsno, nt_sice
+use icepack_tracers, only: icepack_init_tracer_sizes, icepack_init_tracer_indices
 use icepack_parameters, only: icepack_init_parameters, icepack_recompute_constants
-use icepack_parameters, only: ktherm, heat_capacity
-use icepack_mushy_physics, only: liquidus_temperature_mush
-use icepack_therm_shared, only: l_brine
+use icepack_parameters, only: ktherm
+use icepack_therm_shared, only: icepack_liquidus_temperature, l_brine
 
 use soca_geom_mod, only: soca_geom
 use soca_state_mod, only: soca_state
@@ -88,8 +87,7 @@ subroutine soca_soca2cice_setup(self, geom)
   call icepack_recompute_constants()
   l_brine = .true.
   ktherm = 2
-  heat_capacity = .true.
-
+  call icepack_init_tracer_sizes(ncat_in=self%ncat, nilyr_in=self%ice_lev, nslyr_in=self%sno_lev)
   ! initialize cice
   call self%cice%init(geom, self%rst_filename, self%rst_out_filename, self%ice_lev, self%sno_lev)
 
@@ -226,7 +224,7 @@ subroutine shuffle_ice(self, geom, xm)
            self%cice%qice(i,j,:,:) = 0_kind_real
            self%cice%sice(i,j,:,:) = 0_kind_real
            self%cice%qsno(i,j,:,:) = 0_kind_real
-           self%cice%tsfcn(i,j,:) = liquidus_temperature_mush(s_ana%val(i,j,1))
+           self%cice%tsfcn(i,j,:) = icepack_liquidus_temperature(s_ana%val(i,j,1))
         endif
         if (self%cice%agg%n_src == 0) cycle               ! skip if there are no points on this task with ice in the background
         ! find neighbors. TODO (G): add constraint for thickness and snow depth as well
@@ -270,7 +268,7 @@ subroutine cleanup_ice(self, geom, xm)
 
   integer :: i, j, k, ntracers
   integer :: nt_tsfc_in, nt_qice_in, nt_qsno_in, nt_sice_in
-  real(kind=kind_real) :: aice, aice0
+  real(kind=kind_real) :: aice, aice0, Tf
   type(soca_field), pointer :: t_ana, s_ana, aice_ana, hice_ana, hsno_ana
   real(kind=kind_real), allocatable :: h_bounds(:)
   real(kind=kind_real), allocatable :: tracers(:,:)   ! (ntracers, ncat)
@@ -280,8 +278,6 @@ subroutine cleanup_ice(self, geom, xm)
                                                       ! argument 2:  (1) aice, (2) vice, (3) vsno
   integer, allocatable :: n_trcr_strata(:)            ! number of underlying tracer layers
   integer, allocatable :: nt_strata(:,:)              ! indices of underlying tracer layers
-  real(kind=kind_real), allocatable :: fiso_ocn(:)    ! isotope flux to ocean, not used as long as icepack's
-                                                      ! tr_iso is false (default), so not initialized here.
 
   ! pointers to soca fields (most likely an analysis)
   call xm%get("sea_water_potential_temperature",t_ana)
@@ -292,7 +288,7 @@ subroutine cleanup_ice(self, geom, xm)
 
   ! get thickness category bounds
   allocate(h_bounds(0:self%ncat))
-  call icepack_init_itd(self%ncat, h_bounds) ! TODO (G): move that in setup
+  call icepack_init_itd(h_bounds) ! TODO (G): move that in setup
   ! initialize tracers (ice/snow temperature, ice and snow enthalpies, ice salinity)
   ntracers = 1+2*self%ice_lev+self%sno_lev
   allocate(tracers(ntracers, self%ncat))
@@ -332,6 +328,7 @@ subroutine cleanup_ice(self, geom, xm)
    trcr_base(nt_sice_in + k - 1, 2) = 1.0
   enddo
 
+  call icepack_init_tracer_sizes(ntrcr_in=ntracers)
   call icepack_init_tracer_indices(nt_tsfc_in=nt_tsfc_in, nt_qice_in=nt_qice_in, &
                                    nt_qsno_in=nt_qsno_in, nt_sice_in=nt_sice_in)
   allocate(first_ice(self%ncat))
@@ -340,36 +337,36 @@ subroutine cleanup_ice(self, geom, xm)
   do i = geom%isc, geom%iec
      do j = geom%jsc, geom%jec
         ! setup tracers at this gridpoint
-        tracers(nt_tsfc,:) = self%cice%tsfcn(i,j,:)
+        tracers(nt_tsfc_in,:) = self%cice%tsfcn(i,j,:)
         do k = 1, self%ice_lev
-          tracers(nt_qice+k-1, :) = self%cice%qice(i,j,:,k)
-          tracers(nt_sice+k-1, :) = self%cice%sice(i,j,:,k)
+          tracers(nt_qice_in+k-1, :) = self%cice%qice(i,j,:,k)
+          tracers(nt_sice_in+k-1, :) = self%cice%sice(i,j,:,k)
         enddo
         do k = 1, self%sno_lev
-          tracers(nt_qsno+k-1, :) = self%cice%qsno(i,j,:,k)
+          tracers(nt_qsno_in+k-1, :) = self%cice%qsno(i,j,:,k)
         enddo
+
         ! call icepack_cleanup_itd: rebins thickness categories if necessary,
         ! eliminates very small ice areas while conserving mass and energy
-        call cleanup_itd(self%dt, ntracers, self%ice_lev, self%sno_lev, self%ncat, &
-                         h_bounds, self%cice%aicen(i,j,:), tracers, &
+        Tf = icepack_liquidus_temperature(s_ana%val(i,j,1))
+        call cleanup_itd(self%dt, h_bounds, self%cice%aicen(i,j,:), tracers, &
                          self%cice%vicen(i,j,:), self%cice%vsnon(i,j,:), &
                          ! ice and total water concentration are computed in the call using aicen
-                         aice, aice0, &
-                         ! number of aerosol tracers, bio tracers, bio layers
-                         0, 0, 0, &
-                         ! aerosol flag, topo pond flag, heat capacity flag, flag for zapping ice for bgc and s tracers
-                         .false., .false., .true., first_ice, &
+                         aice0, aice, &
+                         ! aerosol flag, topo pond flag, flag for zapping ice for bgc and s tracers
+                         .false., .false., first_ice, &
                          ! tracer indices and sizes used in rebinning
                          trcr_depend, trcr_base, n_trcr_strata, nt_strata, &
-                         fiso_ocn=fiso_ocn)
+                         ! freezing temperature
+                         Tf = Tf)
         ! put tracers back
-        self%cice%tsfcn(i,j,:) = tracers(nt_tsfc,:)
+        self%cice%tsfcn(i,j,:) = tracers(nt_tsfc_in,:)
         do k = 1, self%ice_lev
-          self%cice%qice(i,j,:,k) = tracers(nt_qice+k-1, :)
-          self%cice%sice(i,j,:,k) = tracers(nt_sice+k-1, :)
+          self%cice%qice(i,j,:,k) = tracers(nt_qice_in+k-1, :)
+          self%cice%sice(i,j,:,k) = tracers(nt_sice_in+k-1, :)
         enddo
         do k = 1, self%sno_lev
-          self%cice%qsno(i,j,:,k) = tracers(nt_qsno+k-1, :)
+          self%cice%qsno(i,j,:,k) = tracers(nt_qsno_in+k-1, :)
         enddo
         call icepack_warnings_flush(6)
         if (icepack_warnings_aborted()) then


### PR DESCRIPTION
## Description

Updates icepack hash to [3792520](https://github.com/cice-consortium/icepack/tree/3792520561cf9419082ef41f9f0dffd03edf2e43) and changes the calling code in Soca2Cice accordingly.

For the low res soca2cice test here, the only changes are in the ice/snow surface temperature. That's not surprising, given that `icepack_itd` now additionally takes freezing temperature (computed now in Soca2Cice as `icepack_liquidus_temperature`, similar to how @guillaumevernieres coded it for zero ice case).

### Issue(s) addressed

Fixes https://github.com/JCSDA-internal/soca/issues/1119

## Testing

orion/gnu; ctest in soca.
TBD: intel/hera; high res case