### PR TITLE
Use time_interp_external2_mod for FMS 2.1 compatibility

### DIFF
--- a/src/soca/Geometry/soca_geom_mod.F90
+++ b/src/soca/Geometry/soca_geom_mod.F90
@@ -31,7 +31,7 @@ use mpp_domains_mod, only : mpp_get_compute_domain, mpp_get_data_domain, &
                             mpp_get_global_domain, mpp_update_domains, &
                             CYCLIC_GLOBAL_DOMAIN, FOLD_NORTH_EDGE
 use mpp_mod,only : mpp_init
-use time_interp_external_mod, only : time_interp_external_init
+use time_interp_external2_mod, only : time_interp_external_init
 use time_manager_mod, only: time_type
 
 ! soca modules


### PR DESCRIPTION
## Description

Switch the `time_interp_external_init` import to `time_interp_external2_mod` so soca builds against the FMS shipped in spack-stack 2.1. Verified to build and pass tests under both spack-stack 1.9 and 2.1.

## Issue(s) addressed

see https://github.com/JCSDA-internal/soca/pull/1242#issuecomment-4492637366

## Dependencies

n/a

## Impact

n/a

## Manual Testing Instructions (optional)

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR