### PR TITLE
Adjust SST in Soca2Cice

### DIFF
--- a/src/soca/VariableChange/Soca2Cice/Soca2Cice.F90
+++ b/src/soca/VariableChange/Soca2Cice/Soca2Cice.F90
@@ -73,9 +73,13 @@ subroutine soca_soca2cice_setup_f90(c_key_self, c_conf, c_key_geom) &
   call f_conf%get_or_die("arctic.rescale prior.rescale", self%arctic%rescale_prior)
   call f_conf%get_or_die("arctic.rescale prior.min hice", self%arctic%rescale_min_hice)
   call f_conf%get_or_die("arctic.rescale prior.min hsno", self%arctic%rescale_min_hsno)
+  call f_conf%get_or_die("arctic.update SST", self%arctic%update_sst)
+  call f_conf%get_or_die("arctic.max positive SST update", self%arctic%max_update_sst)
   call f_conf%get_or_die("antarctic.rescale prior.rescale", self%antarctic%rescale_prior)
   call f_conf%get_or_die("antarctic.rescale prior.min hice", self%antarctic%rescale_min_hice)
   call f_conf%get_or_die("antarctic.rescale prior.min hsno", self%antarctic%rescale_min_hsno)
+  call f_conf%get_or_die("antarctic.update SST", self%antarctic%update_sst)
+  call f_conf%get_or_die("antarctic.max positive SST update", self%antarctic%max_update_sst)
   ! icepack time step for rebinning
   call f_conf%get_or_die("icepack time step", self%dt)
   ! shuffle stencil size

--- a/src/soca/VariableChange/Soca2Cice/Soca2Cice.h
+++ b/src/soca/VariableChange/Soca2Cice/Soca2Cice.h
@@ -51,6 +51,11 @@ class Soca2Cice: public VariableChangeBase {
     oops::Parameter<RescaleParameters> rescale{"rescale prior",
       "Option to rescale sea ice in the ice pack zone (where ice concentration"
       " > seaice edge)", {}, this};
+    oops::Parameter<bool> adjustSST{"update SST",
+      "Option to update sea surface temperature", true, this};
+    oops::Parameter<double> sstDiffMax{"max positive SST update",
+      "Maximum update to sea surface temperature (K)", 1.0, this,
+      {oops::minConstraint(0.0)}};
   };
 
   // ---------------------------------------------------------------------------

--- a/src/soca/VariableChange/Soca2Cice/soca_soca2cice_mod.F90
+++ b/src/soca/VariableChange/Soca2Cice/soca_soca2cice_mod.F90
@@ -10,6 +10,7 @@ use fckit_configuration_module, only: fckit_configuration
 use fckit_exception_module, only: fckit_exception
 use fckit_mpi_module, only: fckit_mpi_comm
 use kinds, only: kind_real
+use mpp_domains_mod, only : mpp_update_domains
 
 use icepack_itd, only: icepack_init_itd, cleanup_itd
 use icepack_warnings, only: icepack_warnings_flush, icepack_warnings_aborted
@@ -42,6 +43,8 @@ type, public :: soca_soca2cice_params
    logical :: rescale_prior
    real(kind=kind_real) :: rescale_min_hice
    real(kind=kind_real) :: rescale_min_hsno
+   logical :: update_sst
+   real(kind=kind_real) :: max_update_sst
 end type soca_soca2cice_params
 
 type, public :: soca_soca2cice
@@ -180,12 +183,14 @@ subroutine shuffle_ice(self, geom, xm)
   type(soca_geom), target, intent(in)  :: geom
   type(soca_state),      intent(inout) :: xm
 
-  real(kind=kind_real) :: local_aice, seaice_edge, sst, Tf
+  real(kind=kind_real) :: local_aice, seaice_edge, sst, Tf, max_update_sst
+  logical :: update_sst
   integer :: i, j, k, ii, jj, atlas_idx, halo, npos
   integer :: minidx(2)
   real(kind=kind_real), allocatable :: testmin(:,:)
 
   type(cice_state) :: cice_in
+  real(kind=kind_real), allocatable :: tocn_in(:,:)
   type(atlas_field) :: tocn, socn, aice
   real(kind=kind_real), pointer :: data_tocn(:,:), data_socn(:,:), data_aice(:,:)
 
@@ -210,7 +215,18 @@ subroutine shuffle_ice(self, geom, xm)
 
   allocate(testmin(2*halo + 1, 2*halo + 1))
 
