### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/mains/AnalysisPostproc.h
+++ b/src/mains/AnalysisPostproc.h
@@ -216,7 +216,7 @@ class AnalysisPostproc : public oops::Application {
         const size_t ensMember = incs.local_ens()[iens];
         oops::Log::info() << "recentering ice state " << ensMember << ":" << ens[iens] << std::endl;
         for (size_t itime = 0; itime < ens.local_time_size(); ++itime) {
-          ens(itime, iens) += incs[itime, iens];
+          ens(itime, iens) += incs(itime, iens);
         }
         oops::Log::info() << "recentered ice state " << ensMember << ":" << ens[iens] << std::endl;
         // set up variable change

--- a/src/soca/LinearVariableChange/Balance/Balance.h
+++ b/src/soca/LinearVariableChange/Balance/Balance.h
@@ -39,10 +39,10 @@ class Balance: public LinearVariableChangeBase {
   ~Balance();
 
 /// Perform linear transforms
-  void multiply(const Increment &, Increment &) const;
-  void multiplyInverse(const Increment &, Increment &) const;
-  void multiplyAD(const Increment &, Increment &) const;
-  void multiplyInverseAD(const Increment &, Increment &) const;
+  void multiply(const Increment &, Increment &) const override;
+  void multiplyInverse(const Increment &, Increment &) const override;
+  void multiplyAD(const Increment &, Increment &) const override;
+  void multiplyInverseAD(const Increment &, Increment &) const override;
 
  private:
   void print(std::ostream &) const override;

--- a/src/soca/VariableChange/Model2Ana/Model2Ana.h
+++ b/src/soca/VariableChange/Model2Ana/Model2Ana.h
@@ -31,7 +31,7 @@ namespace soca {
 
 class Model2Ana: public VariableChangeBase {
  public:
-  const std::string classname() {return "soca::Model2Ana";}
+  const std::string classname() override {return "soca::Model2Ana";}
 
   Model2Ana(const Geometry &, const eckit::Configuration &);
   ~Model2Ana();

--- a/src/soca/VariableChange/Model2GeoVaLs/Model2GeoVaLs.h
+++ b/src/soca/VariableChange/Model2GeoVaLs/Model2GeoVaLs.h
@@ -16,7 +16,7 @@ namespace soca {
 
 class Model2GeoVaLs: public VariableChangeBase {
  public:
-  const std::string classname() {return "soca::Model2GeoVaLs";}
+  const std::string classname() override {return "soca::Model2GeoVaLs";}
 
   Model2GeoVaLs(const Geometry &, const eckit::Configuration &);
   ~Model2GeoVaLs();

--- a/src/soca/VariableChange/Soca2Cice/Soca2Cice.h
+++ b/src/soca/VariableChange/Soca2Cice/Soca2Cice.h
@@ -98,7 +98,7 @@ class Soca2Cice: public VariableChangeBase {
             "minimum allowable ice volume", 0.00001, this, {oops::minConstraint(0.0)}};
   };
 
-  const std::string classname() {return "soca::Soca2Cice";}
+  const std::string classname() override {return "soca::Soca2Cice";}
 
   Soca2Cice(const Geometry &, const eckit::Configuration &);
   ~Soca2Cice();


### PR DESCRIPTION
Fixes some compiler warnings raised by IntelLLVM 2025.3
- use of comma operator revealed an `IncSet[a, b]` evaluating to `IncSet[b]`, but that should likely have been written as `IncSet(a, b)` — this one could have correctness implications!
- override warnings