### PR TITLE
Add more variables to soca default list (for coupled Var)

### DIFF
--- a/src/soca/ModelData/ModelData.h
+++ b/src/soca/ModelData/ModelData.h
@@ -27,6 +27,7 @@ class ModelData : public util::Printable {
   static const oops::Variables defaultVariables() {
     return oops::Variables(std::vector<std::string>({"skin_temperature_at_surface_where_sea",
             "sea_water_potential_temperature", "sea_water_salinity", "sea_water_cell_thickness",
+            "distance_from_coast", "sea_area_fraction", "sea_ice_snow_thickness",
             "sea_surface_height_above_geoid", "sea_ice_area_fraction",
             "sea_ice_thickness", "Carbon_nitrogen_detritus_concentration",
             "Particulate_inorganic_carbon", "colored_dissolved_organic_carbon",


### PR DESCRIPTION
## Description

Adds a few more default soca variables to `ModelData` class to facilitate coupled soca-fv3 Var.