+  ! make copies of the cice state and sst since the original state
+  ! needs to be used for the shuffle
   call cice_in%copydata(self%cice)
+  allocate(tocn_in(geom%isd:geom%ied, geom%jsd:geom%jed))
+  do j = geom%jsc, geom%jec
+    do i = geom%isc, geom%iec
+      atlas_idx = geom%atlas_ij2idx(i,j)
+      tocn_in(i,j) = data_tocn(1, atlas_idx)
+    end do
+  end do
+  call mpp_update_domains(tocn_in, geom%Domain%mpp_domain)
+
   do j = geom%jsc, geom%jec
      do i = geom%isc, geom%iec
         if (geom%mask2d(i,j) == 0) cycle        ! skip land points
@@ -222,43 +238,46 @@ subroutine shuffle_ice(self, geom, xm)
         if (geom%lat(i,j)>0.0_kind_real) then
           if (.not. self%arctic%shuffle) cycle
           seaice_edge = self%arctic%seaice_edge
+          update_sst = self%arctic%update_sst
+          max_update_sst = self%arctic%max_update_sst
         else
           if (.not. self%antarctic%shuffle) cycle
           seaice_edge = self%antarctic%seaice_edge
+          update_sst = self%antarctic%update_sst
+          max_update_sst = self%antarctic%max_update_sst
         endif
         if (self%cice%aice(i,j).gt.seaice_edge) cycle     ! skip if the background has more ice than the threshold
         if (local_aice.le.0.0_kind_real) then             ! set state to zero if the analysis is zero
-          self%cice%aicen(i,j,:) = 0_kind_real
-          self%cice%vicen(i,j,:) = 0_kind_real
-          self%cice%vsnon(i,j,:) = 0_kind_real
-          self%cice%apnd(i,j,:) = 0_kind_real
-          self%cice%hpnd(i,j,:) = 0_kind_real
-          self%cice%ipnd(i,j,:) = 0_kind_real
-          self%cice%qice(i,j,:,:) = 0_kind_real
-          self%cice%sice(i,j,:,:) = 0_kind_real
-          self%cice%qsno(i,j,:,:) = 0_kind_real
-          Tf = icepack_liquidus_temperature(data_socn(1, atlas_idx))
-          self%cice%tsfcn(i,j,:) = Tf
-          ! adjust SST (when we have some data) if ice is removed and SST is freezing
-          if ((cice_in%aice(i,j) > 0.0) .and. (data_tocn(1,atlas_idx)<Tf+0.1)) then
-            npos = 1
-            sst = data_tocn(1, atlas_idx)
-            do ii = i - 1, i + 1
-              do jj = j - 1, j + 1
-                if (cice_in%aice(ii,jj) == 0.0) then
-                  sst = sst + data_tocn(1, geom%atlas_ij2idx(ii,jj))
-                  npos = npos + 1
-                endif
-              enddo
-            enddo
-            sst = sst / npos
-            if (sst > data_tocn(1,atlas_idx) + 1.0) then
-              sst = data_tocn(1, atlas_idx) + 1.0
-            endif
-            print *, "soca2cice: setting SST from ", data_tocn(1, atlas_idx), "to ", sst, &
-                     " at (", i, ",", j, ") with no ice"
-          endif
-          cycle
+           self%cice%aicen(i,j,:) = 0_kind_real
+           self%cice%vicen(i,j,:) = 0_kind_real
+           self%cice%vsnon(i,j,:) = 0_kind_real
+           self%cice%apnd(i,j,:) = 0_kind_real
+           self%cice%hpnd(i,j,:) = 0_kind_real
+           self%cice%ipnd(i,j,:) = 0_kind_real
+           self%cice%qice(i,j,:,:) = 0_kind_real
+           self%cice%sice(i,j,:,:) = 0_kind_real
+           self%cice%qsno(i,j,:,:) = 0_kind_real
+           Tf = icepack_liquidus_temperature(data_socn(1, atlas_idx))
+           self%cice%tsfcn(i,j,:) = Tf
+           ! adjust SST (when we have some data) if ice is removed and SST is freezing
+           if (update_sst .and. (cice_in%aice(i,j) > 0.0) .and. (data_tocn(1,atlas_idx)<=Tf)) then
+             npos = 1
+             sst = data_tocn(1,atlas_idx)
+             do ii = i - 1, i + 1
+               do jj = j - 1, j + 1
+                 if (cice_in%aice(ii,jj) == 0.0) then
+                   sst = sst + tocn_in(ii,jj)
+                   npos = npos + 1
+                 endif
+               enddo
+             enddo
+             sst = sst / npos
+             if (sst > data_tocn(1,atlas_idx) + max_update_sst) then
+               sst = data_tocn(1, atlas_idx) + max_update_sst
+             endif
+             data_tocn(1, atlas_idx) = sst
+           endif
+           cycle
         endif
         do ii = i - halo, i + halo
           do jj = j - halo, j + halo
