### PR TITLE
Bugfix for Soca2Cice: use correct mask to mask out points on land

### DIFF
--- a/src/soca/VariableChange/Soca2Cice/soca_ciceutils_mod.F90
+++ b/src/soca/VariableChange/Soca2Cice/soca_ciceutils_mod.F90
@@ -17,14 +17,6 @@ use mpp_mod, only : mpp_gather, mpp_root_pe, mpp_pe
 implicit none
 private
 
-type, public :: agg_cice_state
-   real(kind=kind_real),  allocatable :: aice(:)
-   real(kind=kind_real),  allocatable :: lon(:)
-   real(kind=kind_real),  allocatable :: lat(:)
-   integer,  allocatable :: ij(:,:)
-   integer :: n_src
-end type agg_cice_state
-
 type, public :: cice_state
    integer :: ncat, ni, nj, ice_lev, sno_lev
    integer :: isc, iec, jsc, jec   ! compute domain
@@ -43,9 +35,7 @@ type, public :: cice_state
    real(kind=kind_real),  allocatable :: qice(:,:,:,:)   ! volume-weighted ice enthalpy
    real(kind=kind_real),  allocatable :: qsno(:,:,:,:)   ! volume-weighted snow enthalpy
    real(kind=kind_real),  allocatable :: sice(:,:,:,:)   ! volume-weighted ice bulk salinity
-   real(kind=kind_real),  allocatable :: iceumask(:,:)
    real(kind=kind_real),  allocatable :: aice(:,:)       ! total ice concentration
-   type(agg_cice_state):: agg
 contains
   procedure :: init => soca_ciceutils_init
   procedure :: alloc => soca_ciceutils_alloc
@@ -142,51 +132,44 @@ subroutine soca_ciceutils_gather(self, glb, geom)
   end if
   allocate(var2d(self%ni, self%nj))
 
-  ! gather 2D arrays
-  call mpp_gather(self%isc, self%iec, self%jsc, self%jec, pelist, &
-       self%iceumask(self%isc:self%iec,self%jsc:self%jec), &
-       var2d, is_root_pe)
-  if ( pe == mpp_root_pe()) glb%iceumask(1:self%ni,1:self%nj) = var2d
-  call geom%f_comm%barrier()
-
   ! gather 2D arrays along categories, snow and ice levels
   do n = 1, self%ncat
      ! aicen
      call mpp_gather(self%isc, self%iec, self%jsc, self%jec, pelist, &
           self%aicen(self%isc:self%iec,self%jsc:self%jec,n), &
           var2d, is_root_pe)
-     if ( pe == mpp_root_pe()) glb%aicen(1:self%ni,1:self%nj,n) = var2d*glb%iceumask
+     if ( pe == mpp_root_pe()) glb%aicen(1:self%ni,1:self%nj,n) = var2d
 
      ! vicen
      call mpp_gather(self%isc, self%iec, self%jsc, self%jec, pelist, &
           self%vicen(self%isc:self%iec,self%jsc:self%jec,n), &
           var2d, is_root_pe)
-     if ( pe == mpp_root_pe()) glb%vicen(1:self%ni,1:self%nj,n) = var2d*glb%iceumask
+     if ( pe == mpp_root_pe()) glb%vicen(1:self%ni,1:self%nj,n) = var2d
 
      ! vsnon
      call mpp_gather(self%isc, self%iec, self%jsc, self%jec, pelist, &
           self%vsnon(self%isc:self%iec,self%jsc:self%jec,n), &
           var2d, is_root_pe)
-     if ( pe == mpp_root_pe()) glb%vsnon(1:self%ni,1:self%nj,n) = var2d*glb%iceumask
+     if ( pe == mpp_root_pe()) glb%vsnon(1:self%ni,1:self%nj,n) = var2d
 
      ! Tsfcn
      call mpp_gather(self%isc, self%iec, self%jsc, self%jec, pelist, &
           self%tsfcn(self%isc:self%iec,self%jsc:self%jec,n), &
           var2d, is_root_pe)
-     if ( pe == mpp_root_pe()) glb%tsfcn(1:self%ni,1:self%nj,n) = var2d*glb%iceumask
+     if ( pe == mpp_root_pe()) glb%tsfcn(1:self%ni,1:self%nj,n) = var2d
 
      do l = 1, self%ice_lev
         ! Qice
         call mpp_gather(self%isc, self%iec, self%jsc, self%jec, pelist, &
              self%qice(self%isc:self%iec,self%jsc:self%jec,n,l), &
              var2d, is_root_pe)
