### PR TITLE
Bugfix for ice thickness and snow thickness adjustment

### DIFF
--- a/src/soca/VariableChange/Soca2Cice/README.md
+++ b/src/soca/VariableChange/Soca2Cice/README.md
@@ -32,7 +32,7 @@ Sea ice in CICE is represented using multiple thickness categories (`ncat`), whi
 - Operates in the ice pack (where concentration > `seaice_edge`) 
 - Rescales the background ice distribution to match the analyzed aggregated values
 - Preserves the shape of the distribution across categories
-- Separately adjusts ice volume and snow volume when they exceed minimum thresholds
+- Separately adjusts ice thickness and snow thickness to match the analysis when they exceed minimum thresholds
 
 ### 4. Ice State Cleanup (`cleanup_ice`)
 - Calls icepack's `cleanup_itd` to rebin thickness categories if necessary
@@ -49,8 +49,8 @@ SOCA2CICE offers separate configurations for Arctic and Antarctic regions:
 - `shuffle`: Enable/disable shuffling in marginal ice zone (default: true)
 - `rescale prior`: Options for rescaling in the ice pack
   - `rescale` : Enable/disable rescaling in the ice pack (default: false)
-  - `min hice`: Minimum ice thickness to trigger adjusting ice volume during rescaling (default: 0.5m)
-  - `min hsno`: Minimum snow thickness to trigger adjusting snow volume during rescaling (default: 0.1m)
+  - `min hice`: Minimum ice thickness to trigger adjusting ice thickness to the analysis ice thickness during rescaling (default: 0.5m)
+  - `min hsno`: Minimum snow thickness to trigger adjusting snow thickness to the analysis snow thickness during rescaling (default: 0.1m)
 - `update SST`: Adjust sea surface temperature when adding/removing ice (default: true)
 - `max positive SST update`: Maximum allowed SST increase when removing ice (default: 1.0K)
 

--- a/src/soca/VariableChange/Soca2Cice/soca_soca2cice_mod.F90
+++ b/src/soca/VariableChange/Soca2Cice/soca_soca2cice_mod.F90
@@ -557,18 +557,19 @@ subroutine prior_dist_rescale(self, geom, xm)
            self%cice%vsnon(i,j,c) = alpha*self%cice%vsnon(i,j,c)
         end do
 
-        ! adjust ice volume to match mean cell thickness
-        local_hice = sum(self%cice%vicen(i,j,:))/self%cice%aice(i,j)
-        if (local_hice.gt.rescale_min_hice) then
-           alpha = data_hice(1, idx)/local_hice
-           self%cice%vicen(i,j,:) = alpha*self%cice%vicen(i,j,:)
-        end if
-
-        ! adjust snow volume to match mean cell thickness
-        local_hsno = sum(self%cice%vsnon(i,j,:))/self%cice%aice(i,j)
-        if (local_hsno.gt.rescale_min_hsno) then
-           alpha = data_hsno(1, idx)/local_hsno
-           self%cice%vsnon(i,j,:) = alpha*self%cice%vsnon(i,j,:)
+        if (self%cice%aice(i,j).gt.0.0) then
+          ! adjust ice volume to match mean cell thickness
+          local_hice = sum(self%cice%vicen(i,j,:))/self%cice%aice(i,j)
+          if (local_hice.gt.rescale_min_hice) then
+             alpha = data_hice(1, idx)/local_hice
+             self%cice%vicen(i,j,:) = alpha*self%cice%vicen(i,j,:)
+          end if
+          ! adjust snow volume to match mean cell thickness
+          local_hsno = sum(self%cice%vsnon(i,j,:))/self%cice%aice(i,j)
+          if (local_hsno.gt.rescale_min_hsno) then
+             alpha = data_hsno(1, idx)/local_hsno
+             self%cice%vsnon(i,j,:) = alpha*self%cice%vsnon(i,j,:)
+          end if
         end if
     end do
   end do

--- a/src/soca/VariableChange/Soca2Cice/soca_soca2cice_mod.F90
+++ b/src/soca/VariableChange/Soca2Cice/soca_soca2cice_mod.F90
@@ -481,6 +481,11 @@ subroutine cleanup_ice(self, geom, xm)
         data_aice(1, idx) = sum(self%cice%aicen(i,j,:))
         data_hice(1, idx) = sum(self%cice%vicen(i,j,:))
         data_hsno(1, idx) = sum(self%cice%vsnon(i,j,:))
+        ! compute thickness from volume
+        if (data_aice(1, idx)> 0.0) then
+          data_hice(1, idx) = data_hice(1, idx) / data_aice(1, idx)
+          data_hsno(1, idx) = data_hsno(1, idx) / data_aice(1, idx)
+        endif
      end do
   end do
   if (count_thinice > 0) then
@@ -553,14 +558,14 @@ subroutine prior_dist_rescale(self, geom, xm)
         end do
 
         ! adjust ice volume to match mean cell thickness
-        local_hice = sum(self%cice%vicen(i,j,:))
+        local_hice = sum(self%cice%vicen(i,j,:))/self%cice%aice(i,j)
         if (local_hice.gt.rescale_min_hice) then
            alpha = data_hice(1, idx)/local_hice
            self%cice%vicen(i,j,:) = alpha*self%cice%vicen(i,j,:)
         end if
 
         ! adjust snow volume to match mean cell thickness
