### PR TITLE
Bugfix for Fortran fieldset finalizations

### DIFF
--- a/src/soca/AnalyticInit/soca_analytic_mod.F90
+++ b/src/soca/AnalyticInit/soca_analytic_mod.F90
@@ -80,8 +80,8 @@ subroutine soca_analytic_state(state)
       end do
     end do
     call field%set_dirty()
-    call field%final()
   end do
+  call field%final()
 end subroutine
 
 

--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -338,11 +338,10 @@ end subroutine
 subroutine soca_fields_create(self, geom, vars, aFieldset)
   class(soca_fields),        intent(inout) :: self
   type(soca_geom),  pointer, intent(inout) :: geom !< geometry to associate with the fields
-  type(oops_variables),      intent(in)    :: vars !< list of field names to create
-  type(atlas_fieldset),      intent(inout) :: aFieldset
+  type(oops_variables),      intent(in) :: vars !< list of field names to create
+  type(atlas_fieldset),      intent(in) :: aFieldset
 
   self%afieldset = aFieldset
-  call aFieldset%final()
   self%geom => geom
 
   ! make sure current object has not already been allocated
@@ -433,8 +432,8 @@ subroutine soca_fields_ones(self)
     call field%data(fdata)
     fdata(:,:) = 1.0_kind_real
     call field%set_dirty(.false.)
-    call field%final()
   end do
+  call field%final()
 
 end subroutine soca_fields_ones
 
@@ -523,7 +522,6 @@ subroutine soca_fields_read(self, f_conf, vdate)
         afield1  = self%afieldset%field(self%fields(f)%name)
         call afield1%data(adata1)
         adata1(:,:) = self%fields(f)%metadata%constant_value
-        call afield1%final()
       end if
     end do
 
@@ -628,8 +626,6 @@ subroutine soca_fields_read(self, f_conf, vdate)
         end do
       end do
       call afield1%set_dirty()
-      call afield1%final()
-      call afield2%final()
     end if
 
     ! Compute mixed layer depth TODO: Move somewhere else ...
@@ -652,10 +648,6 @@ subroutine soca_fields_read(self, f_conf, vdate)
         end do
       end do
       call afield1%set_dirty()
-      call afield1%final()
-      call afield2%final()
-      call afield3%final()
-      call afield4%final()
     end if
 
     ! Remap layers if needed
@@ -694,20 +686,20 @@ subroutine soca_fields_read(self, f_conf, vdate)
           end do
         end do
         call afield2%set_dirty()
-
-        ! cleanup
-        call afield2%final()
       end do
 
       ! cleanup
       call end_remapping(remapCS)
       deallocate(h_common_ij, hocn_ij, varocn_ij, varocn2_ij)
-      call afield1%final()
     end if
   end if
 
   ! cleanup
   if (allocated(h_common)) deallocate(h_common)
+  call afield1%final()
+  call afield2%final()
+  call afield3%final()
+  call afield4%final()
 end subroutine soca_fields_read
 
 
@@ -802,7 +794,6 @@ subroutine soca_fields_read_seaice(self, filename, seaice_categories_vars)
           end do
         end do
         call afield%set_dirty()
-        call afield%final()
       end if
     end do
   end if
@@ -842,10 +833,10 @@ subroutine soca_fields_read_seaice(self, filename, seaice_categories_vars)
           end do
         end do
         call afield%set_dirty()
-        call afield%final()
       end if
     end do
   end if
+  call afield%final()
 end subroutine soca_fields_read_seaice
 
 
@@ -867,7 +858,6 @@ subroutine soca_fields_write_rst(self, f_conf, vdate)
 
   character(len=3), allocatable :: domains(:)
   character(len=:), allocatable :: domain_filename
-  type(atlas_field) :: afield
 
   type(varwrapper), allocatable :: vars(:)
 
@@ -990,13 +980,13 @@ subroutine soca_fields_tohpoints(self)
     deallocate(fdata)
 
     call afield%set_dirty()
-    call afield%final()
 
     ! Update grid location to h-points
     self%fields(n)%metadata%grid = 'h'
     self%fields(n)%lon => self%geom%lon
     self%fields(n)%lat => self%geom%lat
  end do
+ call afield%final()
 
 end subroutine soca_fields_tohpoints
 
@@ -1047,12 +1037,10 @@ subroutine soca_fields_update_fields(self, vars)
       if (metadata%masked) then
         call ameta%set('mask', 'interp_mask')
       end if
-      call ameta%final()
-
-
-      call afield%final()
     end if
   end do
+  call ameta%final()
+  call afield%final()
 end subroutine soca_fields_update_fields
 
 ! ------------------------------------------------------------------------------

