### PR TITLE
Update for rm fortran fields: Make sure soca2cice doesn't copy states with different variables

### DIFF
--- a/src/soca/VariableChange/Soca2Cice/Soca2Cice.cc
+++ b/src/soca/VariableChange/Soca2Cice/Soca2Cice.cc
@@ -41,7 +41,8 @@ Soca2Cice::~Soca2Cice() {}
 void Soca2Cice::changeVar(const State & xin, State & xout) const
 {
   util::Timer timer("soca::Soca2Cice", "changeVar");
-
+  oops::Variables varsout = xout.variables();
+  xout.updateFields(xin.variables());
   xout = xin;
   soca_soca2cice_changevar_f90(keySoca2Cice_, geom_.toFortran(),
                                xin.toFortran(), xout.toFortran());
@@ -61,6 +62,7 @@ void Soca2Cice::changeVar(const State & xin, State & xout) const
     inc += socainc;
     inc.write(*params_.incOutput.value());
   }
+  xout.updateFields(varsout);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
A change that I found we needed for some soca2cice calls. There may be a better fix, but in parallel I'm working on refactoring the postprocessing, which as a first step will move soca2cice from a VariableChange class to a postprocessing class (the goal is to use backgrounds and increments for postprocessing, and this doesn't work well within variablechange infrastructure). So I didn't feel very inspired to look for a better fix.