-        local_hsno = sum(self%cice%vsnon(i,j,:))
+        local_hsno = sum(self%cice%vsnon(i,j,:))/self%cice%aice(i,j)
         if (local_hsno.gt.rescale_min_hsno) then
            alpha = data_hsno(1, idx)/local_hsno
            self%cice%vsnon(i,j,:) = alpha*self%cice%vsnon(i,j,:)

--- a/test/testref/convertstate_soca2cice.test
+++ b/test/testref/convertstate_soca2cice.test
@@ -1,9 +1,9 @@
 Input state: 
   Valid time: 2018-04-15T00:00:00Z
-sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772957651668
-             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897892885
+sea_water_potential_temperature   min=-1.8883899372702533   max=31.7004645720658580   mean=6.0192772781549593
+             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897706012
        sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642064969300
-          sea_ice_area_fraction   min=-0.0001291896201772   max=1.0000039848914943   mean=0.1175172743954775
+          sea_ice_area_fraction   min=-0.0001291896323735   max=1.0000039848918769   mean=0.1175172743971132
               sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246947   mean=0.4712515705773916
          sea_ice_snow_thickness   min=0.0000000000000000   max=1.2712833951042413   mean=0.0886865877527975
 Variable transform: 
@@ -12,16 +12,16 @@ Variable change to: 6 variables: sea_water_potential_temperature, sea_water_sali
 State after variable transform: 
   Valid time: 2018-04-15T00:00:00Z
 sea_water_potential_temperature   min=-1.8951460167747605   max=31.7004645720658580   mean=6.0192510258625207
-             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897892885
+             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897706012
        sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642064969300
-          sea_ice_area_fraction   min=0.0000000000000000   max=1.0000000000000000   mean=0.1167406327227200
-              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246938   mean=0.2807012092576640
-         sea_ice_snow_thickness   min=0.0000000000000000   max=1.2100926350035233   mean=0.0412917261980119
+          sea_ice_area_fraction   min=0.0000000000000000   max=1.0000000000000000   mean=0.1167403768734428
+              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246929   mean=0.3195396038013688
+         sea_ice_snow_thickness   min=0.0000000000000000   max=1.2101054641859532   mean=0.0523276949797452
 Output state: 
   Valid time: 2018-04-15T00:00:00Z
 sea_water_potential_temperature   min=-1.8951460167747605   max=31.7004645720658580   mean=6.0192510258625207
-             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897892885
+             sea_water_salinity   min=10.7210460395083924   max=40.4416591897031168   mean=34.5443997897706012
        sea_water_cell_thickness   min=0.0009999999999977   max=1345.6400000000003274   mean=128.6280642064969300
-          sea_ice_area_fraction   min=0.0000000000000000   max=1.0000000000000000   mean=0.1167406327227200
-              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246938   mean=0.2807012092576640
-         sea_ice_snow_thickness   min=0.0000000000000000   max=1.2100926350035233   mean=0.0412917261980119
+          sea_ice_area_fraction   min=0.0000000000000000   max=1.0000000000000000   mean=0.1167403768734428
+              sea_ice_thickness   min=0.0000000000000000   max=4.0326673084246929   mean=0.3195396038013688
+         sea_ice_snow_thickness   min=0.0000000000000000   max=1.2101054641859532   mean=0.0523276949797452


### PR DESCRIPTION
## Description

Update for soca2cice code to fix an issue with ice and snow thickness adjustment.

This was noticed by Nick Szapiro in https://github.com/NOAA-EMC/GDASApp/issues/1868#issuecomment-3222018558.

Plots below are for ice concentration with: background restart, soca analysis, result of soca2cice on develop, result of soca2cice with the fix (plots are from the results of soca2cice test):
<img width="400" height="400" alt="background_arctic_ice_thickness_m" src="https://github.com/user-attachments/assets/8fddfc96-4a71-455d-8dc7-14dc2b6f4b68" /> <img width="400" height="400" alt="outputan_arctic_hi_h" src="https://github.com/user-attachments/assets/7609cef6-a7e9-4e58-8f3f-96a3ccb3cdaa" /> <img width="400" height="400" alt="analysis_arctic_ice_thickness_m" src="https://github.com/user-attachments/assets/cb95956b-5a33-4196-9453-c92bcd1be454" /> <img width="400" height="400" alt="analysisnew3_arctic_ice_thickness_m" src="https://github.com/user-attachments/assets/a4712035-6532-4ce0-8cf1-44acb3f45145" />

With the changes in this branch, as expected, in the ice pack where rescaling is happening, ice thickness now matches what analysis is.

I also ran the test replacing soca analysis with what's in the background to mimic what we do in GFSv17 (no ice thickness updates).
<img width="400" height="400" alt="background_arctic_ice_thickness_m" src="https://github.com/user-attachments/assets/bc453839-6e5e-4a7c-8c0a-aa3a3684ab7c" /> <img width="400" height="400" alt="outputnew_arctic_hi_h" src="https://github.com/user-attachments/assets/07c291be-a755-4cd7-aaed-8ae6804121be" /> <img width="400" height="400" alt="analysisnew5_arctic_ice_thickness_m" src="https://github.com/user-attachments/assets/bd61203b-2e60-431c-b170-e7b29e281582" /> <img width="400" height="400" alt="analysisnew_arctic_ice_thickness_m" src="https://github.com/user-attachments/assets/05d83ebf-2d57-4389-84a8-e22465e1e397" />

Again, with changes in this branch ice thickness is correct.