--- a/src/soca/Fields/soca_fields_mod.F90
+++ b/src/soca/Fields/soca_fields_mod.F90
@@ -338,15 +338,11 @@ end subroutine
 subroutine soca_fields_create(self, geom, vars, aFieldset)
   class(soca_fields),        intent(inout) :: self
   type(soca_geom),  pointer, intent(inout) :: geom !< geometry to associate with the fields
-  type(oops_variables),      intent(in) :: vars !< list of field names to create
-  type(atlas_fieldset),      intent(in) :: aFieldset
-
-  character(len=:), allocatable :: vars_str(:)
-  integer :: i
-  type(atlas_field) :: afield
-  real(kind=kind_real), pointer :: adata(:,:)
+  type(oops_variables),      intent(in)    :: vars !< list of field names to create
+  type(atlas_fieldset),      intent(inout) :: aFieldset
 
   self%afieldset = aFieldset
+  call aFieldset%final()
   self%geom => geom
 
   ! make sure current object has not already been allocated
@@ -355,6 +351,7 @@ subroutine soca_fields_create(self, geom, vars, aFieldset)
 
   ! initialize the variables
   call self%update_fields(vars)
+
 end subroutine soca_fields_create
 
 
@@ -369,6 +366,7 @@ subroutine soca_fields_delete(self)
   ! clear the fields and nullify pointers
   nullify(self%geom)
   deallocate(self%fields)
+  call self%afieldset%final()
 
 end subroutine
 

--- a/src/soca/Geometry/soca_geom_mod.F90
+++ b/src/soca/Geometry/soca_geom_mod.F90
@@ -314,6 +314,7 @@ subroutine soca_geom_end(self)
   if (allocated(self%cell_area))     deallocate(self%cell_area)
   nullify(self%Domain)
   call self%functionspace%final()
+  call self%fieldset%final()
 
 end subroutine soca_geom_end
 
@@ -420,18 +421,6 @@ subroutine soca_geom_init_fieldset(self, f_conf, gen)
   call fCos%halo_exchange()
   call fSin%halo_exchange()
 
-  ! done, cleanup
-  call fArea%final()
-  call fInterpMask%final()
-  call fVertCoord%final()
-  call fGmask%final()
-  call fOwned%final()
-  call fMaskH%final()
-  call fMaskU%final()
-  call fMaskV%final()
-  call fCos%final()
-  call fSin%final()
-
   ! -----------------------------------------------------------------------------------------------
   if (gen) then
     ! some fields are still being generated the fortran side (someday this will be moved to c++)
@@ -445,7 +434,6 @@ subroutine soca_geom_init_fieldset(self, f_conf, gen)
       end do
     end do
     call aField%halo_exchange()
-    call aField%final()
   else
     ! otherwise, read in files from the gridspec file and place directly into atlas fieldset
     atlasVars = [character(len=20) :: "rossby_radius", "distance_from_coast"]
@@ -471,8 +459,20 @@ subroutine soca_geom_init_fieldset(self, f_conf, gen)
       end do
       call aField%halo_exchange()
     end do
-    call aField%final()
   endif
+
+  ! done, cleanup
+  call fArea%final()
+  call fInterpMask%final()
+  call fVertCoord%final()
+  call fGmask%final()
+  call fOwned%final()
+  call fMaskH%final()
+  call fMaskU%final()
+  call fMaskV%final()
+  call fCos%final()
+  call fSin%final()
+  call aField%final()
 end subroutine soca_geom_init_fieldset
 
 
@@ -598,6 +598,7 @@ subroutine soca_geom_distance_from_coast(self, dist)
 
   ! cleanup
   call kd%final()
+  call ageometry%final()
 
 end subroutine
 
@@ -660,7 +661,6 @@ subroutine soca_geom_write(self, f_conf)
         fieldData(i,j,v ) = aFieldData(1, self%atlas_ij2idx(i,j))
       end do
     end do
-    call aField%final()
 
     ! register with FMS
     r = register_restart_field(geom_restart, str, trim(atlasVars(v)), fieldData(:,:, v), self%Domain%mpp_domain)
@@ -681,6 +681,7 @@ subroutine soca_geom_write(self, f_conf)
     call write2pe(reshape(self%lat(self%isc:self%iec,self%jsc:self%jec),(/ns/)),'lat',geom_output_pe,.true.)
   end if
 
+  call aField%final()
 end subroutine soca_geom_write
 
 

--- a/src/soca/Increment/soca_increment.interface.F90
+++ b/src/soca/Increment/soca_increment.interface.F90
@@ -50,6 +50,7 @@ subroutine soca_increment_create_c(c_key_self, c_key_geom, c_vars, c_afieldsest)
   vars = oops_variables(c_vars)
   afieldset = atlas_fieldset(c_afieldsest)
   call self%create(geom, vars, afieldset)
+  call afieldset%final()
 
 end subroutine soca_increment_create_c
 

