### PR TITLE
Loosen test tolerances for intel/oneapi CI

### DIFF
--- a/test/testinput/3dvar.yml
+++ b/test/testinput/3dvar.yml
@@ -304,4 +304,4 @@ output:
 test:
   reference filename: testref/3dvar.test
   test output filename: testoutput/3dvar.test
-  float relative tolerance: 2e-4
+  float relative tolerance: 4e-4

--- a/test/testinput/3dvar_lowres.yml
+++ b/test/testinput/3dvar_lowres.yml
@@ -310,4 +310,4 @@ output:
 test:
   reference filename: testref/3dvar_lowres.test
   test output filename: testoutput/3dvar_lowres.test
-  float relative tolerance: 2e-4
+  float relative tolerance: 4e-4

--- a/test/testinput/dirac_diffusion.yml
+++ b/test/testinput/dirac_diffusion.yml
@@ -55,3 +55,4 @@ output dirac:
 test:
   reference filename: testref/dirac_diffusion.test
   test output filename: testoutput/dirac_diffusion.test
+  float relative tolerance: 2e-5

--- a/test/testinput/linearization_error.yml
+++ b/test/testinput/linearization_error.yml
@@ -178,4 +178,4 @@ output:
 test:
   reference filename: testref/linearization_error.test
   test output filename: testoutput/linearization_error.test
-  float absolute tolerance: 1e-4
+  float absolute tolerance: 4e-4

--- a/test/testinput/setcorscales.yml
+++ b/test/testinput/setcorscales.yml
@@ -58,4 +58,4 @@ rv output:
 test:
   reference filename: testref/setcorscales.test
   test output filename: testoutput/setcorscales.test
-  float relative tolerance: 1e-5
+  float relative tolerance: 2e-5


### PR DESCRIPTION
## Description

Similar to #1140 but targeting the tolerance changes for Ubuntu 24 intel/oneapi spack-stack 1.9 — the next intel CI environment.