-        if ( pe == mpp_root_pe()) glb%qice(1:self%ni,1:self%nj,n,l) = var2d*glb%iceumask
+        if ( pe == mpp_root_pe()) glb%qice(1:self%ni,1:self%nj,n,l) = var2d
 
         ! Sice
         call mpp_gather(self%isc, self%iec, self%jsc, self%jec, pelist, &
              self%sice(self%isc:self%iec,self%jsc:self%jec,n,l), &
              var2d, is_root_pe)
-        if ( pe == mpp_root_pe()) glb%sice(1:self%ni,1:self%nj,n,l) = var2d*glb%iceumask
+        if ( pe == mpp_root_pe()) glb%sice(1:self%ni,1:self%nj,n,l) = var2d
      end do
 
      do l = 1, self%sno_lev
@@ -194,7 +177,7 @@ subroutine soca_ciceutils_gather(self, glb, geom)
         call mpp_gather(self%isc, self%iec, self%jsc, self%jec, pelist, &
              self%qsno(self%isc:self%iec,self%jsc:self%jec,n,l), &
              var2d, is_root_pe)
-        if ( pe == mpp_root_pe()) glb%qsno(1:self%ni,1:self%nj,n,l) = var2d*glb%iceumask
+        if ( pe == mpp_root_pe()) glb%qsno(1:self%ni,1:self%nj,n,l) = var2d
      end do
   end do
   deallocate(var2d)
@@ -210,8 +193,6 @@ subroutine soca_ciceutils_alloc(self, isd, ied, jsd, jed)
   ncat = self%ncat
   ice_lev = self%ice_lev
   sno_lev = self%sno_lev
-
-  allocate(self%iceumask(isd:ied, jsd:jed));      self%iceumask = 0.0_kind_real
 
   allocate(self%aice(isd:ied, jsd:jed));          self%aice = 0.0_kind_real
 
@@ -251,8 +232,6 @@ subroutine soca_ciceutils_copydata(self, other)
   self%jsd = other%jsd; jsd = other%jsd
   self%jed = other%jed; jed = other%jed
 
-  allocate(self%iceumask(isd:ied, jsd:jed));      self%iceumask = other%iceumask
-
   allocate(self%aice(isd:ied, jsd:jed));          self%aice = other%aice
 
   allocate(self%aicen(isd:ied, jsd:jed, ncat));   self%aicen = other%aicen
@@ -275,13 +254,10 @@ subroutine soca_ciceutils_read(self, geom)
   class(cice_state), intent(inout) :: self
   type(soca_geom), target, intent(in)  :: geom
 
-  integer(kind=4) :: ncid, dimid, varid, i, j, cnt, n_src
+  integer(kind=4) :: ncid, dimid, varid, i, j
   real(kind=kind_real) :: aice0
 
   call nc_check(nf90_open(self%rst_filename, nf90_nowrite, ncid))
-
-  ! ice mask
-  call getvar2d('iceumask', self%iceumask, self%ni, self%nj, geom, ncid)
 
   ! dynamic variables
   call getvar3d('aicen', self%aicen, self%ni, self%nj, self%ncat, geom, ncid)
@@ -301,25 +277,9 @@ subroutine soca_ciceutils_read(self, geom)
 
   call nc_check(nf90_close(ncid))
 
-  ! aggregate categories
-  cnt = 1
-  n_src = sum(self%iceumask)
-  self%agg%n_src = n_src
-  allocate(self%agg%lon(n_src), self%agg%lat(n_src), self%agg%aice(n_src))
-  allocate(self%agg%ij(2,n_src))
-
   do j = geom%jsd, geom%jed
      do i = geom%isd, geom%ied
-        if (self%iceumask(i,j).eq.1) then
-           call aggregate_area (self%aicen(i,j,:), &
-                                self%aice(i,j), aice0)
-           self%agg%lon(cnt) = geom%lon(i,j)
-           self%agg%lat(cnt) = geom%lat(i,j)
-           self%agg%aice(cnt) = self%aice(i,j)
-           self%agg%ij(1,cnt) = i
-           self%agg%ij(2,cnt) = j
-           cnt = cnt + 1
-        end if
+       call aggregate_area(self%aicen(i,j,:), self%aice(i,j), aice0)
      end do
   end do
 
@@ -361,9 +321,6 @@ subroutine soca_ciceutils_write(self, geom)
      call nc_check(nf90_inq_varid(ncid,"Tsfcn",varid))
      call nc_check(nf90_put_var(ncid,varid,glb%tsfcn))
 
-     call nc_check(nf90_inq_varid(ncid,"iceumask",varid))
-     call nc_check(nf90_put_var(ncid,varid,glb%iceumask))
-
      do l = 1, self%ice_lev
         write(strnum,'(i1)') l
         cicevarname = "qice00"//strnum
@@ -397,8 +354,6 @@ subroutine soca_ciceutils_finalize(self)
   ncat = 0
   ice_lev = 0
   sno_lev = 0