--- a/src/soca/Increment/soca_increment_mod.F90
+++ b/src/soca/Increment/soca_increment_mod.F90
@@ -86,7 +86,6 @@ subroutine soca_increment_random(self)
 
     ! NOTE: can't randomize "hocn", testIncrementInterpAD fails
     if (afield%name() == "sea_water_cell_thickness") then
-      call afield%final()
       cycle
     end if
 
@@ -117,9 +116,8 @@ subroutine soca_increment_random(self)
     end if
 
     call afield%set_dirty()
-    call afield%final()
   end do
-
+  call afield%final()
 end subroutine soca_increment_random
 
 
@@ -181,7 +179,6 @@ subroutine soca_increment_dirac(self, f_conf)
     field = self%afieldset%field(n)
     call field%data(fdata)
     fdata = 0.0
-    call field%final()
   end do
 
   ! Setup Diracs
@@ -198,8 +195,8 @@ subroutine soca_increment_dirac(self, f_conf)
     ! set dirac
     fdata(izdir(n), self%geom%atlas_ij2idx(ixdir(n),iydir(n))) = 1.0
 
-    call field%final()
   end do
+  call field%final()
 end subroutine soca_increment_dirac
 
 
@@ -256,8 +253,8 @@ subroutine soca_horiz_scales(self, f_conf)
     end do
 
     call afield%set_dirty(rossby%dirty() .or. area%dirty())
-    call afield%final()
   end do
+  call afield%final()
   call rossby%final()
   call area%final()
 end subroutine soca_horiz_scales
@@ -290,9 +287,8 @@ subroutine soca_vert_scales(self, vert)
       end do
     end do
 
-    call field%final()
   end do
-
+  call field%final()
   call mask%final()
 end subroutine soca_vert_scales
 ! ------------------------------------------------------------------------------

--- a/src/soca/LinearVariableChange/Balance/soca_balance_mod.F90
+++ b/src/soca/LinearVariableChange/Balance/soca_balance_mod.F90
@@ -221,7 +221,7 @@ subroutine soca_balance_setup(self, f_conf, traj, geom)
   call hocn%final()
   call mld%final()
   call layer_depth%final()
-  if (associated(data_cice)) call cice%final()
+  call cice%final()
 
 end subroutine soca_balance_setup
 
@@ -315,10 +315,9 @@ subroutine soca_balance_mult(self, dxa, dxm)
 
     end select
 
-    call fld_m%final()
-    call fld_a%final()
   end do
-
+  call fld_m%final()
+  call fld_a%final()
   call tocn_a%final()
   call socn_a%final()
 
@@ -390,13 +389,13 @@ subroutine soca_balance_multad(self, dxa, dxm)
       call fld_a%set_dirty()
     end select
 
-    call fld_a%final()
-    call fld_m%final()
   end do
 
+  call fld_a%final()
+  call fld_m%final()
   call socn_m%final()
   call ssh_m%final()
-  if ( associated(data_cice) ) call cice_m%final()
+  call cice_m%final()
 
 end subroutine soca_balance_multad
 
@@ -469,9 +468,10 @@ subroutine soca_balance_multinv(self, dxa, dxm)
       call fld_a%set_dirty()
 
     end select
-    call fld_m%final()
-    call fld_a%final()
+
   end do
+  call fld_m%final()
+  call fld_a%final()
   call tocn_m%final()
   call socn_m%final()
 
@@ -544,13 +544,14 @@ subroutine soca_balance_multinvad(self, dxa, dxm)
       call fld_m%set_dirty()
 
     end select
-    call fld_m%final()
-    call fld_a%final()
+
   end do
 
+  call fld_m%final()
+  call fld_a%final()
   call socn_a%final()
   call ssh_a%final()
-  if (associated(data_cice)) call cice_a%final()
+  call cice_a%final()
 
 end subroutine soca_balance_multinvad
 

--- a/src/soca/State/soca_state.interface.F90
+++ b/src/soca/State/soca_state.interface.F90
@@ -6,7 +6,7 @@
 !> C++ interfaces for soca_state_mod::soca_state
 module soca_state_mod_c
 
-use atlas_module, only: atlas_fieldset, atlas_field, atlas_real, atlas_metadata
+use atlas_module, only: atlas_fieldset
 use datetime_mod, only: datetime, c_f_datetime
 use fckit_configuration_module, only: fckit_configuration
 use iso_c_binding
@@ -55,6 +55,7 @@ subroutine soca_state_create_c(c_key_self, c_key_geom, c_vars, c_afieldsest) &
     vars = oops_variables(c_vars)
     afieldset = atlas_fieldset(c_afieldsest)
     call self%create(geom, vars, afieldset)
+    call afieldset%final()
 
 end subroutine soca_state_create_c
 

