### PR TITLE
Update soca test dependencies.

### DIFF
--- a/.github/workflows/start-jedi-ci.yaml
+++ b/.github/workflows/start-jedi-ci.yaml
@@ -41,8 +41,8 @@ jobs:
         uses: JCSDA-internal/jedi-ci@develop
         with:
           container_version: 'latest'
-          unittest_tag: 'vader'
-          unittest_dependencies: gsw ioda oasim oops saber ufo vader ufo-data ioda-data
+          unittest_tag: 'soca'
+          unittest_dependencies: gsw ioda ioda-data oasim oops saber ufo ufo-data vader jedi-model-data
           test_script: run_tests.sh
           target_repo_dir: target_repository
           bundle_branch: develop


### PR DESCRIPTION
The good news is that soca tests were running, the bad news is that they were only running during the integration-test phase.

This change is being tested in https://github.com/JCSDA-internal/soca/pull/1194