### PR TITLE
Fix corrupted qice007

### DIFF
--- a/src/soca/PostProcess/PostProcessIce.cc
+++ b/src/soca/PostProcess/PostProcessIce.cc
@@ -807,7 +807,7 @@ void PostProcessIce::applyThermoStage(
     sLayer[l] = icephysics::siceLayerCice4(static_cast<int>(l)+1,
                                            static_cast<int>(iceLev));
   }
-  const std::size_t lSurf = iceLev - 1;
+  const std::size_t lSurf = 0;
 
   for (std::size_t jnode = 0; jnode < field_size; ++jnode) {
     for (std::size_t k = 0; k < ncat_; ++k) {


### PR DESCRIPTION
- closes #1257 

John's real time 3DVAR in black, buggy "soca2cice" in blue, fixed "soca2cice" in orange. 
<img width="1350" height="750" alt="image" src="https://github.com/user-attachments/assets/31f014fb-221b-4cf1-a563-5fae8eade679" />