@@ -286,16 +305,15 @@ subroutine shuffle_ice(self, geom, xm)
            self%cice%qsno(i, j,: , k) = cice_in%qsno(ii, jj, :, k)
         end do
         ! adjust SST when ice is added
-        if ((self%cice%aice(i, j) > 0.0) .and. (cice_in%aice(i,j) == 0.0)) then
+        if (update_sst .and. (self%cice%aice(i, j) > 0.0) .and. (cice_in%aice(i,j) == 0.0)) then
            local_aice = self%cice%aice(i, j)
            sst = local_aice * icepack_liquidus_temperature(data_socn(1, atlas_idx)) + &
                  (1.0_kind_real - local_aice) * data_tocn(1, atlas_idx)
-           print *, "soca2cice: setting SST from ", data_tocn(1, atlas_idx), "to ", &
-                 sst, " at (", i, ",", j, ") with ice"
            data_tocn(1, atlas_idx) = sst
         endif
      end do
   end do
+  deallocate(tocn_in)
   call tocn%final()
   call socn%final()
   call aice%final()

--- a/src/soca/VariableChange/Soca2Cice/soca_soca2cice_mod.F90
+++ b/src/soca/VariableChange/Soca2Cice/soca_soca2cice_mod.F90
@@ -180,17 +180,19 @@ subroutine shuffle_ice(self, geom, xm)
   type(soca_geom), target, intent(in)  :: geom
   type(soca_state),      intent(inout) :: xm
 
-  real(kind=kind_real) :: local_aice, seaice_edge
-  integer :: i, j, k, ii, jj, atlas_idx, halo
+  real(kind=kind_real) :: local_aice, seaice_edge, sst, Tf
+  integer :: i, j, k, ii, jj, atlas_idx, halo, npos
   integer :: minidx(2)
   real(kind=kind_real), allocatable :: testmin(:,:)
 
   type(cice_state) :: cice_in
-  type(atlas_field) :: socn, aice
-  real(kind=kind_real), pointer :: data_socn(:,:), data_aice(:,:)
+  type(atlas_field) :: tocn, socn, aice
+  real(kind=kind_real), pointer :: data_tocn(:,:), data_socn(:,:), data_aice(:,:)
 
+  tocn = xm%afieldset%field("sea_water_potential_temperature")
   socn = xm%afieldset%field("sea_water_salinity")
   aice = xm%afieldset%field("sea_ice_area_fraction")
+  call tocn%data(data_tocn)
   call socn%data(data_socn)
   call aice%data(data_aice)
 
@@ -226,17 +228,37 @@ subroutine shuffle_ice(self, geom, xm)
         endif
         if (self%cice%aice(i,j).gt.seaice_edge) cycle     ! skip if the background has more ice than the threshold
         if (local_aice.le.0.0_kind_real) then             ! set state to zero if the analysis is zero