--- a/src/soca/Utils/soca_utils.F90
+++ b/src/soca/Utils/soca_utils.F90
@@ -255,6 +255,8 @@ subroutine soca_stencil_interp(lon_src, lat_src, lon_dst, lat_dst, data, data_ou
      data_out(k) = val/sum(w(1:nn))
   end do
 
+  call ageometry%final()
+
 end subroutine soca_stencil_interp
 
 ! ------------------------------------------------------------------------------

--- a/src/soca/VariableChange/Model2GeoVaLs/Model2GeoVaLs.F90
+++ b/src/soca/VariableChange/Model2GeoVaLs/Model2GeoVaLs.F90
@@ -84,7 +84,6 @@ subroutine soca_model2geovals_changevar_f90(c_key_geom, c_key_xin, c_key_xout) &
         end do
       end do
       call field_out%set_dirty(field2%dirty());
-      call field2%final()
 
     case ('distance_from_coast')
       field2 = geom%fieldset%field("distance_from_coast")
@@ -93,7 +92,6 @@ subroutine soca_model2geovals_changevar_f90(c_key_geom, c_key_xin, c_key_xout) &
         data_out(1, ii) = data2(1, ii)
       end do
       call field_out%set_dirty(field2%dirty())
-      call field2%final()
 
     case ('sea_area_fraction')
       do jj=geom%jsc,geom%jec
@@ -115,7 +113,6 @@ subroutine soca_model2geovals_changevar_f90(c_key_geom, c_key_xin, c_key_xout) &
               data2(1, idx)
         end do
       end do
-      call field2%final()
       call field_out%set_dirty()
 
     ! special derived state variables
@@ -129,7 +126,6 @@ subroutine soca_model2geovals_changevar_f90(c_key_geom, c_key_xin, c_key_xout) &
         end do
       end do
       call field_out%set_dirty()
-      call field2%final()
 
     case ('sea_floor_depth_below_sea_surface')
       field2 = xin%afieldset%field("sea_water_cell_thickness")
@@ -141,7 +137,6 @@ subroutine soca_model2geovals_changevar_f90(c_key_geom, c_key_xin, c_key_xout) &
         end do
       end do
       call field_out%set_dirty(field2%dirty())
-      call field2%final()
 
     ! identity operators
     case default
@@ -168,11 +163,10 @@ subroutine soca_model2geovals_changevar_f90(c_key_geom, c_key_xin, c_key_xout) &
                         // field_out%name() )
       end if
       call field_out%set_dirty(field2%dirty())
-      call field2%final()
     end select
-
-    call field_out%final()
   end do
+  call field_out%final()
+  call field2%final()
 end subroutine
 
 !-------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

TLDR: this should fix large memory leaks observed with spack-stack/1.9+ and with earlier spack-stack versions on some intel compilers.

Starting stack-stack/1.9 with all compilers (and before that with some intel compilers), fckit is built with `-DENABLE_FINAL=OFF`. Practically this means that one has to call `%final()` methods explicitly in Fortran code to ensure that objects are destructed correctly.
On develop we are missing `afieldset%final()` on increment creation and destruction. This would especially affect applications that create many increments or states. Remember we had unexpectedly huge memory gain on the problematic platform when switching from oops to saber covariances? (https://github.com/NOAA-EMC/GDASApp/issues/1322). oops ensemble covariance uses Increments in multiply, while saber ensemble covariance uses fieldsets. We were just leaking a lot less memory when using saber covariances.

Note: `%final()` should be called for all relevant Fortran fckit/atlas objects, and we may be leaking memory in other places too. I went through the `atlas` objects in Fortran code and checked which ones are not finalized, but it would be good for someone else to double-check if I missed something.

For those interested, investigation happened in https://github.com/JCSDA/spack-stack/issues/1588.

## Testing

Tested on my mac/orbstack/spack-stack1.9 with a simple memory debugging app (https://github.com/JCSDA/spack-stack/issues/1588#issuecomment-3254585996) that creates an increment in a loop, and calls toFieldset on it.

On develop:
```
Iteration 0 before create inc RSS = 78.7656 MB
Iteration 0 after create inc RSS = 79.3906 MB
Iteration 0 after create fs = 79.3906 MB
...
Iteration 99 before create inc RSS = 378.656 MB
Iteration 99 after create inc RSS = 381.656 MB
Iteration 99 after create fs = 381.656 MB
```
On this branch:
```
Iteration 0 before create inc RSS = 79.0273 MB
Iteration 0 after create inc RSS = 79.6523 MB
Iteration 0 after create fs = 79.6523 MB
...
Iteration 99 before create inc RSS = 80.6523 MB
Iteration 99 after create inc RSS = 80.6523 MB
Iteration 99 after create fs = 80.6523 MB
```