-
-  deallocate(self%iceumask)
 
   deallocate(self%aicen)
   deallocate(self%vicen)

--- a/src/soca/VariableChange/Soca2Cice/soca_soca2cice_mod.F90
+++ b/src/soca/VariableChange/Soca2Cice/soca_soca2cice_mod.F90
@@ -415,18 +415,18 @@ subroutine cleanup_ice(self, geom, xm)
           endif
         enddo
         ! remove ice over land
-        ! if (geom%mask2d(i,j) == 0) then
-        !   self%cice%aicen(i,j,:) = 0_kind_real
-        !   self%cice%vicen(i,j,:) = 0_kind_real
-        !   self%cice%vsnon(i,j,:) = 0_kind_real
-        !   self%cice%apnd(i,j,:) = 0_kind_real
-        !   self%cice%hpnd(i,j,:) = 0_kind_real
-        !   self%cice%ipnd(i,j,:) = 0_kind_real
-        !   self%cice%qice(i,j,:,:) = 0_kind_real
-        !   self%cice%sice(i,j,:,:) = 0_kind_real
-        !   self%cice%qsno(i,j,:,:) = 0_kind_real
-        !   self%cice%tsfcn(i,j,:) = 0_kind_real
-        ! endif
+        if (geom%mask2d(i,j) == 0) then
+          self%cice%aicen(i,j,:) = 0_kind_real
+          self%cice%vicen(i,j,:) = 0_kind_real
+          self%cice%vsnon(i,j,:) = 0_kind_real
+          self%cice%apnd(i,j,:) = 0_kind_real
+          self%cice%hpnd(i,j,:) = 0_kind_real
+          self%cice%ipnd(i,j,:) = 0_kind_real
+          self%cice%qice(i,j,:,:) = 0_kind_real
+          self%cice%sice(i,j,:,:) = 0_kind_real
+          self%cice%qsno(i,j,:,:) = 0_kind_real
+          self%cice%tsfcn(i,j,:) = 0_kind_real
+        endif
         ! re-compute aggregates = analysis that is effectively inserted in the restart
         data_aice(1, idx) = sum(self%cice%aicen(i,j,:))
         data_hice(1, idx) = sum(self%cice%vicen(i,j,:))

--- a/src/soca/VariableChange/Soca2Cice/soca_soca2cice_mod.F90
+++ b/src/soca/VariableChange/Soca2Cice/soca_soca2cice_mod.F90
@@ -211,6 +211,8 @@ subroutine shuffle_ice(self, geom, xm)
   call cice_in%copydata(self%cice)
   do j = geom%jsc, geom%jec
      do i = geom%isc, geom%iec
+        if (geom%mask2d(i,j) == 0) cycle        ! skip land points
+
         atlas_idx = geom%atlas_ij2idx(i,j)
         local_aice = data_aice(1, atlas_idx)    ! ice fraction analysis
 
@@ -223,7 +225,7 @@ subroutine shuffle_ice(self, geom, xm)
           seaice_edge = self%antarctic%seaice_edge
         endif
         if (self%cice%aice(i,j).gt.seaice_edge) cycle     ! skip if the background has more ice than the threshold
-        if (local_aice.le.0.0_kind_real) then
+        if (local_aice.le.0.0_kind_real) then             ! set state to zero if the analysis is zero
            self%cice%aicen(i,j,:) = 0_kind_real
            self%cice%vicen(i,j,:) = 0_kind_real
            self%cice%vsnon(i,j,:) = 0_kind_real
@@ -234,8 +236,8 @@ subroutine shuffle_ice(self, geom, xm)
            self%cice%sice(i,j,:,:) = 0_kind_real
            self%cice%qsno(i,j,:,:) = 0_kind_real
            self%cice%tsfcn(i,j,:) = icepack_liquidus_temperature(data_socn(1, atlas_idx))
+           cycle
         endif
-        if (self%cice%agg%n_src == 0) cycle               ! skip if there are no points on this task with ice in the background
         do ii = i - halo, i + halo
           do jj = j - halo, j + halo
             testmin(ii-i+halo+1, jj-j+halo+1) = abs(cice_in%aice(ii,jj) - local_aice)
@@ -412,6 +414,19 @@ subroutine cleanup_ice(self, geom, xm)
             self%cice%tsfcn(i,j,k) = Tf
           endif
         enddo
