### PR TITLE
Fix soca builds

### DIFF
--- a/src/soca/SaberBlocks/ParametricOceanStdDev/ParametricOceanStdDev.cc
+++ b/src/soca/SaberBlocks/ParametricOceanStdDev/ParametricOceanStdDev.cc
@@ -5,6 +5,8 @@
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+#include <cmath>
+
 #include "oops/util/Logger.h"
 #include "oops/util/Timer.h"
 
@@ -144,7 +146,7 @@ ParametricOceanStdDev::ParametricOceanStdDev(
       double sstVal = v_sstErr(i, 0);
       for (size_t z = 0; z < levels; z++) {
         // step 1: calc value from dT/dz
-        auto val = abs(tocnParams.dz.value() * v_dtdz(i, z));
+        auto val = std::abs(tocnParams.dz.value() * v_dtdz(i, z));
 
         // step 2: calc a min from the e-folding scale, and min SST value
         auto localMin = minVal + (sstVal - minVal) * exp(-v_depth(i, z) / efold);

--- a/src/soca/Utils/OceanSmoother.cc
+++ b/src/soca/Utils/OceanSmoother.cc
@@ -12,6 +12,7 @@
 #include "oops/base/GeometryData.h"
 #include "oops/generic/Diffusion.h"
 #include "oops/util/FieldSetHelpers.h"
+#include "oops/util/Logger.h"
 
 #include "soca/Utils/OceanSmoother.h"
 


### PR DESCRIPTION
## Description

Fix,
- missing header, that on develop is transitively brought in by oops, but breaks with oops changes in https://github.com/JCSDA-internal/oops/pull/3333
- missing header that leads to calling an integer `abs` function; this broke compilation with gcc13 for me, i don't know why this hasn't shown up previously...?

