### PR TITLE
3dhyb test tolerance

### DIFF
--- a/test/testinput/3dhyb.yml
+++ b/test/testinput/3dhyb.yml
@@ -191,4 +191,4 @@ output:
 test:
   reference filename: testref/3dhyb.test
   test output filename: testoutput/3dhyb.test
-  float relative tolerance: 1e-5
+  float relative tolerance: 2e-5


### PR DESCRIPTION
## Description

Change test tolerance for ctest to pass on ubuntu24.04 with gcc 13.3 on orbstack VM.

## Testing

See above

## Dependencies

None