-           self%cice%aicen(i,j,:) = 0_kind_real
-           self%cice%vicen(i,j,:) = 0_kind_real
-           self%cice%vsnon(i,j,:) = 0_kind_real
-           self%cice%apnd(i,j,:) = 0_kind_real
-           self%cice%hpnd(i,j,:) = 0_kind_real
-           self%cice%ipnd(i,j,:) = 0_kind_real
-           self%cice%qice(i,j,:,:) = 0_kind_real
-           self%cice%sice(i,j,:,:) = 0_kind_real
-           self%cice%qsno(i,j,:,:) = 0_kind_real
-           self%cice%tsfcn(i,j,:) = icepack_liquidus_temperature(data_socn(1, atlas_idx))
-           cycle
+          self%cice%aicen(i,j,:) = 0_kind_real
+          self%cice%vicen(i,j,:) = 0_kind_real
+          self%cice%vsnon(i,j,:) = 0_kind_real
+          self%cice%apnd(i,j,:) = 0_kind_real
+          self%cice%hpnd(i,j,:) = 0_kind_real
+          self%cice%ipnd(i,j,:) = 0_kind_real
+          self%cice%qice(i,j,:,:) = 0_kind_real
+          self%cice%sice(i,j,:,:) = 0_kind_real
+          self%cice%qsno(i,j,:,:) = 0_kind_real
+          Tf = icepack_liquidus_temperature(data_socn(1, atlas_idx))
+          self%cice%tsfcn(i,j,:) = Tf
+          ! adjust SST (when we have some data) if ice is removed and SST is freezing
+          if ((cice_in%aice(i,j) > 0.0) .and. (data_tocn(1,atlas_idx)<Tf+0.1)) then
+            npos = 1
+            sst = data_tocn(1, atlas_idx)
+            do ii = i - 1, i + 1
+              do jj = j - 1, j + 1
+                if (cice_in%aice(ii,jj) == 0.0) then
+                  sst = sst + data_tocn(1, geom%atlas_ij2idx(ii,jj))
+                  npos = npos + 1
+                endif
+              enddo
+            enddo
+            sst = sst / npos
+            if (sst > data_tocn(1,atlas_idx) + 1.0) then
+              sst = data_tocn(1, atlas_idx) + 1.0
+            endif
+            print *, "soca2cice: setting SST from ", data_tocn(1, atlas_idx), "to ", sst, &
+                     " at (", i, ",", j, ") with no ice"
+          endif
+          cycle
         endif
         do ii = i - halo, i + halo
           do jj = j - halo, j + halo
@@ -263,9 +285,18 @@ subroutine shuffle_ice(self, geom, xm)
         do k = 1, self%sno_lev
            self%cice%qsno(i, j,: , k) = cice_in%qsno(ii, jj, :, k)
         end do
+        ! adjust SST when ice is added
+        if ((self%cice%aice(i, j) > 0.0) .and. (cice_in%aice(i,j) == 0.0)) then
+           local_aice = self%cice%aice(i, j)
+           sst = local_aice * icepack_liquidus_temperature(data_socn(1, atlas_idx)) + &
+                 (1.0_kind_real - local_aice) * data_tocn(1, atlas_idx)
+           print *, "soca2cice: setting SST from ", data_tocn(1, atlas_idx), "to ", &
+                 sst, " at (", i, ",", j, ") with ice"
+           data_tocn(1, atlas_idx) = sst
+        endif
      end do
   end do
-
+  call tocn%final()
   call socn%final()
   call aice%final()
 end subroutine shuffle_ice

--- a/test/testref/convertstate_soca2cice.test
+++ b/test/testref/convertstate_soca2cice.test
@@ -11,7 +11,7 @@ Variable change from: 6 variables: sea_water_potential_temperature, sea_water_sa
 Variable change to: 6 variables: sea_water_potential_temperature, sea_water_salinity, sea_water_cell_thickness, sea_ice_area_fraction, sea_ice_thickness, sea_ice_snow_thickness
 State after variable transform: 
   Valid time: 2018-04-15T00:00:00Z
-sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772957651668
+sea_water_potential_temperature   min=-1.8951460167747605   max=31.7004645720658580   mean=6.0192510258625207
              sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897892885
        sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642064969300
           sea_ice_area_fraction   min=0.0000000000000000   max=1.0000000000000000   mean=0.1167406327227200
@@ -19,7 +19,7 @@ sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658
          sea_ice_snow_thickness   min=0.0000000000000000   max=1.2100926350035233   mean=0.0412917261980119
 Output state: 
   Valid time: 2018-04-15T00:00:00Z
-sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772957651668
+sea_water_potential_temperature   min=-1.8951460167747605   max=31.7004645720658580   mean=6.0192510258625207
              sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897892885
        sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642064969300
           sea_ice_area_fraction   min=0.0000000000000000   max=1.0000000000000000   mean=0.1167406327227200


### PR DESCRIPTION
## Description

Adjusts SST when adding ice increment if `update SST` is set to true (it is by default now):
- if ice is removed, average current SST with SST from the nearby gridpoints without ice, and limit the increment to `max positive SST update` (1C by default)
- if ice is added, make SST a weighted average of current SST with freezing temperature (weights are based on ice concentration).

A new exciting way to do coupled covariances 🩹 

## Testing

I'll post results from the high-res runs once ready.