+        ! remove ice over land
+        ! if (geom%mask2d(i,j) == 0) then
+        !   self%cice%aicen(i,j,:) = 0_kind_real
+        !   self%cice%vicen(i,j,:) = 0_kind_real
+        !   self%cice%vsnon(i,j,:) = 0_kind_real
+        !   self%cice%apnd(i,j,:) = 0_kind_real
+        !   self%cice%hpnd(i,j,:) = 0_kind_real
+        !   self%cice%ipnd(i,j,:) = 0_kind_real
+        !   self%cice%qice(i,j,:,:) = 0_kind_real
+        !   self%cice%sice(i,j,:,:) = 0_kind_real
+        !   self%cice%qsno(i,j,:,:) = 0_kind_real
+        !   self%cice%tsfcn(i,j,:) = 0_kind_real
+        ! endif
         ! re-compute aggregates = analysis that is effectively inserted in the restart
         data_aice(1, idx) = sum(self%cice%aicen(i,j,:))
         data_hice(1, idx) = sum(self%cice%vicen(i,j,:))
@@ -461,6 +476,8 @@ subroutine prior_dist_rescale(self, geom, xm)
 
   do j = geom%jsc, geom%jec
     do i = geom%isc, geom%iec
+      if (geom%mask2d(i,j) == 0) cycle   ! skip land points
+
       idx = geom%atlas_ij2idx(i,j)
 
         if (geom%lat(i,j)>0.0_kind_real) then

--- a/test/testref/convertstate_soca2cice.test
+++ b/test/testref/convertstate_soca2cice.test
@@ -1,9 +1,9 @@
 Input state: 
   Valid time: 2018-04-15T00:00:00Z
-sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772900527789
-             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897729602
+sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772957651668
+             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897892885
        sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642064969300
-          sea_ice_area_fraction   min=-0.0001291896179326   max=1.0000039848914242   mean=0.1175172743974210
+          sea_ice_area_fraction   min=-0.0001291896201772   max=1.0000039848914943   mean=0.1175172743954775
               sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246947   mean=0.4712515705773916
          sea_ice_snow_thickness   min=0.0000000000000000   max=1.2712833951042413   mean=0.0886865877527975
 Variable transform: 
@@ -11,17 +11,17 @@ Variable change from: 6 variables: sea_water_potential_temperature, sea_water_sa
 Variable change to: 6 variables: sea_water_potential_temperature, sea_water_salinity, sea_water_cell_thickness, sea_ice_area_fraction, sea_ice_thickness, sea_ice_snow_thickness
 State after variable transform: 
   Valid time: 2018-04-15T00:00:00Z
-sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772900527789
-             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897729602
+sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772957651668
+             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897892885
        sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642064969300
-          sea_ice_area_fraction   min=0.0000000000000000   max=1.0000000000000000   mean=0.1175336615036262
-              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246938   mean=0.2803526142139755
-         sea_ice_snow_thickness   min=0.0000000000000000   max=1.2712833951042413   mean=0.0419941236461814
+          sea_ice_area_fraction   min=0.0000000000000000   max=1.0000000000000000   mean=0.1167406327227200
+              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246938   mean=0.2807012092576640
+         sea_ice_snow_thickness   min=0.0000000000000000   max=1.2100926350035233   mean=0.0412917261980119
 Output state: 
   Valid time: 2018-04-15T00:00:00Z
-sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772900527789
-             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897729602
+sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772957651668
+             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897892885
        sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642064969300
-          sea_ice_area_fraction   min=0.0000000000000000   max=1.0000000000000000   mean=0.1175336615036262
-              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246938   mean=0.2803526142139755
-         sea_ice_snow_thickness   min=0.0000000000000000   max=1.2712833951042413   mean=0.0419941236461814
+          sea_ice_area_fraction   min=0.0000000000000000   max=1.0000000000000000   mean=0.1167406327227200
+              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246938   mean=0.2807012092576640
+         sea_ice_snow_thickness   min=0.0000000000000000   max=1.2100926350035233   mean=0.0412917261980119


### PR DESCRIPTION
## Description

Soca2Cice on develop is effectively removing ice close to the coast, especially evident in the Canadian Archipelago in winter. This is because it's using umask from the restart files to remove ice "over land" (except it turns out it's not really over land).

This is fixing it by using the mask from the geometry to mask out points on land. Some code that is no longer used is removed.


### Issue(s) addressed

Fixes #1160 

Test from a winter high-res experiment:
CICE restart background:
![bg](https://github.com/user-attachments/assets/678f1a8f-e654-480e-8521-aaa3c9847b4d)
Raw SOCA increment:
![soca_inc](https://github.com/user-attachments/assets/70c9ece9-8c2e-41ac-b23c-985df219bc70)
CICE restart analysis (result of ConvertState using Soca2Cice and increment above) - CICE restart background, on develop (note coastlines pattern):
![restan_restbg_diff_dev](https://github.com/user-attachments/assets/b72239a9-60d8-4239-8a5b-0f42d03a7dda)
CICE restart analysis - CICE restart background, with this branch:
![restan_restbg_diff_fix](https://github.com/user-attachments/assets/31abe39c-431d-4a87-9273-e210e0348557)
